### PR TITLE
build: UNIX 系環境から TL866II Plus で書き込む導線を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 ASL ?= asl
 P2BIN ?= p2bin
 P2HEX ?= p2hex
+MINIPRO ?= minipro
 
 TARGET := mc6800-monitor
 OUTDIR := build
@@ -10,6 +11,44 @@ LST := $(OUTDIR)/$(TARGET).lst
 BIN := $(OUTDIR)/$(TARGET).bin
 SREC := $(OUTDIR)/$(TARGET).srec
 IHEX := $(OUTDIR)/$(TARGET).hex
+ROM_KIND ?= 27C64
+ROM_FILL ?= 0xFF
+
+ifeq ($(ROM_KIND),27C64)
+ROM_CHIP_SIZE := 0x2000
+ROM_RANGE_START := 0xE000
+ROM_RANGE_END := 0xFFFF
+MINIPRO_DEVICE ?= 27C64@DIP28
+else ifeq ($(ROM_KIND),27C128)
+ROM_CHIP_SIZE := 0x4000
+ROM_RANGE_START := 0xC000
+ROM_RANGE_END := 0xFFFF
+MINIPRO_DEVICE ?= 27C128@DIP28
+else ifeq ($(ROM_KIND),27C256)
+ROM_CHIP_SIZE := 0x8000
+ROM_RANGE_START := 0x8000
+ROM_RANGE_END := 0xFFFF
+MINIPRO_DEVICE ?= 27C256@DIP28
+else ifeq ($(ROM_KIND),28C256)
+ROM_CHIP_SIZE := 0x8000
+ROM_RANGE_START := 0x8000
+ROM_RANGE_END := 0xFFFF
+MINIPRO_DEVICE ?= 28C256@DIP28
+else ifeq ($(ROM_KIND),UPD28C256)
+ROM_CHIP_SIZE := 0x8000
+ROM_RANGE_START := 0x8000
+ROM_RANGE_END := 0xFFFF
+MINIPRO_DEVICE ?= UPD28C256
+else ifeq ($(ROM_KIND),W27C512)
+ROM_CHIP_SIZE := 0x10000
+ROM_RANGE_START := 0x0000
+ROM_RANGE_END := 0xFFFF
+MINIPRO_DEVICE ?= W27C512@DIP28
+else
+$(error Unsupported ROM_KIND '$(ROM_KIND)')
+endif
+
+ROMBIN := $(OUTDIR)/$(TARGET)-$(ROM_KIND).bin
 
 ifeq ($(OS),Windows_NT)
 ASL_PATHSEP := ;
@@ -25,7 +64,7 @@ endif
 
 ASL_INCLUDE := $(CURDIR)/include$(ASL_PATHSEP)$(CURDIR)/src
 
-.PHONY: all clean bin srec ihex
+.PHONY: all clean bin srec ihex rombin rombin-27c64 rombin-27c128 rombin-27c256 rombin-28c256 rombin-w27c512 program verify readback program-27c64 program-27c128 program-27c256 program-28c256 program-w27c512 program-upd28c256
 
 all: srec ihex
 
@@ -49,6 +88,54 @@ ihex: $(IHEX)
 
 $(IHEX): $(OBJ)
 	$(P2HEX) $(OBJ) $(IHEX) -q -F Intel -i 1
+
+rombin: $(ROMBIN)
+
+$(ROMBIN): $(OBJ)
+	$(P2BIN) $(OBJ) $(ROMBIN) -q -r $(ROM_RANGE_START)-$(ROM_RANGE_END) -l $(ROM_FILL)
+
+rombin-27c64:
+	$(MAKE) rombin ROM_KIND=27C64
+
+rombin-27c128:
+	$(MAKE) rombin ROM_KIND=27C128
+
+rombin-27c256:
+	$(MAKE) rombin ROM_KIND=27C256
+
+rombin-28c256:
+	$(MAKE) rombin ROM_KIND=28C256
+
+rombin-w27c512:
+	$(MAKE) rombin ROM_KIND=W27C512
+
+program: $(ROMBIN)
+	$(MINIPRO) -p "$(MINIPRO_DEVICE)" -w $(ROMBIN)
+
+verify: $(ROMBIN)
+	$(MINIPRO) -p "$(MINIPRO_DEVICE)" -m $(ROMBIN)
+
+readback:
+	$(MINIPRO) -p "$(MINIPRO_DEVICE)" -r $(OUTDIR)/$(TARGET)-$(ROM_KIND)-readback.bin
+
+program-27c64:
+	$(MAKE) program ROM_KIND=27C64
+
+program-27c128:
+	$(MAKE) program ROM_KIND=27C128
+
+program-27c256:
+	$(MAKE) program ROM_KIND=27C256
+
+program-28c256:
+	$(MAKE) program ROM_KIND=28C256
+
+program-w27c512:
+	$(MAKE) program ROM_KIND=W27C512
+
+program-upd28c256:
+	$(MAKE) program ROM_KIND=UPD28C256
+
 
 clean:
 	$(RM_RF)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ MIKBUG 全体の完全互換は狙いませんが、電大版 BASIC が利用す
 - [docs/plans/implementation_plan.md](/Users/kuninet/git/MC6800_monitor/docs/plans/implementation_plan.md): 実装計画
 - [docs/progress/2026-03-22.md](/Users/kuninet/git/MC6800_monitor/docs/progress/2026-03-22.md): 初期進捗ログ
 - [docs/testing/sbc6800_bringup.md](/Users/kuninet/git/MC6800_monitor/docs/testing/sbc6800_bringup.md): SBC6800 実機確認手順
+- [docs/testing/macos_tl866ii_plus.md](/Users/kuninet/git/MC6800_monitor/docs/testing/macos_tl866ii_plus.md): macOS から TL866II Plus で ROM を書き込む手順
 
 ## 初版スコープ
 
@@ -83,6 +84,7 @@ SBC6800 前提の現在値:
 - `asl`
 - `p2bin`
 - `p2hex`
+- `minipro`
 
 ## 想定ディレクトリ構成
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ MIKBUG 全体の完全互換は狙いませんが、電大版 BASIC が利用す
 - [docs/plans/implementation_plan.md](/Users/kuninet/git/MC6800_monitor/docs/plans/implementation_plan.md): 実装計画
 - [docs/progress/2026-03-22.md](/Users/kuninet/git/MC6800_monitor/docs/progress/2026-03-22.md): 初期進捗ログ
 - [docs/testing/sbc6800_bringup.md](/Users/kuninet/git/MC6800_monitor/docs/testing/sbc6800_bringup.md): SBC6800 実機確認手順
-- [docs/testing/macos_tl866ii_plus.md](/Users/kuninet/git/MC6800_monitor/docs/testing/macos_tl866ii_plus.md): macOS から TL866II Plus で ROM を書き込む手順
+- [docs/testing/macos_tl866ii_plus.md](/Users/kuninet/git/MC6800_monitor/docs/testing/macos_tl866ii_plus.md): UNIX 系環境で TL866II Plus を使う手順
 
 ## 初版スコープ
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,4 +25,5 @@
 - [design/memory_map.md](/Users/kuninet/git/MC6800_monitor/docs/design/memory_map.md)
 - [plans/implementation_plan.md](/Users/kuninet/git/MC6800_monitor/docs/plans/implementation_plan.md)
 - [testing/sbc6800_bringup.md](/Users/kuninet/git/MC6800_monitor/docs/testing/sbc6800_bringup.md)
+- [testing/macos_tl866ii_plus.md](/Users/kuninet/git/MC6800_monitor/docs/testing/macos_tl866ii_plus.md)
 - [progress/2026-03-22.md](/Users/kuninet/git/MC6800_monitor/docs/progress/2026-03-22.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,5 +25,5 @@
 - [design/memory_map.md](/Users/kuninet/git/MC6800_monitor/docs/design/memory_map.md)
 - [plans/implementation_plan.md](/Users/kuninet/git/MC6800_monitor/docs/plans/implementation_plan.md)
 - [testing/sbc6800_bringup.md](/Users/kuninet/git/MC6800_monitor/docs/testing/sbc6800_bringup.md)
-- [testing/macos_tl866ii_plus.md](/Users/kuninet/git/MC6800_monitor/docs/testing/macos_tl866ii_plus.md)
+- [testing/macos_tl866ii_plus.md](/Users/kuninet/git/MC6800_monitor/docs/testing/macos_tl866ii_plus.md): UNIX 系環境で TL866II Plus を使う手順
 - [progress/2026-03-22.md](/Users/kuninet/git/MC6800_monitor/docs/progress/2026-03-22.md)

--- a/docs/testing/macos_tl866ii_plus.md
+++ b/docs/testing/macos_tl866ii_plus.md
@@ -1,0 +1,140 @@
+# macOS で TL866II Plus を使って ROM を書き込む
+
+## 目的
+
+`TL866II Plus` を macOS から使い、ビルド結果から ROM ライタ向けバイナリを生成して `minipro` で書き込む。
+
+## 前提
+
+- `Homebrew` が使える
+- ライタは `TL866II Plus`
+- 書き込みツールは `minipro`
+
+## インストール
+
+```bash
+brew install minipro
+```
+
+## 方針
+
+このプロジェクトのビルド結果は CPU アドレス空間を持っている。
+
+ROM ライタへ渡すときは、実際のチップ内アドレスに合わせたバイナリへ変換した方が安全である。
+
+そのため、Makefile では次の流れにしている。
+
+1. `make` で Intel HEX を生成する
+2. `make rombin ROM_KIND=...` で `p2bin` を使ってチップ容量に合わせたバイナリを作る
+3. `make program ROM_KIND=...` で `minipro` から書き込む
+
+## 対応している ROM_KIND
+
+| ROM_KIND | 容量 | 想定マップ | 生成されるバイナリ |
+| --- | --- | --- | --- |
+| `27C64` | 8KB | `E000-FFFF` | `build/mc6800-monitor-27C64.bin` |
+| `27C128` | 16KB | `C000-FFFF` | `build/mc6800-monitor-27C128.bin` |
+| `27C256` | 32KB | `8000-FFFF` | `build/mc6800-monitor-27C256.bin` |
+| `28C256` | 32KB | `8000-FFFF` | `build/mc6800-monitor-28C256.bin` |
+| `UPD28C256` | 32KB | `8000-FFFF` | `build/mc6800-monitor-UPD28C256.bin` |
+| `W27C512` | 64KB | `0000-FFFF` | `build/mc6800-monitor-W27C512.bin` |
+
+## 重要な注意
+
+上の想定マップは、「その容量の ROM が CPU の上位アドレス空間へ素直に張られている」前提。
+
+例えば `27C256` や `W27C512` を変換基板や配線で別の見せ方にしている場合は、Makefile の既定値のままでは合わない可能性がある。
+
+その場合は次を上書きする。
+
+- `ROM_KIND`
+- `MINIPRO_DEVICE`
+- 必要であれば `ROM_RANGE_START`
+- 必要であれば `ROM_RANGE_END`
+
+## 基本手順
+
+### 1. W27C512 に書く
+
+```bash
+make clean
+make
+make rombin ROM_KIND=W27C512
+make program ROM_KIND=W27C512
+```
+
+### 2. 27C256 に書く
+
+```bash
+make clean
+make
+make rombin ROM_KIND=27C256
+make program ROM_KIND=27C256
+```
+
+### 3. 27C64 に書く
+
+```bash
+make clean
+make
+make rombin ROM_KIND=27C64
+make program ROM_KIND=27C64
+```
+
+## 省略形ターゲット
+
+よく使うものは専用ターゲットも用意してある。
+
+```bash
+make rombin-w27c512
+make program-w27c512
+
+make rombin-27c256
+make program-27c256
+
+make rombin-27c64
+make program-27c64
+
+make program-upd28c256
+```
+
+## verify と readback
+
+書き込み後の比較:
+
+```bash
+make verify ROM_KIND=W27C512
+```
+
+読み出し:
+
+```bash
+make readback ROM_KIND=W27C512
+```
+
+読み出したファイルは次になる。
+
+```text
+build/mc6800-monitor-W27C512-readback.bin
+```
+
+## minipro のデバイス名が違う場合
+
+`minipro` のデバイス名は手元の database に依存することがある。
+
+もし既定値で合わない場合は、`MINIPRO_DEVICE` を明示して実行する。
+
+```bash
+make program ROM_KIND=W27C512 MINIPRO_DEVICE=W27C512@DIP28
+```
+
+## 実装メモ
+
+Makefile では `p2bin` に対して次のような変換をかけている。
+
+- `.p` オブジェクトを入力
+- `ROM_RANGE_START-ROM_RANGE_END` を切り出す
+- 未使用領域は `0xFF` で埋める
+- ROM ライタ向けのバイナリとして出力する
+
+これにより、CPU アドレス基準の出力から ROM ライタ向けのチップイメージを作っている。

--- a/docs/testing/macos_tl866ii_plus.md
+++ b/docs/testing/macos_tl866ii_plus.md
@@ -1,20 +1,73 @@
-# macOS で TL866II Plus を使って ROM を書き込む
+# UNIX 系環境で TL866II Plus を使って ROM を書き込む
 
 ## 目的
 
-`TL866II Plus` を macOS から使い、ビルド結果から ROM ライタ向けバイナリを生成して `minipro` で書き込む。
+`TL866II Plus` を UNIX 系環境から使い、ビルド結果から ROM ライタ向けバイナリを生成して `minipro` で書き込む。
 
 ## 前提
 
-- `Homebrew` が使える
+- `minipro` が動く UNIX 系環境がある
 - ライタは `TL866II Plus`
 - 書き込みツールは `minipro`
 
-## インストール
+## 想定する環境
+
+- macOS
+- Linux
+- Windows 上の WSL 2
+
+Makefile の `rombin` / `program` / `verify` / `readback` ターゲットは、`minipro` と `p2bin` が使える UNIX 系環境であれば基本的に同じ手順で使える。
+
+## macOS でのインストール
 
 ```bash
 brew install minipro
 ```
+
+## Linux でのインストール例
+
+ディストリビューションごとにパッケージ名は異なるが、少なくとも `minipro` と `libusb` 系が必要になる。
+
+例:
+
+```bash
+sudo apt install minipro
+```
+
+## WSL 2 での参考手順
+
+WSL 2 では USB デバイスをそのまま Linux 側から使えないため、`usbipd-win` を使って TL866II Plus を WSL へアタッチする必要がある。
+
+公式:
+- [Microsoft Learn: USB デバイスを接続する](https://learn.microsoft.com/ja-jp/windows/wsl/connect-usb)
+
+大まかな流れは次の通り。
+
+1. Windows 側で `usbipd-win` を入れる
+2. `wsl --update` で WSL を最新化する
+3. 管理者権限の PowerShell で `usbipd list` を実行する
+4. TL866II Plus の bus id を確認して `usbipd bind --busid <busid>` を実行する
+5. 通常権限の PowerShell で `usbipd attach --wsl --busid <busid>` を実行する
+6. WSL 側で `lsusb` や `minipro --version` で認識を確認する
+
+例:
+
+```powershell
+winget install --interactive --exact dorssel.usbipd-win
+wsl --update
+usbipd list
+usbipd bind --busid 4-4
+usbipd attach --wsl --busid 4-4
+```
+
+WSL 側:
+
+```bash
+lsusb
+minipro --version
+```
+
+WSL にアタッチしている間、その USB デバイスは Windows ネイティブ側からは使えない点に注意する。
 
 ## 方針
 
@@ -127,6 +180,38 @@ build/mc6800-monitor-W27C512-readback.bin
 ```bash
 make program ROM_KIND=W27C512 MINIPRO_DEVICE=W27C512@DIP28
 ```
+
+まず使えるデバイス名を確認するには次を使う。
+
+```bash
+minipro -l | rg '27C64|27C256|28C256|W27C512|UPD28C256'
+```
+
+プログラマの接続状況確認は次でよい。
+
+```bash
+minipro --version
+```
+
+接続されていれば `Found TL866II+` のように表示される。
+
+## 既知の制約
+
+macOS で `minipro` を使った書き込みでは、少なくとも一部の環境で次の現象を確認している。
+
+- `minipro --version` では TL866II Plus を認識する
+- `minipro -t` の自己診断は成功する
+- `minipro -r` の読み出しは成功する
+- 消去も成功する
+- しかし書き込みだけ途中で `LIBUSB_TRANSFER_TIMED_OUT` になることがある
+
+この現象は `W27C512` だけでなく `28C256` 系でも確認した。少なくともこのリポジトリの確認環境では、`macOS + minipro + TL866II Plus` の組み合わせで書き込みが安定しない場合がある。
+
+そのため、現時点では次の運用が現実的である。
+
+- UNIX 系環境ではビルドと ROM イメージ生成まで行う
+- 実際の書き込みは Windows の純正ソフトを継続利用する
+- もしくは WSL 2 側の Linux `minipro` を試す
 
 ## 実装メモ
 


### PR DESCRIPTION
## 概要
- 容量違いの ROM 向けに `p2bin` で ROM ライタ用バイナリを生成する Makefile ターゲットを追加
- `minipro` を使った書き込み、verify、readback の導線を Makefile に追加
- macOS を起点にしつつ、UNIX 系環境全般で使える手順として `docs/testing/` に追加
- WSL 2 から利用する場合の参考手順も追記

## 確認内容
- `make rombin-w27c512`
- `make rombin-27c64`
- `make -n program-upd28c256`

## 補足
- `srec_cat` は現行の `p2hex` 出力と相性が悪かったため、ROM ライタ向けイメージ生成は `p2bin` ベースにしています
- macOS + `minipro` での書き込み自体は一部チップで `LIBUSB_TRANSFER_TIMED_OUT` が出ており、手順書に既知制約として記載しています
- 手順書は macOS 専用ではなく、Linux や WSL 2 も含む UNIX 系環境向けの内容として整理しています

Closes #12