### PR TITLE
phase2: 最小CLIの行入力土台を実装

### DIFF
--- a/include/hardware.inc
+++ b/include/hardware.inc
@@ -12,6 +12,16 @@ ACIA_DATA        equ $8019
 
 CHR_CR           equ $0D
 CHR_LF           equ $0A
+CHR_BS           equ $08
+CHR_DEL          equ $7F
+CHR_SPACE        equ $20
+CHR_PROMPT       equ ']'
+CHR_ECHO         equ '='
+
+LINE_BUF_SIZE    equ 32
+LINE_BUF         equ RAM_START
+LINE_PTR         equ LINE_BUF+LINE_BUF_SIZE
+LINE_LEN         equ LINE_PTR+2
 
 ACIA_STAT_RDRF   equ $01
 ACIA_STAT_TDRE   equ $02

--- a/src/acia6850.asm
+++ b/src/acia6850.asm
@@ -35,8 +35,10 @@ OUTEEE:
         pula
         cmpa    #CHR_CR
         bne     OUTEEE_DONE
+        psha
         ldaa    #CHR_LF
         jsr     ACIA_PUTC
+        pula
 OUTEEE_DONE:
         rts
 

--- a/src/main.asm
+++ b/src/main.asm
@@ -10,10 +10,96 @@ RESET:
         jsr     ACIA_INIT
         ldaa    #'*'
         jsr     OUTEEE
+        ldaa    #CHR_CR
+        jsr     OUTEEE
 
 MAIN_LOOP:
-        jsr     INEEE
+        jsr     PRINT_PROMPT
+        jsr     READ_LINE
+        jsr     ECHO_LINE
         bra     MAIN_LOOP
+
+PRINT_PROMPT:
+        ldaa    #CHR_PROMPT
+        jsr     OUTEEE
+        ldaa    #CHR_SPACE
+        jsr     OUTEEE
+        rts
+
+READ_LINE:
+        ldx     #LINE_BUF
+        stx     LINE_PTR
+        clr     LINE_LEN
+
+READ_LINE_LOOP:
+        jsr     ACIA_GETC
+        cmpa    #CHR_LF
+        beq     READ_LINE_LOOP
+        cmpa    #CHR_CR
+        beq     READ_LINE_DONE
+        cmpa    #CHR_BS
+        beq     READ_LINE_BACKSPACE
+        cmpa    #CHR_DEL
+        beq     READ_LINE_BACKSPACE
+        cmpa    #CHR_SPACE
+        blo     READ_LINE_LOOP
+
+        ldab    LINE_LEN
+        cmpb    #LINE_BUF_SIZE
+        bhs     READ_LINE_LOOP
+
+        ldx     LINE_PTR
+        staa    0,x
+        inx
+        stx     LINE_PTR
+        inc     LINE_LEN
+        jsr     OUTEEE
+        bra     READ_LINE_LOOP
+
+READ_LINE_BACKSPACE:
+        tst     LINE_LEN
+        beq     READ_LINE_LOOP
+
+        ldx     LINE_PTR
+        dex
+        stx     LINE_PTR
+        dec     LINE_LEN
+
+        ldaa    #CHR_BS
+        jsr     ACIA_PUTC
+        ldaa    #CHR_SPACE
+        jsr     ACIA_PUTC
+        ldaa    #CHR_BS
+        jsr     ACIA_PUTC
+        bra     READ_LINE_LOOP
+
+READ_LINE_DONE:
+        ldaa    #CHR_CR
+        jsr     OUTEEE
+        rts
+
+ECHO_LINE:
+        ldaa    #CHR_ECHO
+        jsr     OUTEEE
+        ldaa    #CHR_SPACE
+        jsr     OUTEEE
+
+        ldab    LINE_LEN
+        ldx     #LINE_BUF
+
+ECHO_LINE_LOOP:
+        cmpb    #0
+        beq     ECHO_LINE_DONE
+        ldaa    0,x
+        jsr     OUTEEE
+        inx
+        decb
+        bra     ECHO_LINE_LOOP
+
+ECHO_LINE_DONE:
+        ldaa    #CHR_CR
+        jsr     OUTEEE
+        rts
 
 SPURIOUS_IRQ:
         rti


### PR DESCRIPTION
﻿## 概要
- `] ` プロンプトを表示する最小CLIを追加
- 1行入力バッファを実装し、`BS` / `DEL` で編集できるようにした
- `CR` で確定し、検証用に `= ` 付きでバッファ内容を返すようにした
- `OUTEEE` の `CR -> CRLF` 展開で A レジスタを保持するように修正した

## 確認
- `cmd /c "make clean && make -B"` でビルド成功
- SBC6800 実機で `] ABC` → `= ABC`、BS編集、空Enter を確認

## 位置づけ
- closes #23
- refs #11
