### PR TITLE
docs: minipro の取得元 URL を修正

### DIFF
--- a/docs/testing/wsl2_tl866ii_plus.md
+++ b/docs/testing/wsl2_tl866ii_plus.md
@@ -148,7 +148,7 @@ sudo apt-get install -y build-essential pkg-config git libusb-1.0-0-dev usbutils
 
 ```bash
 cd ~
-git clone https://github.com/vdudouyt/minipro.git
+git clone https://gitlab.com/DavidGriffith/minipro.git
 cd ~/minipro
 make
 sudo make install


### PR DESCRIPTION
## 概要
- WSL2 手順書の minipro 取得元 URL を GitHub から GitLab に修正

## 背景
- minipro のソース取得先として GitHub URL を記載していたが、正しい取得元は https://gitlab.com/DavidGriffith/minipro だった

Closes #19