### PR TITLE
Issue #52 DIR/LF filenameコマンドを統合

### DIFF
--- a/docs/plans/issue-52_dir_lf_command.md
+++ b/docs/plans/issue-52_dir_lf_command.md
@@ -1,0 +1,45 @@
+# Issue #52 DIR/LF filenameコマンド統合 実装計画
+
+## 関連リンク
+
+- Issue #52: https://github.com/kuninet/mc6800-rom-monitor/issues/52
+- Issue #51: https://github.com/kuninet/mc6800-rom-monitor/issues/51
+- PoC PR #46: https://github.com/kuninet/mc6800-rom-monitor/pull/46
+
+## 方針
+
+Issue #52では、FAT32 read-only基盤をモニタコマンドへ接続する。
+実装対象は `DIR` によるroot directory表示と、`LF filename` によるFAT上ファイル検索入口までとする。
+
+既存の `L` はシリアルLOADとして維持する。S-Record/Intel HEXの実ロード処理は #53 に分離し、今回の `LF` ではファイル内容をRAMへロードしない。
+
+## 実装範囲
+
+- `DIR`
+  - `DIR` 完全一致で認識する。
+  - `D` / `Dssss` / `Dssss-eeee` の既存dump動作を維持する。
+  - `FAT32_MOUNT` 後、root directory cluster chainを読み、通常file entryだけを表示する。
+  - 表示形式は `NAME.EXT A 0000001F` とする。
+- `LF filename`
+  - `LF TEST.S`、`LF   TEST.HEX   ` のような空白を許容する。
+  - filenameをroot上の8.3 short filename 11 byteへ変換し、`FAT32_FIND_83` に渡す。
+  - 成功時は `OK` を表示し、検索済みmetadataは既存FAT変数に保持する。
+  - 失敗時は `?` を表示する。
+- `H` と `docs/usage/monitor_commands.md` に `DIR` / `LF filename` を追加する。
+
+## 対象外
+
+- `LF` でのS-Record/Intel HEX実ロード
+- file内容の自動解析
+- subdirectory、LFN、wildcard対応
+- SAVE/write対応
+- `V` コマンド追加
+
+## 確認方針
+
+- `DIR` でfixture上の `TEST.S`、`TEST.HEX`、`MULTI.BIN` が表示されることを確認する。
+- `LF TEST.S` と `LF   TEST.HEX   ` が `OK` を返すことを確認する。
+- `LF NOFILE.S` が `?` を返すことを確認する。
+- bare `L` は既存シリアルLOADとして維持されることを確認する。
+- `V` は `?` のままであることを確認する。
+- 既存dumpコマンド `D0100` が壊れていないことを確認する。

--- a/docs/usage/monitor_commands.md
+++ b/docs/usage/monitor_commands.md
@@ -19,9 +19,11 @@
 | `D` | 継続アドレスから 64 バイト分をダンプする |
 | `Dssss` | `ssss` から 64 バイト分をダンプする |
 | `Dssss-eeee` | `ssss` から `eeee` までをダンプする |
+| `DIR` | SDカード上のroot directoryにある8.3通常ファイルを表示する |
 | `Mssss` | `ssss` からメモリを変更する |
 | `Gssss` | `ssss` へジャンプして実行する |
 | `L` | S-Record または Intel HEX をロードする |
+| `LF filename` | SDカード上の8.3名ファイルを検索して開く |
 | `H` | コマンド一覧を表示する |
 | `Fssss-eeee vv` | `ssss` から `eeee` までを `vv` で埋める |
 | `B` | 現在のブレークポイント状態を表示する |
@@ -128,13 +130,39 @@ OK
 ロード処理はレコードを受信しながら解析する。
 ロード中の進捗表示は速度を優先して行わず、正常終了時は `OK`、異常時は `?S1` から `?S5`、または `?I1` から `?I5` を表示する。
 
+`LF filename` はSDカード上のroot directoryから8.3 short filenameのファイルを検索する。
+既存の `L` とは別の入口で、Issue #52時点ではファイルを開くところまでを確認し、S-RecordやIntel HEXとしての実ロードはまだ行わない。
+
+```text
+] LF TEST.S
+OK
+]
+```
+
+ファイル名の前後の空白は無視する。subdirectory、LFN、wildcardは対象外である。
+
+## SD directory
+
+`DIR` はSDカード上のroot directoryにある8.3通常ファイルを表示する。
+LFN、削除entry、volume label、subdirectoryは表示しない。
+
+```text
+] DIR
+TEST.S A 0000001E
+TEST.HEX A 00000020
+MULTI.BIN A 00000400
+]
+```
+
+サイズは8桁16進で表示する。`DIR` は `D` dumpとは別コマンドであり、従来の `D0100` や `D0100-011F` はそのまま使える。
+
 ## ヘルプ
 
 `H` は短いコマンド一覧を表示する。
 
 ```text
 ] H
-D M G L B C R U H F
+D DIR M G L LF B C R U H F
 ]
 ```
 

--- a/src/main.asm
+++ b/src/main.asm
@@ -66,6 +66,10 @@ MAIN_LOOP:
         ldaa    LINE_BUF
         cmpa    #'D'
         bne     CHK_CMD_MOD
+        jsr     IS_CMD_DIR
+        bcs     MAIN_DISPATCH_DUMP
+        jmp     CMD_DIR
+MAIN_DISPATCH_DUMP:
         jmp     CMD_DUMP
 CHK_CMD_MOD:
         cmpa    #'M'
@@ -107,6 +111,22 @@ CHK_CMD_FILL:
 MAIN_LOOP_ERROR:
         jsr     SHOW_ERROR
         bra     MAIN_LOOP
+
+IS_CMD_DIR:
+        ldab    LINE_LEN
+        cmpb    #3
+        bne     IS_CMD_DIR_FAIL
+        ldaa    LINE_BUF+1
+        cmpa    #'I'
+        bne     IS_CMD_DIR_FAIL
+        ldaa    LINE_BUF+2
+        cmpa    #'R'
+        bne     IS_CMD_DIR_FAIL
+        clc
+        rts
+IS_CMD_DIR_FAIL:
+        sec
+        rts
 
 CMD_DUMP:
         ldab    LINE_LEN
@@ -372,6 +392,229 @@ PARSE_FILL_FAIL:
         sec
         rts
 
+PARSE_FILENAME_83:
+        stx     ARG_PTR
+        stab    ARG_LEN
+        jsr     CLEAR_FIND_NAME
+PARSE_FILENAME_SKIP_HEAD:
+        tst     ARG_LEN
+        bne     PARSE_FILENAME_SKIP_HAS
+        jmp     PARSE_FILENAME_FAIL
+PARSE_FILENAME_SKIP_HAS:
+        ldx     ARG_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        bne     PARSE_FILENAME_NAME_START
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        bra     PARSE_FILENAME_SKIP_HEAD
+
+PARSE_FILENAME_NAME_START:
+        ldx     #FAT_FIND_NAME0
+        stx     FAT_ENTRY_PTR
+        clr     ARG2_LEN
+PARSE_FILENAME_NAME_LOOP:
+        tst     ARG_LEN
+        beq     PARSE_FILENAME_NAME_DONE
+        ldx     ARG_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        bne     PARSE_FILENAME_NAME_NOT_SPACE
+        jmp     PARSE_FILENAME_TRAILING
+PARSE_FILENAME_NAME_NOT_SPACE:
+        cmpa    #'.'
+        bne     PARSE_FILENAME_NAME_NOT_DOT
+        jmp     PARSE_FILENAME_EXT_START
+PARSE_FILENAME_NAME_NOT_DOT:
+        ldab    ARG2_LEN
+        cmpb    #8
+        blo     PARSE_FILENAME_NAME_ROOM
+        jmp     PARSE_FILENAME_FAIL
+PARSE_FILENAME_NAME_ROOM:
+        jsr     TO_UPPER
+        ldx     FAT_ENTRY_PTR
+        staa    0,x
+        inx
+        stx     FAT_ENTRY_PTR
+        inc     ARG2_LEN
+        ldx     ARG_PTR
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        bra     PARSE_FILENAME_NAME_LOOP
+
+PARSE_FILENAME_NAME_DONE:
+        tst     ARG2_LEN
+        bne     PARSE_FILENAME_NAME_OK
+        jmp     PARSE_FILENAME_FAIL
+PARSE_FILENAME_NAME_OK:
+        clc
+        rts
+
+PARSE_FILENAME_EXT_START:
+        tst     ARG2_LEN
+        bne     PARSE_FILENAME_EXT_NAME_OK
+        jmp     PARSE_FILENAME_FAIL
+PARSE_FILENAME_EXT_NAME_OK:
+        ldx     ARG_PTR
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        ldx     #FAT_FIND_NAME8
+        stx     FAT_ENTRY_PTR
+        clr     ARG2_LEN
+PARSE_FILENAME_EXT_LOOP:
+        tst     ARG_LEN
+        bne     PARSE_FILENAME_EXT_HAS_LEN
+        jmp     PARSE_FILENAME_OK
+PARSE_FILENAME_EXT_HAS_LEN:
+        ldx     ARG_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        bne     PARSE_FILENAME_EXT_NOT_SPACE
+        jmp     PARSE_FILENAME_TRAILING
+PARSE_FILENAME_EXT_NOT_SPACE:
+        cmpa    #'.'
+        bne     PARSE_FILENAME_EXT_CHAR_OK
+        jmp     PARSE_FILENAME_FAIL
+PARSE_FILENAME_EXT_CHAR_OK:
+        ldab    ARG2_LEN
+        cmpb    #3
+        blo     PARSE_FILENAME_EXT_ROOM
+        jmp     PARSE_FILENAME_FAIL
+PARSE_FILENAME_EXT_ROOM:
+        jsr     TO_UPPER
+        ldx     FAT_ENTRY_PTR
+        staa    0,x
+        inx
+        stx     FAT_ENTRY_PTR
+        inc     ARG2_LEN
+        ldx     ARG_PTR
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        bra     PARSE_FILENAME_EXT_LOOP
+
+PARSE_FILENAME_TRAILING:
+        ldx     ARG_PTR
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+PARSE_FILENAME_TRAILING_LOOP:
+        tst     ARG_LEN
+        beq     PARSE_FILENAME_OK
+        ldx     ARG_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        beq     PARSE_FILENAME_TRAILING_SPACE_OK
+        jmp     PARSE_FILENAME_FAIL
+PARSE_FILENAME_TRAILING_SPACE_OK:
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        bra     PARSE_FILENAME_TRAILING_LOOP
+
+PARSE_FILENAME_OK:
+        clc
+        rts
+PARSE_FILENAME_FAIL:
+        sec
+        rts
+
+CLEAR_FIND_NAME:
+        ldx     #FAT_FIND_NAME0
+        ldab    #11
+CLEAR_FIND_NAME_LOOP:
+        ldaa    #CHR_SPACE
+        staa    0,x
+        inx
+        decb
+        bne     CLEAR_FIND_NAME_LOOP
+        rts
+
+TO_UPPER:
+        cmpa    #'a'
+        blo     TO_UPPER_DONE
+        cmpa    #'z'
+        bhi     TO_UPPER_DONE
+        suba    #$20
+TO_UPPER_DONE:
+        rts
+
+CMD_DIR_PRINT_ENTRY:
+        ldx     FAT_ENTRY_PTR
+        ldab    #8
+CMD_DIR_PRINT_BASE_LOOP:
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        beq     CMD_DIR_PRINT_BASE_SKIP
+        jsr     MON_OUTEEE
+CMD_DIR_PRINT_BASE_SKIP:
+        inx
+        decb
+        bne     CMD_DIR_PRINT_BASE_LOOP
+        jsr     CMD_DIR_EXT_HAS_CHAR
+        bcs     CMD_DIR_PRINT_ATTR
+        ldaa    #'.'
+        jsr     MON_OUTEEE
+        ldx     FAT_ENTRY_PTR
+        ldab    #8
+CMD_DIR_PRINT_EXT_POS:
+        inx
+        decb
+        bne     CMD_DIR_PRINT_EXT_POS
+        ldab    #3
+CMD_DIR_PRINT_EXT_LOOP:
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        beq     CMD_DIR_PRINT_EXT_SKIP
+        jsr     MON_OUTEEE
+CMD_DIR_PRINT_EXT_SKIP:
+        inx
+        decb
+        bne     CMD_DIR_PRINT_EXT_LOOP
+CMD_DIR_PRINT_ATTR:
+        jsr     PRINT_SPACE
+        ldaa    #'A'
+        jsr     MON_OUTEEE
+        jsr     PRINT_SPACE
+        ldx     FAT_ENTRY_PTR
+        ldaa    31,x
+        jsr     PRINT_HEX8
+        ldx     FAT_ENTRY_PTR
+        ldaa    30,x
+        jsr     PRINT_HEX8
+        ldx     FAT_ENTRY_PTR
+        ldaa    29,x
+        jsr     PRINT_HEX8
+        ldx     FAT_ENTRY_PTR
+        ldaa    28,x
+        jsr     PRINT_HEX8
+        jsr     PRINT_CRLF
+        rts
+
+CMD_DIR_EXT_HAS_CHAR:
+        ldx     FAT_ENTRY_PTR
+        ldab    #8
+CMD_DIR_EXT_POS:
+        inx
+        decb
+        bne     CMD_DIR_EXT_POS
+        ldab    #3
+CMD_DIR_EXT_SCAN:
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        bne     CMD_DIR_EXT_YES
+        inx
+        decb
+        bne     CMD_DIR_EXT_SCAN
+        sec
+        rts
+CMD_DIR_EXT_YES:
+        clc
+        rts
+
 CMP_X_DUMP_END:
         stx     HEX_VALUE_HI
         ldaa    HEX_VALUE_HI
@@ -621,7 +864,7 @@ CMD_FILL_ERR:
 CMD_LOAD:
         ldab    LINE_LEN
         cmpb    #1
-        bne     CMD_LOAD_BADARG
+        bne     CMD_LOAD_EXTENDED
 
         ldaa    #'L'
         jsr     MON_OUTEEE
@@ -653,6 +896,79 @@ CMD_LOAD_ERROR:
 
 CMD_LOAD_BADARG:
         jmp     MAIN_LOOP_ERROR
+
+CMD_LOAD_EXTENDED:
+        ldaa    LINE_BUF+1
+        cmpa    #'F'
+        beq     CMD_LF
+        cmpa    #'f'
+        beq     CMD_LF
+        jmp     CMD_LOAD_BADARG
+
+CMD_LF:
+        ldab    LINE_LEN
+        subb    #2
+        ldx     #LINE_BUF+2
+        jsr     PARSE_FILENAME_83
+        bcs     CMD_LF_ERROR
+        jsr     FAT32_MOUNT
+        bcs     CMD_LF_ERROR
+        ldx     #FAT_FIND_NAME0
+        jsr     FAT32_FIND_83
+        bcs     CMD_LF_ERROR
+        ldx     #TXT_OK
+        jsr     PDATA1
+        jsr     PRINT_CRLF
+        jmp     MAIN_LOOP
+CMD_LF_ERROR:
+        jmp     MAIN_LOOP_ERROR
+
+CMD_DIR:
+        ldab    LINE_LEN
+        cmpb    #3
+        beq     CMD_DIR_START
+        jmp     MAIN_LOOP_ERROR
+CMD_DIR_START:
+        jsr     FAT32_MOUNT
+        bcc     CMD_DIR_MOUNT_OK
+        jmp     MAIN_LOOP_ERROR
+CMD_DIR_MOUNT_OK:
+        jsr     FAT_COPY_ROOT_TO_CUR
+CMD_DIR_CLUSTER:
+        jsr     FAT_CLUSTER_TO_SD_LBA
+        ldx     #SD_SECTOR_BUF
+        jsr     SD_READ_SECTOR
+        bcc     CMD_DIR_SCAN_PREP
+        jmp     MAIN_LOOP_ERROR
+CMD_DIR_SCAN_PREP:
+        ldx     #SD_SECTOR_BUF
+        stx     FAT_ENTRY_PTR
+        ldaa    #16
+        staa    FAT_DIR_COUNT
+CMD_DIR_ENTRY_LOOP:
+        ldx     FAT_ENTRY_PTR
+        ldaa    0,x
+        beq     CMD_DIR_DONE
+        cmpa    #$E5
+        beq     CMD_DIR_SKIP_ENTRY
+        ldaa    11,x
+        anda    #$0F
+        cmpa    #$0F
+        beq     CMD_DIR_SKIP_ENTRY
+        ldaa    11,x
+        bita    #$18
+        bne     CMD_DIR_SKIP_ENTRY
+        jsr     CMD_DIR_PRINT_ENTRY
+CMD_DIR_SKIP_ENTRY:
+        jsr     FAT_ADVANCE_ENTRY_PTR
+        dec     FAT_DIR_COUNT
+        bne     CMD_DIR_ENTRY_LOOP
+        jsr     FAT32_NEXT_CLUSTER
+        bcs     CMD_DIR_DONE
+        jsr     FAT_COPY_NEXT_TO_CUR
+        bra     CMD_DIR_CLUSTER
+CMD_DIR_DONE:
+        jmp     MAIN_LOOP
 
 PRINT_PROMPT:
         ldaa    #CHR_PROMPT
@@ -1350,7 +1666,9 @@ TXT_BRK:        fcc     "BRK "
                 fcb     $04
 TXT_WELCOME:    fcc     "MC6800 MONITOR"
                 fcb     $04
-TXT_HELP:       fcc     "D M G L B C R U H F"
+TXT_HELP:       fcc     "D DIR M G L LF B C R U H F"
+                fcb     $04
+TXT_OK:         fcc     "OK"
                 fcb     $04
 TXT_BP:         fcc     "BP "
                 fcb     $04

--- a/tests/test_sd_fixture.py
+++ b/tests/test_sd_fixture.py
@@ -536,6 +536,35 @@ def test_rom_fat32_find_chained_root_entry() -> None:
     print("[PASS] test_rom_fat32_find_chained_root_entry")
 
 
+def test_rom_dir_command_lists_root_files() -> None:
+    image = build_fat32_image(with_mbr=True)
+    stdout, stderr, rc = _run_emu_with_sd("DIR\r\r", image, max_cycles=80_000_000)
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    assert "TEST.S A 0000001E" in stdout, f"missing TEST.S DIR entry: {stdout!r}"
+    assert "TEST.HEX A 00000020" in stdout, f"missing TEST.HEX DIR entry: {stdout!r}"
+    assert "MULTI.BIN A 00000400" in stdout, f"missing MULTI.BIN DIR entry: {stdout!r}"
+    assert "SKIP" not in stdout, f"volume/subdirectory-like entries should be skipped: {stdout!r}"
+    print("[PASS] test_rom_dir_command_lists_root_files")
+
+
+def test_rom_dir_keeps_dump_command() -> None:
+    image = build_fat32_image(with_mbr=True)
+    stdout, stderr, rc = _run_emu_with_sd("D0100\r\r", image)
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    assert "0100" in stdout, f"dump command should still work: {stdout!r}"
+    print("[PASS] test_rom_dir_keeps_dump_command")
+
+
+def test_rom_lf_command_opens_83_files_only() -> None:
+    image = build_fat32_image(with_mbr=True)
+    input_text = "LF TEST.S\rLF   test.hex   \rLF NOFILE.S\rV\r\r"
+    stdout, stderr, rc = _run_emu_with_sd(input_text, image, max_cycles=80_000_000)
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    assert stdout.count("OK") >= 2, f"LF should open existing files: {stdout!r}"
+    assert stdout.count("?") >= 2, f"missing LF not found / V errors: {stdout!r}"
+    print("[PASS] test_rom_lf_command_opens_83_files_only")
+
+
 def main() -> None:
     print("=" * 50)
     print("SD/PIA fixture tests")
@@ -554,6 +583,9 @@ def main() -> None:
         test_rom_fat32_find_and_read_multicluster_file,
         test_rom_fat32_find_respects_file_size,
         test_rom_fat32_find_chained_root_entry,
+        test_rom_dir_command_lists_root_files,
+        test_rom_dir_keeps_dump_command,
+        test_rom_lf_command_opens_83_files_only,
     ]
 
     passed = 0

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -127,7 +127,7 @@ def test_error_display():
 
 def test_help_command():
     stdout, stderr, rc = run_emu("H\r\r")
-    assert "D M G L B C R U H F" in stdout, f"missing help command list: {stdout!r}"
+    assert "D DIR M G L LF B C R U H F" in stdout, f"missing help command list: {stdout!r}"
     print("[PASS] test_help_command")
 
 


### PR DESCRIPTION
## 対応Issue

Closes #52

## 変更内容

- `docs/plans/issue-52_dir_lf_command.md` を追加し、DIR/LF統合の判断と #53 へ残す範囲を記録しました。
- `DIR` コマンドを追加し、FAT32 root directory の8.3通常ファイルを `NAME.EXT A 0000001E` 形式で表示するようにしました。
- `LF filename` を追加し、root上の8.3ファイルを検索してメタデータを保持する入口を追加しました。
- 既存の bare `L` はシリアルLOADとして維持し、`D0100` など既存dumpも維持しました。
- help表示と `docs/usage/monitor_commands.md` に `DIR` / `LF filename` を追加しました。
- smoke / SD fixture テストに DIR/LF の回帰テストを追加しました。

## テスト結果

- `make bin` 成功
- `$env:REQUIRE_BUILD_ROM='1'; python tests/test_smoke.py` 成功（18 passed）
- `python tests/test_sd_fixture.py` 成功（15 passed）
- `python -m py_compile emu\sbc6800_emu.py tests\sd_fixtures.py tests\test_sd_fixture.py tests\test_smoke.py` 成功
- `git diff --check` 成功

## 追加/更新したテスト

- `DIR` で fixture の `TEST.S`、`TEST.HEX`、`MULTI.BIN` が表示されること。
- `DIR` 追加後も `D0100` がdumpコマンドとして動作すること。
- `LF TEST.S` と `LF   test.hex   ` が成功すること。
- `LF NOFILE.S` と `V` が `?` を返すこと。

## 影響範囲

- ROMモニタのコマンドdispatch、help表示、FAT32 read-only検索入口。
- SD/FAT fixtureを使うエミュレータテスト。

## 未対応事項

- `LF filename` はファイル検索入口までです。S-Record / Intel HEX の実ロード処理は #53 で扱います。
- subdirectory、LFN、wildcard、SAVE/write は対象外です。
- `V` コマンドは追加していません。

## 関連リンク

- Issue #52: https://github.com/kuninet/mc6800-rom-monitor/issues/52
- Issue #51: https://github.com/kuninet/mc6800-rom-monitor/issues/51
- PoC PR #46: https://github.com/kuninet/mc6800-rom-monitor/pull/46