### PR TITLE
Issue #49 SDHCセクタ読み込みを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ all: srec ihex
 $(OUTDIR):
 	$(MKDIR_P)
 
-$(OBJ): $(TOPSRC) include/hardware.inc include/mikbug.inc src/acia6850.asm | $(OUTDIR)
+$(OBJ): $(TOPSRC) include/hardware.inc include/mikbug.inc src/acia6850.asm src/sdcard.asm | $(OUTDIR)
 	$(ASL) -q -L -olist $(LST) -o $(OBJ) -i $(ASL_INCLUDE_ARG) $(TOPSRC)
 
 bin: $(BIN)

--- a/docs/plans/issue-49_sd_sector_read.md
+++ b/docs/plans/issue-49_sd_sector_read.md
@@ -1,0 +1,50 @@
+# Issue #49 SDHC sector read実装計画
+
+## 関連リンク
+
+- Issue #49: https://github.com/kuninet/mc6800-rom-monitor/issues/49
+- Issue #48: https://github.com/kuninet/mc6800-rom-monitor/issues/48
+- PoC PR #46: https://github.com/kuninet/mc6800-rom-monitor/pull/46
+
+## 方針
+
+Issue #49では、FAT32、`DIR`、`LF`、S-Record/Intel HEX LOAD連携には入らない。
+ROM側へ内部APIとしてSDHC初期化と`CMD17`による512 byte sector readだけを追加する。
+
+公開モニタコマンドは追加しない。後続 #50 以降でFAT32処理を実装するときの下回りとして扱う。
+
+## 実装範囲
+
+- PIAアドレスはエミュレータ暫定値として `$8050-$8053` を定義する。
+- Port BのSPI bit割当は #48 と同じ `SCLK=$01`, `MOSI=$02`, `MISO=$04`, `CS=$08` とする。
+- `src/sdcard.asm` を追加し、`SD_INIT`、`SD_READ_SECTOR`、`SD_SPI_XFER` を実装する。
+- `SD_LBA0..3` はSDHCのLBA sector番号をbig-endianで保持する。
+- `SD_READ_SECTOR` は `X=書き込み先RAM`、`SD_LBA0..3=LBA` を入力とし、成功時C=0、失敗時C=1を返す。
+- 既定のsector buffer候補は `$1C00-$1DFF` とする。
+
+## 対象外
+
+- ROMモニタの公開コマンド追加
+- FAT32 BPB/MBR解析
+- root directory走査
+- `DIR` / `LF filename`
+- SAVE/write対応
+- 実機SBC-IOアドレスの最終決定
+- PoC由来の大規模差分や生成済み `.img`
+
+## 確認方針
+
+`tests/test_sd_fixture.py` にROM統合テストを追加する。
+
+- FAT32 fixtureを一時ファイルとして生成し、エミュレータへ `--sd` で接続する。
+- listingから `SD_INIT`、`SD_READ_SECTOR`、`SD_LBA0..3`、`SD_SECTOR_BUF` のアドレスを取得する。
+- モニタの `M` コマンドでRAMへ小さなテストハーネスを注入する。
+- ハーネスは `SD_INIT`、LBA設定、`SD_READ_SECTOR`、`SWI` を実行する。
+- `D` コマンドでsector buffer先頭をdumpし、fixtureの既知バイト列と一致することを確認する。
+
+## 実装時の確認結果
+
+- `SD_INIT`、`SD_READ_SECTOR`、`SD_SPI_XFER` は公開コマンドではなく内部APIとして追加した。
+- `DIR`、`LF`、S-Record/Intel HEX LOAD処理、FAT32解析には手を入れていない。
+- ROM統合テストでは、MBRありFAT32 fixture上の `MULTI.BIN` 第1クラスタLBAを読み、`SD_SECTOR_BUF` 先頭が既知バイト列 `MULTI-CLUSTER-1` になることを確認する。
+- `SD_SECTOR_BUF=$1C00` は今回の既定候補であり、SBC-IO RAM拡張や `$C000` buffer案は後続Issueで扱う。

--- a/include/hardware.inc
+++ b/include/hardware.inc
@@ -14,6 +14,21 @@ STACK_TOP        equ MIKBUG_STACK_TOP
 ACIA_CTRL        equ $8018
 ACIA_DATA        equ $8019
 
+; PIAアドレスはエミュレータ暫定値。実機SBC-IOの最終決定は #54 で扱う。
+PIA_BASE         equ $8050
+PIA_PRA          equ PIA_BASE
+PIA_CRA          equ PIA_BASE+1
+PIA_PRB          equ PIA_BASE+2
+PIA_CRB          equ PIA_BASE+3
+
+PIA_DDR_SELECT   equ $04
+
+SPI_SCLK         equ $01
+SPI_MOSI         equ $02
+SPI_MISO         equ $04
+SPI_CS           equ $08
+SPI_OUTPUT_MASK  equ SPI_SCLK+SPI_MOSI+SPI_CS
+
 CHR_CR           equ $0D
 CHR_LF           equ $0A
 CHR_BS           equ $08
@@ -60,6 +75,29 @@ BRK_SAVE_A       equ BRK_SAVE_B+1
 BRK_SAVE_X       equ BRK_SAVE_A+1
 BRK_SAVE_PC      equ BRK_SAVE_X+2
 FILL_VALUE       equ BRK_SAVE_PC+2
+SD_ERROR         equ FILL_VALUE+1
+SD_LBA0          equ SD_ERROR+1
+SD_LBA1          equ SD_LBA0+1
+SD_LBA2          equ SD_LBA1+1
+SD_LBA3          equ SD_LBA2+1
+SD_PORTB_SHADOW  equ SD_LBA3+1
+SD_TX            equ SD_PORTB_SHADOW+1
+SD_RX            equ SD_TX+1
+SD_BIT_COUNT     equ SD_RX+1
+SD_TIMEOUT_HI    equ SD_BIT_COUNT+1
+SD_TIMEOUT_LO    equ SD_TIMEOUT_HI+1
+SD_CMD_BYTE      equ SD_TIMEOUT_LO+1
+SD_CRC_BYTE      equ SD_CMD_BYTE+1
+SD_BUF_PTR       equ SD_CRC_BYTE+1
+
+SD_SECTOR_BUF    equ $1C00
+
+SD_ERR_NONE      equ 0
+SD_ERR_TIMEOUT   equ 1
+SD_ERR_R1        equ 2
+SD_ERR_R7        equ 3
+SD_ERR_OCR       equ 4
+SD_ERR_TOKEN     equ 5
 
 LOAD_MODE_NONE   equ 0
 LOAD_MODE_SREC   equ 1

--- a/src/main.asm
+++ b/src/main.asm
@@ -1434,6 +1434,7 @@ SPURIOUS_IRQ:
         rti
 
         include "acia6850.asm"
+        include "sdcard.asm"
 
         org     VEC_IRQ
         fdb     SPURIOUS_IRQ     ; VEC_IRQ

--- a/src/sdcard.asm
+++ b/src/sdcard.asm
@@ -1,0 +1,334 @@
+; Minimal SDHC SPI sector read via MC6821 PIA Port B.
+; This module is an internal API for later FAT code. It adds no monitor command.
+
+SD_INIT:
+        clr     SD_ERROR
+        jsr     SD_PIA_INIT
+
+        ldab    #10
+SD_INIT_DUMMY_LOOP:
+        ldaa    #$FF
+        jsr     SD_SPI_XFER
+        decb
+        bne     SD_INIT_DUMMY_LOOP
+
+        jsr     SD_SELECT
+
+        ldaa    #$40
+        staa    SD_CMD_BYTE
+        clr     SD_LBA0
+        clr     SD_LBA1
+        clr     SD_LBA2
+        clr     SD_LBA3
+        ldaa    #$95
+        staa    SD_CRC_BYTE
+        jsr     SD_SEND_CMD
+        bcc     SD_INIT_CMD0_R1
+        jmp     SD_INIT_FAIL
+SD_INIT_CMD0_R1:
+        cmpa    #$01
+        beq     SD_INIT_CMD8
+        ldaa    #SD_ERR_R1
+        jmp     SD_FAIL_A
+
+SD_INIT_CMD8:
+        ldaa    #$48
+        staa    SD_CMD_BYTE
+        clr     SD_LBA0
+        clr     SD_LBA1
+        ldaa    #$01
+        staa    SD_LBA2
+        ldaa    #$AA
+        staa    SD_LBA3
+        ldaa    #$87
+        staa    SD_CRC_BYTE
+        jsr     SD_SEND_CMD
+        bcc     SD_INIT_CMD8_R1
+        jmp     SD_INIT_FAIL
+SD_INIT_CMD8_R1:
+        cmpa    #$01
+        beq     SD_INIT_R7_1
+        ldaa    #SD_ERR_R1
+        jmp     SD_FAIL_A
+
+SD_INIT_R7_1:
+        ldaa    #$FF
+        jsr     SD_SPI_XFER
+        bne     SD_INIT_R7_FAIL
+        ldaa    #$FF
+        jsr     SD_SPI_XFER
+        bne     SD_INIT_R7_FAIL
+        ldaa    #$FF
+        jsr     SD_SPI_XFER
+        cmpa    #$01
+        bne     SD_INIT_R7_FAIL
+        ldaa    #$FF
+        jsr     SD_SPI_XFER
+        cmpa    #$AA
+        beq     SD_INIT_ACMD41_PREP
+SD_INIT_R7_FAIL:
+        ldaa    #SD_ERR_R7
+        jmp     SD_FAIL_A
+
+SD_INIT_ACMD41_PREP:
+        ldx     #$0100
+        stx     SD_TIMEOUT_HI
+
+SD_INIT_ACMD41_LOOP:
+        ldaa    #$77
+        staa    SD_CMD_BYTE
+        clr     SD_LBA0
+        clr     SD_LBA1
+        clr     SD_LBA2
+        clr     SD_LBA3
+        ldaa    #$FF
+        staa    SD_CRC_BYTE
+        jsr     SD_SEND_CMD
+        bcc     SD_INIT_CMD55_R1
+        jmp     SD_INIT_FAIL
+SD_INIT_CMD55_R1:
+        cmpa    #$02
+        bhs     SD_INIT_R1_FAIL
+
+        ldaa    #$69
+        staa    SD_CMD_BYTE
+        ldaa    #$40
+        staa    SD_LBA0
+        clr     SD_LBA1
+        clr     SD_LBA2
+        clr     SD_LBA3
+        ldaa    #$FF
+        staa    SD_CRC_BYTE
+        jsr     SD_SEND_CMD
+        bcc     SD_INIT_ACMD41_R1
+        jmp     SD_INIT_FAIL
+SD_INIT_ACMD41_R1:
+        cmpa    #$00
+        beq     SD_INIT_CMD58
+        cmpa    #$01
+        bne     SD_INIT_R1_FAIL
+
+        ldx     SD_TIMEOUT_HI
+        dex
+        stx     SD_TIMEOUT_HI
+        bne     SD_INIT_ACMD41_LOOP
+        ldaa    #SD_ERR_TIMEOUT
+        jmp     SD_FAIL_A
+
+SD_INIT_R1_FAIL:
+        ldaa    #SD_ERR_R1
+        jmp     SD_FAIL_A
+
+SD_INIT_CMD58:
+        ldaa    #$7A
+        staa    SD_CMD_BYTE
+        clr     SD_LBA0
+        clr     SD_LBA1
+        clr     SD_LBA2
+        clr     SD_LBA3
+        ldaa    #$FF
+        staa    SD_CRC_BYTE
+        jsr     SD_SEND_CMD
+        bcc     SD_INIT_CMD58_R1
+        jmp     SD_INIT_FAIL
+SD_INIT_CMD58_R1:
+        cmpa    #$00
+        beq     SD_INIT_OCR
+        ldaa    #SD_ERR_R1
+        jmp     SD_FAIL_A
+
+SD_INIT_OCR:
+        ldaa    #$FF
+        jsr     SD_SPI_XFER
+        anda    #$40
+        beq     SD_INIT_OCR_FAIL
+        ldaa    #$FF
+        jsr     SD_SPI_XFER
+        ldaa    #$FF
+        jsr     SD_SPI_XFER
+        ldaa    #$FF
+        jsr     SD_SPI_XFER
+        jsr     SD_DESELECT
+        ldaa    #SD_ERR_NONE
+        staa    SD_ERROR
+        clc
+        rts
+
+SD_INIT_OCR_FAIL:
+        ldaa    #SD_ERR_OCR
+        jmp     SD_FAIL_A
+
+SD_INIT_FAIL:
+        jmp     SD_FAIL
+
+SD_READ_SECTOR:
+        stx     SD_BUF_PTR
+        jsr     SD_SELECT
+        ldaa    #$51
+        staa    SD_CMD_BYTE
+        ldaa    #$FF
+        staa    SD_CRC_BYTE
+        jsr     SD_SEND_CMD
+        bcc     SD_READ_R1
+        jmp     SD_READ_FAIL
+SD_READ_R1:
+        cmpa    #$00
+        beq     SD_READ_WAIT_TOKEN_PREP
+        ldaa    #SD_ERR_R1
+        jmp     SD_FAIL_A
+
+SD_READ_WAIT_TOKEN_PREP:
+        ldx     #$0200
+        stx     SD_TIMEOUT_HI
+SD_READ_WAIT_TOKEN:
+        ldaa    #$FF
+        jsr     SD_SPI_XFER
+        cmpa    #$FE
+        beq     SD_READ_DATA_PREP
+        cmpa    #$FF
+        bne     SD_READ_TOKEN_FAIL
+        ldx     SD_TIMEOUT_HI
+        dex
+        stx     SD_TIMEOUT_HI
+        bne     SD_READ_WAIT_TOKEN
+        ldaa    #SD_ERR_TIMEOUT
+        jmp     SD_FAIL_A
+
+SD_READ_TOKEN_FAIL:
+        ldaa    #SD_ERR_TOKEN
+        jmp     SD_FAIL_A
+
+SD_READ_DATA_PREP:
+        ldx     #$0200
+        stx     SD_TIMEOUT_HI
+SD_READ_DATA_LOOP:
+        ldaa    #$FF
+        jsr     SD_SPI_XFER
+        ldx     SD_BUF_PTR
+        staa    0,x
+        inx
+        stx     SD_BUF_PTR
+        ldx     SD_TIMEOUT_HI
+        dex
+        stx     SD_TIMEOUT_HI
+        bne     SD_READ_DATA_LOOP
+
+        ldaa    #$FF
+        jsr     SD_SPI_XFER
+        ldaa    #$FF
+        jsr     SD_SPI_XFER
+        jsr     SD_DESELECT
+        ldaa    #SD_ERR_NONE
+        staa    SD_ERROR
+        clc
+        rts
+
+SD_READ_FAIL:
+        jmp     SD_FAIL
+
+SD_SEND_CMD:
+        ldaa    SD_CMD_BYTE
+        jsr     SD_SPI_XFER
+        ldaa    SD_LBA0
+        jsr     SD_SPI_XFER
+        ldaa    SD_LBA1
+        jsr     SD_SPI_XFER
+        ldaa    SD_LBA2
+        jsr     SD_SPI_XFER
+        ldaa    SD_LBA3
+        jsr     SD_SPI_XFER
+        ldaa    SD_CRC_BYTE
+        jsr     SD_SPI_XFER
+        jmp     SD_WAIT_R1
+
+SD_WAIT_R1:
+        ldab    #16
+SD_WAIT_R1_LOOP:
+        ldaa    #$FF
+        jsr     SD_SPI_XFER
+        cmpa    #$FF
+        bne     SD_WAIT_R1_OK
+        decb
+        bne     SD_WAIT_R1_LOOP
+        ldaa    #SD_ERR_TIMEOUT
+        staa    SD_ERROR
+        sec
+        rts
+SD_WAIT_R1_OK:
+        staa    SD_RX
+        clc
+        rts
+
+SD_PIA_INIT:
+        clr     PIA_CRB
+        ldaa    #SPI_OUTPUT_MASK
+        staa    PIA_PRB
+        ldaa    #PIA_DDR_SELECT
+        staa    PIA_CRB
+        ldaa    #SPI_CS
+        staa    SD_PORTB_SHADOW
+        staa    PIA_PRB
+        rts
+
+SD_SELECT:
+        ldaa    SD_PORTB_SHADOW
+        anda    #$FF-SPI_CS-SPI_SCLK
+        staa    SD_PORTB_SHADOW
+        staa    PIA_PRB
+        rts
+
+SD_DESELECT:
+        ldaa    SD_PORTB_SHADOW
+        oraa    #SPI_CS
+        anda    #$FF-SPI_SCLK
+        staa    SD_PORTB_SHADOW
+        staa    PIA_PRB
+        ldaa    #$FF
+        jsr     SD_SPI_XFER
+        rts
+
+SD_SPI_XFER:
+        staa    SD_TX
+        clr     SD_RX
+        ldaa    #8
+        staa    SD_BIT_COUNT
+SD_SPI_XFER_LOOP:
+        asl     SD_TX
+        bcs     SD_SPI_XFER_MOSI_1
+        ldaa    SD_PORTB_SHADOW
+        anda    #$FF-SPI_MOSI-SPI_SCLK
+        bra     SD_SPI_XFER_MOSI_SET
+SD_SPI_XFER_MOSI_1:
+        ldaa    SD_PORTB_SHADOW
+        oraa    #SPI_MOSI
+        anda    #$FF-SPI_SCLK
+SD_SPI_XFER_MOSI_SET:
+        staa    SD_PORTB_SHADOW
+        staa    PIA_PRB
+
+        ldaa    SD_RX
+        asla
+        staa    SD_RX
+        ldaa    PIA_PRB
+        anda    #SPI_MISO
+        beq     SD_SPI_XFER_CLOCK
+        inc     SD_RX
+
+SD_SPI_XFER_CLOCK:
+        ldaa    SD_PORTB_SHADOW
+        oraa    #SPI_SCLK
+        staa    PIA_PRB
+        ldaa    SD_PORTB_SHADOW
+        staa    PIA_PRB
+        dec     SD_BIT_COUNT
+        bne     SD_SPI_XFER_LOOP
+        ldaa    SD_RX
+        clc
+        rts
+
+SD_FAIL_A:
+        staa    SD_ERROR
+SD_FAIL:
+        jsr     SD_DESELECT
+        sec
+        rts

--- a/tests/test_sd_fixture.py
+++ b/tests/test_sd_fixture.py
@@ -4,12 +4,17 @@
 from __future__ import annotations
 
 import sys
+import subprocess
+import tempfile
 from pathlib import Path
 
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "tests"))
 sys.path.insert(0, str(PROJECT_ROOT / "emu"))
+EMU_PATH = PROJECT_ROOT / "emu" / "sbc6800_emu.py"
+BUILD_ROM_PATH = PROJECT_ROOT / "build" / "mc6800-monitor.bin"
+BUILD_LST_PATH = PROJECT_ROOT / "build" / "mc6800-monitor.lst"
 
 from sbc6800_emu import PIA, PIA_CRB, PIA_PRB, SDCard, SPI_CS, SPI_MISO, SPI_MOSI, SPI_SCLK
 from sd_fixtures import (
@@ -178,6 +183,83 @@ def _poll_until(read_byte, expected: int) -> int:
     raise AssertionError(f"SD byte {expected:02X} timeout")
 
 
+def _load_symbol_addresses(*names: str) -> dict[str, int]:
+    import re
+
+    text = BUILD_LST_PATH.read_text(encoding="utf-8", errors="replace")
+    result: dict[str, int] = {}
+    wanted = set(names)
+    symbol_patterns = {
+        name: [
+            re.compile(rf"\b{re.escape(name)}\s*:\s*([0-9A-Fa-f]{{1,4}})\b"),
+            re.compile(rf":=\$([0-9A-Fa-f]{{1,4}})\s+{re.escape(name)}\s+equ\b"),
+        ]
+        for name in names
+    }
+    for name, patterns in symbol_patterns.items():
+        for pattern in patterns:
+            match = pattern.search(text)
+            if match:
+                result[name] = int(match.group(1), 16)
+                break
+    missing = wanted - set(result)
+    if missing:
+        raise AssertionError(f"missing symbols in listing: {sorted(missing)}")
+    return result
+
+
+def _run_emu_with_sd(input_text: str, sd_image: bytes, max_cycles: int = 30_000_000) -> tuple[str, str, int]:
+    if not BUILD_ROM_PATH.exists() or not BUILD_LST_PATH.exists():
+        raise AssertionError("build output missing; run `make bin` first")
+
+    input_bytes = input_text.encode("ascii")
+    with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as input_file:
+        input_file.write(input_bytes)
+        input_path = Path(input_file.name)
+    with tempfile.NamedTemporaryFile(suffix=".img", delete=False) as sd_file:
+        sd_file.write(sd_image)
+        sd_path = Path(sd_file.name)
+
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(EMU_PATH),
+                str(BUILD_ROM_PATH),
+                "--input",
+                str(input_path),
+                "--max-cycles",
+                str(max_cycles),
+                "--sd",
+                str(sd_path),
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=15,
+            cwd=PROJECT_ROOT,
+        )
+        return result.stdout, result.stderr, result.returncode
+    except subprocess.TimeoutExpired as exc:
+        return exc.stdout or "", (exc.stderr or "") + "[TIMEOUT]", -1
+    finally:
+        input_path.unlink(missing_ok=True)
+        sd_path.unlink(missing_ok=True)
+
+
+def _hex_bytes(values: list[int]) -> str:
+    return "\r".join(f"{value:02X}" for value in values)
+
+
+def _dump_line(stdout: str, address: int) -> str:
+    marker = f"{address:04X}"
+    for line in stdout.splitlines():
+        if line.lstrip().startswith(marker):
+            return line
+    raise AssertionError(f"missing dump line {marker}: {stdout!r}")
+
+
 def test_mbr_fat32_fixture_layout() -> None:
     image = build_fat32_image(with_mbr=True)
     mbr = sector(image, 0)
@@ -236,6 +318,48 @@ def test_pia_bitbang_reads_known_sector() -> None:
     print("[PASS] test_pia_bitbang_reads_known_sector")
 
 
+def test_rom_sd_read_sector_reads_known_fixture_sector() -> None:
+    image = build_fat32_image(with_mbr=True)
+    layout = layout_for_image(with_mbr=True)
+    symbols = _load_symbol_addresses(
+        "SD_INIT",
+        "SD_READ_SECTOR",
+        "SD_LBA0",
+        "SD_LBA1",
+        "SD_LBA2",
+        "SD_LBA3",
+        "SD_SECTOR_BUF",
+    )
+    lba = layout.cluster_lba(MULTI_CLUSTER_1)
+    harness_addr = 0x0100
+    fail_offset = 0x1B
+    harness = [
+        0xBD, (symbols["SD_INIT"] >> 8) & 0xFF, symbols["SD_INIT"] & 0xFF,
+        0x25, fail_offset,
+        0x86, (lba >> 24) & 0xFF, 0xB7, (symbols["SD_LBA0"] >> 8) & 0xFF, symbols["SD_LBA0"] & 0xFF,
+        0x86, (lba >> 16) & 0xFF, 0xB7, (symbols["SD_LBA1"] >> 8) & 0xFF, symbols["SD_LBA1"] & 0xFF,
+        0x86, (lba >> 8) & 0xFF, 0xB7, (symbols["SD_LBA2"] >> 8) & 0xFF, symbols["SD_LBA2"] & 0xFF,
+        0x86, lba & 0xFF, 0xB7, (symbols["SD_LBA3"] >> 8) & 0xFF, symbols["SD_LBA3"] & 0xFF,
+        0xCE, (symbols["SD_SECTOR_BUF"] >> 8) & 0xFF, symbols["SD_SECTOR_BUF"] & 0xFF,
+        0xBD, (symbols["SD_READ_SECTOR"] >> 8) & 0xFF, symbols["SD_READ_SECTOR"] & 0xFF,
+        0x3F,
+        0x3F,
+    ]
+    input_text = (
+        f"M{harness_addr:04X}\r"
+        f"{_hex_bytes(harness)}\r.\r"
+        f"G{harness_addr:04X}\r"
+        f"D{symbols['SD_SECTOR_BUF']:04X}-{symbols['SD_SECTOR_BUF'] + 0x0F:04X}\r"
+        "\r"
+    )
+    stdout, stderr, rc = _run_emu_with_sd(input_text, image)
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    line = _dump_line(stdout, symbols["SD_SECTOR_BUF"])
+    expected = " ".join(f"{value:02X}" for value in MULTI_CLUSTER_1_PREFIX[:16])
+    assert expected in line, f"sector prefix mismatch: {line!r}\nstdout={stdout!r}"
+    print("[PASS] test_rom_sd_read_sector_reads_known_fixture_sector")
+
+
 def main() -> None:
     print("=" * 50)
     print("SD/PIA fixture tests")
@@ -247,6 +371,7 @@ def main() -> None:
         test_sdcard_command_sequence_reads_known_sector,
         test_sdcard_cs_release_discards_pending_response,
         test_pia_bitbang_reads_known_sector,
+        test_rom_sd_read_sector_reads_known_fixture_sector,
     ]
 
     passed = 0


### PR DESCRIPTION
## 対応Issue

Closes #49

## 変更内容

- Issue #49 の実装計画を docs/plans/issue-49_sd_sector_read.md に追加しました。
- MC6821 PIA Port B の暫定SPI定義と SD 作業領域を include/hardware.inc に追加しました。
- 内部APIとして SD_INIT、SD_READ_SECTOR、SD_SPI_XFER を src/sdcard.asm に追加しました。公開モニタコマンドは追加していません。
- 既存 FAT32 fixture とエミュレータ --sd を使い、ROM上の SD_INIT -> CMD17 sector read を確認する統合テストを追加しました。

## テスト結果

- make bin: 成功
- $env:REQUIRE_BUILD_ROM='1'; python tests/test_smoke.py: 18 passed, 0 failed
- python tests/test_sd_fixture.py: 6 passed, 0 failed
- python -m py_compile emu\sbc6800_emu.py tests\sd_fixtures.py tests\test_sd_fixture.py: 成功
- git diff --check: 成功

## 追加/更新したテスト

- tests/test_sd_fixture.py に test_rom_sd_read_sector_reads_known_fixture_sector を追加しました。
- MBRありFAT32 fixture上の既知LBAを読み、SD_SECTOR_BUF先頭が MULTI-CLUSTER-1 に一致することを確認します。

## 影響範囲

- ROM内にSDHC初期化と512 byte sector readの内部APIが増えます。
- FAT32解析、DIR、LF、S-Record/Intel HEX LOAD、SAVE/write、公開コマンド一覧は変更していません。
- PIAアドレス - はエミュレータ暫定値で、実機SBC-IO確認は #54 側で扱います。

## 未対応事項

- FAT32 BPB/MBR解析、root directory走査、DIR/LF統合は後続Issueで扱います。
- 実カードとSBC-IO実機でのレベル変換・アドレス競合確認は未実施です。
- 批判的レビュー者は応答待ちタイムアウトのため、今回は実装者側で差分と対象外混入を再確認しました。

## 関連リンク

- Issue #48: https://github.com/kuninet/mc6800-rom-monitor/issues/48
- PoC PR #46: https://github.com/kuninet/mc6800-rom-monitor/pull/46