### PR TITLE
Issue #65 SecPerClus対応のLBA計算を追加

### DIFF
--- a/docs/plans/issue-65_secperclus_lba.md
+++ b/docs/plans/issue-65_secperclus_lba.md
@@ -42,3 +42,16 @@ git diff --check
 ```
 
 実機では、`HELLO.S` を root に置いたカードで `LF HELLO.S` を実行し、`OK` と `D0100` のロード結果を確認する。
+
+## 実機確認結果
+
+PR #67 の実装ROMで、実カード上の `HELLO.S` を `LF HELLO.S` でロードできた。続けて `G0100` を実行し、`HELLO, WORLD` が表示され、`BRK 0106` でモニタへ戻るところまで確認できた。
+
+確認時の要点:
+
+- `F0100-01FF 00` でロード先を初期化。
+- `LF HELLO.S` が `OK` を返した。
+- `D0100` で `CE 01 07 BD E0 7E ... 48 45 4C 4C 4F 2C 20 57 4F 52 4C 44 ...` が入り、S-Recordの内容がRAMへ反映された。
+- `G0100` で `HELLO, WORLD` を表示し、`BRK 0106 A=04 B=00 X=0117 SP=1F42 CC=D4` で停止した。
+
+これにより、Issue #65 の範囲である `SecPerClus>1` カード上の512 byte以下ファイルLOADは実機で確認済みとする。512 byteを超える `MICBAS13.S` / `MICBAS13.HEX` のようなファイルは、予定どおり Issue #66 の cluster内複数sector stream read 対応で扱う。

--- a/docs/plans/issue-65_secperclus_lba.md
+++ b/docs/plans/issue-65_secperclus_lba.md
@@ -1,0 +1,44 @@
+# Issue #65 SecPerClus対応のcluster先頭LBA計算 計画
+
+## 関連リンク
+
+- Issue #65: https://github.com/kuninet/mc6800-rom-monitor/issues/65
+- 親 Issue #54: https://github.com/kuninet/mc6800-rom-monitor/issues/54
+- PR #64: https://github.com/kuninet/mc6800-rom-monitor/pull/64
+
+## 方針
+
+実機では MISO プルアップ後に `DIR` が成功し、SD 初期化、FAT32 mount、root directory read までは確認できた。`LF HELLO.S` は失敗したが、直後の確認で `SD_ERROR=$00`、`FAT_ERROR=$00`、`FAT_SEC_PER_CLUS=$06`、`HELLO.S start cluster=5`、`file size=$54` が見えている。
+
+現行実装は `cluster -> LBA` が `data_start + (cluster - 2)` で、`SecPerClus=1` 前提になっている。実カードでは `SecPerClus=6` のため、file cluster の先頭 LBA がずれる。Issue #65 では、まず 512 byte 以下の単一 sector ファイルを読めるように `FAT_CLUSTER_TO_SD_LBA` だけを `SecPerClus` 対応にする。
+
+cluster 内の2 sector目以降を読む stream 状態管理は Issue #66 に残す。
+
+## 実装内容
+
+- `FAT_CLUSTER_TO_SD_LBA` を `data_start + (cluster - 2) * FAT_SEC_PER_CLUS` に変更する。
+- 計算は既存制約に合わせ、cluster番号の下位8bitを使った加算ループにする。
+- `tests/sd_fixtures.py` は既定 `SecPerClus=1` を維持しつつ、テスト用に `sectors_per_cluster` を指定できるようにする。
+- `tests/test_sd_fixture.py` に `SecPerClus=6` fixtureで `LF TEST.S` 相当の小さいS-Recordファイルをロードできる確認を追加する。
+
+## 対象外
+
+- 512 byte を超えるファイルの `LF`。
+- cluster 内の複数 sector stream read。
+- `FAT32_READ_FILE` の複数 sector 正式対応。
+- SAVE/write、subdirectory、LFN、AUTOEXEC、外部 MCU 化。
+
+## テスト方針
+
+PR 前に次を実行する。
+
+```powershell
+make bin
+$env:REQUIRE_BUILD_ROM='1'
+python tests/test_smoke.py
+python tests/test_sd_fixture.py
+python -m py_compile emu\sbc6800_emu.py tests\sd_fixtures.py tests\test_sd_fixture.py
+git diff --check
+```
+
+実機では、`HELLO.S` を root に置いたカードで `LF HELLO.S` を実行し、`OK` と `D0100` のロード結果を確認する。

--- a/src/fat32.asm
+++ b/src/fat32.asm
@@ -647,7 +647,11 @@ FAT_CLUSTER_TO_SD_LBA:
 FAT_CLUSTER_ADD_LOOP:
         ldaa    FAT_TMP
         beq     FAT_CLUSTER_ADD_DONE
+        ldab    FAT_SEC_PER_CLUS
+FAT_CLUSTER_ADD_SECTOR_LOOP:
         jsr     FAT_INC_SD_LBA
+        decb
+        bne     FAT_CLUSTER_ADD_SECTOR_LOOP
         dec     FAT_TMP
         bra     FAT_CLUSTER_ADD_LOOP
 FAT_CLUSTER_ADD_DONE:

--- a/tests/sd_fixtures.py
+++ b/tests/sd_fixtures.py
@@ -34,21 +34,22 @@ class Fat32Layout:
     fat_lba: int
     root_dir_lba: int
     data_start_lba: int
+    sectors_per_cluster: int = SECTORS_PER_CLUSTER
 
     def cluster_lba(self, cluster: int) -> int:
-        return self.data_start_lba + (cluster - 2) * SECTORS_PER_CLUSTER
+        return self.data_start_lba + (cluster - 2) * self.sectors_per_cluster
 
 
-def build_fat32_image(with_mbr: bool, root_chain: bool = False) -> bytes:
+def build_fat32_image(with_mbr: bool, root_chain: bool = False, sectors_per_cluster: int = SECTORS_PER_CLUSTER) -> bytes:
     volume_start = PARTITION_START_LBA if with_mbr else 0
     total_sectors = volume_start + TOTAL_VOLUME_SECTORS
     image = bytearray(total_sectors * SECTOR_SIZE)
-    layout = layout_for_image(with_mbr)
+    layout = layout_for_image(with_mbr, sectors_per_cluster=sectors_per_cluster)
 
     if with_mbr:
         _write_mbr(image, volume_start, TOTAL_VOLUME_SECTORS)
 
-    _write_vbr(image, volume_start)
+    _write_vbr(image, volume_start, sectors_per_cluster=sectors_per_cluster)
     _write_fsinfo(image, volume_start + 1)
     _write_fats(image, layout, root_chain=root_chain)
     _write_root_dir(image, layout, root_chain=root_chain)
@@ -56,7 +57,7 @@ def build_fat32_image(with_mbr: bool, root_chain: bool = False) -> bytes:
     return bytes(image)
 
 
-def layout_for_image(with_mbr: bool) -> Fat32Layout:
+def layout_for_image(with_mbr: bool, sectors_per_cluster: int = SECTORS_PER_CLUSTER) -> Fat32Layout:
     volume_start = PARTITION_START_LBA if with_mbr else 0
     fat_lba = volume_start + RESERVED_SECTORS
     data_start = volume_start + RESERVED_SECTORS + FAT_COUNT * FAT_SIZE_SECTORS
@@ -65,6 +66,7 @@ def layout_for_image(with_mbr: bool) -> Fat32Layout:
         fat_lba=fat_lba,
         root_dir_lba=data_start,
         data_start_lba=data_start,
+        sectors_per_cluster=sectors_per_cluster,
     )
 
 
@@ -95,12 +97,12 @@ def _write_mbr(image: bytearray, start_lba: int, sector_count: int) -> None:
     image[0:SECTOR_SIZE] = mbr
 
 
-def _write_vbr(image: bytearray, lba: int) -> None:
+def _write_vbr(image: bytearray, lba: int, sectors_per_cluster: int) -> None:
     vbr = bytearray(SECTOR_SIZE)
     vbr[0:3] = b"\xEB\x58\x90"
     vbr[3:11] = b"MSDOS5.0"
     vbr[11:13] = SECTOR_SIZE.to_bytes(2, "little")
-    vbr[13] = SECTORS_PER_CLUSTER
+    vbr[13] = sectors_per_cluster
     vbr[14:16] = RESERVED_SECTORS.to_bytes(2, "little")
     vbr[16] = FAT_COUNT
     vbr[17:19] = (0).to_bytes(2, "little")
@@ -139,9 +141,10 @@ def _write_fats(image: bytearray, layout: Fat32Layout, root_chain: bool) -> None
         ROOT_CLUSTER: ROOT_EXTRA_CLUSTER if root_chain else EOC,
         TEST_S_CLUSTER: EOC,
         TEST_HEX_CLUSTER: EOC,
-        MULTI_CLUSTER_1: MULTI_CLUSTER_2,
-        MULTI_CLUSTER_2: EOC,
+        MULTI_CLUSTER_1: MULTI_CLUSTER_2 if layout.sectors_per_cluster == 1 else EOC,
     }
+    if layout.sectors_per_cluster == 1:
+        entries[MULTI_CLUSTER_2] = EOC
     if root_chain:
         entries[ROOT_EXTRA_CLUSTER] = EOC
         entries[LATE_BIN_CLUSTER] = EOC
@@ -182,7 +185,10 @@ def _write_file_clusters(image: bytearray, layout: Fat32Layout, root_chain: bool
     _write_cluster(image, layout, TEST_S_CLUSTER, _padded(TEST_S_CONTENT, 0x00))
     _write_cluster(image, layout, TEST_HEX_CLUSTER, _padded(TEST_HEX_CONTENT, 0x00))
     _write_cluster(image, layout, MULTI_CLUSTER_1, _padded(MULTI_CLUSTER_1_PREFIX, 0x11))
-    _write_cluster(image, layout, MULTI_CLUSTER_2, _padded(MULTI_CLUSTER_2_PREFIX, 0x22))
+    if layout.sectors_per_cluster == 1:
+        _write_cluster(image, layout, MULTI_CLUSTER_2, _padded(MULTI_CLUSTER_2_PREFIX, 0x22))
+    else:
+        _write_sector(image, layout.cluster_lba(MULTI_CLUSTER_1) + 1, _padded(MULTI_CLUSTER_2_PREFIX, 0x22))
     if root_chain:
         _write_cluster(image, layout, LATE_BIN_CLUSTER, _padded(LATE_BIN_CONTENT, 0x33))
 

--- a/tests/test_sd_fixture.py
+++ b/tests/test_sd_fixture.py
@@ -55,11 +55,11 @@ def entry_cluster(entry: bytes) -> int:
     return (u16(entry, 20) << 16) | u16(entry, 26)
 
 
-def assert_common_bpb(image: bytes, volume_lba: int) -> None:
+def assert_common_bpb(image: bytes, volume_lba: int, sectors_per_cluster: int = 1) -> None:
     bpb = sector(image, volume_lba)
     assert bpb[510:512] == b"\x55\xAA", "missing BPB signature"
     assert u16(bpb, 11) == SECTOR_SIZE, "unexpected bytes per sector"
-    assert bpb[13] == 1, "unexpected sectors per cluster"
+    assert bpb[13] == sectors_per_cluster, "unexpected sectors per cluster"
     assert u16(bpb, 14) == 4, "unexpected reserved sector count"
     assert bpb[16] == 2, "unexpected FAT count"
     assert u16(bpb, 17) == 0, "FAT32 root entry count must be zero"
@@ -325,6 +325,17 @@ def test_chained_root_fat32_fixture_layout() -> None:
     print("[PASS] test_chained_root_fat32_fixture_layout")
 
 
+def test_multisector_cluster_fixture_layout() -> None:
+    image = build_fat32_image(with_mbr=True, sectors_per_cluster=6)
+    layout = layout_for_image(with_mbr=True, sectors_per_cluster=6)
+    assert_common_bpb(image, PARTITION_START_LBA, sectors_per_cluster=6)
+    assert layout.cluster_lba(MULTI_CLUSTER_1) == layout.data_start_lba + (MULTI_CLUSTER_1 - 2) * 6
+    assert sector(image, layout.cluster_lba(TEST_S_CLUSTER)).startswith(TEST_S_CONTENT)
+    assert sector(image, layout.cluster_lba(MULTI_CLUSTER_1)).startswith(MULTI_CLUSTER_1_PREFIX)
+    assert sector(image, layout.cluster_lba(MULTI_CLUSTER_1) + 1).startswith(MULTI_CLUSTER_2_PREFIX)
+    print("[PASS] test_multisector_cluster_fixture_layout")
+
+
 def test_sdcard_command_sequence_reads_known_sector() -> None:
     image = build_fat32_image(with_mbr=True)
     layout = layout_for_image(with_mbr=True)
@@ -586,6 +597,15 @@ def test_rom_lf_file_eof_does_not_wait_for_acia() -> None:
     print("[PASS] test_rom_lf_file_eof_does_not_wait_for_acia")
 
 
+def test_rom_lf_reads_small_file_from_multisector_cluster() -> None:
+    image = build_fat32_image(with_mbr=True, sectors_per_cluster=6)
+    stdout, stderr, rc = _run_emu_with_sd("LF TEST.S\rD0200-0202\r\r", image, max_cycles=80_000_000)
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    assert "OK" in stdout, f"LF should load small file from SecPerClus > 1 image: {stdout!r}"
+    assert "0200 01 02 03" in stdout, f"missing S-Record loaded bytes: {stdout!r}"
+    print("[PASS] test_rom_lf_reads_small_file_from_multisector_cluster")
+
+
 def main() -> None:
     print("=" * 50)
     print("SD/PIA fixture tests")
@@ -595,6 +615,7 @@ def main() -> None:
         test_mbr_fat32_fixture_layout,
         test_superfloppy_fat32_fixture_layout,
         test_chained_root_fat32_fixture_layout,
+        test_multisector_cluster_fixture_layout,
         test_sdcard_command_sequence_reads_known_sector,
         test_sdcard_cs_release_discards_pending_response,
         test_pia_bitbang_reads_known_sector,
@@ -608,6 +629,7 @@ def main() -> None:
         test_rom_dir_keeps_dump_command,
         test_rom_lf_command_opens_83_files_only,
         test_rom_lf_file_eof_does_not_wait_for_acia,
+        test_rom_lf_reads_small_file_from_multisector_cluster,
     ]
 
     passed = 0


### PR DESCRIPTION
## 対応Issue

Closes #65
Refs #54
Refs #64

## 変更内容

- docs/plans/issue-65_secperclus_lba.md に実機ログ由来の判断と検証方針を記録しました。
- FAT_CLUSTER_TO_SD_LBA を SecPerClus 対応にし、data_start + (cluster - 2) * FAT_SEC_PER_CLUS でcluster先頭LBAを求めるようにしました。
- FAT32 fixtureで sectors_per_cluster を指定できるようにし、SecPerClus=6 相当の小さいS-RecordファイルLOAD確認を追加しました。
- SecPerClus>1 fixtureの MULTI.BIN 配置もFAT32として自然になるよう、2 sector目を同一cluster内の次sectorへ置くようにしました。

## テスト結果

- make bin
- $env:REQUIRE_BUILD_ROM='1'; python tests/test_smoke.py
- python tests/test_sd_fixture.py
- python -m py_compile emu\sbc6800_emu.py tests\sd_fixtures.py tests\test_sd_fixture.py
- git diff --check

## 追加/更新したテスト

- SecPerClus=6 fixtureのBPB/cluster LBA/同一cluster内2 sector配置確認を追加しました。
- SecPerClus=6 fixtureで LF TEST.S 相当の小さいファイルがLOADできるROM統合テストを追加しました。

## 影響範囲

- FAT32 read-only の cluster先頭LBA計算。
- テスト用FAT32 fixture生成。

## 未対応事項

- 512 byteを超えるファイルのcluster内複数sector stream readは #66 で対応します。
- SAVE/write、subdirectory、LFN、AUTOEXEC、外部MCU化は対象外です。

## 関連リンク

- 親Issue: https://github.com/kuninet/mc6800-rom-monitor/issues/54
- 前提PR: https://github.com/kuninet/mc6800-rom-monitor/pull/64