### PR TITLE
Issue #74 MAP表示コマンドを追加

### DIFF
--- a/docs/plans/issue-74_map_command.md
+++ b/docs/plans/issue-74_map_command.md
@@ -1,0 +1,50 @@
+# Issue #74 MAP表示
+
+## 関連リンク
+
+- Issue #74: https://github.com/kuninet/mc6800-rom-monitor/issues/74
+- Issue #70: https://github.com/kuninet/mc6800-rom-monitor/issues/70
+- Issue #72: https://github.com/kuninet/mc6800-rom-monitor/issues/72
+- PR #73: https://github.com/kuninet/mc6800-rom-monitor/pull/73
+
+## 背景
+
+Issue #72 で `base` / `sbcio` のビルドプロファイルを分け、`sbcio` ではSD/FATワークを `$C000-$DFFF` へ移せるようにした。次の確認段階として、実機やエミュレータ上で現在のビルドが想定している主要メモリ配置を短く表示できるようにする。
+
+## 採用方針
+
+- 新規コマンドは `MAP` とする。
+- `M` は既存のメモリ変更コマンドなので、`MAP` 完全一致を先に判定し、`MAP` 以外は従来どおり `CMD_MOD` へ渡す。
+- `MAP` は表示専用で、RAM確認や破壊テストはしない。
+- 表示値は実行時検出ではなく、ビルド時の profile 定義をそのまま表示する。
+
+## 表示仕様
+
+`MAP` は次のような固定形式で表示する。
+
+```text
+MAP BASE
+RAM 0000-1FFF
+USER 0000-1FFF
+WORK 1C00-1FFF
+SD 1C00
+MON 1E00
+MIK 1F00
+STK 1F42
+ROM E000-FFFF
+```
+
+`sbcio` profileでは `MAP SBCIO`、`RAM 0000-7FFF`、`WORK C000-DFFF`、`SD C000`、`MON C200` になる。
+
+## 対象外
+
+- Issue #75 の `RAMTEST`。
+- 実機上でRAMが存在するかの確認。
+- RAM容量自動検出。
+- K68-VDG、2nd ACIA、PTM、RTC、BOOT、SAVE/write。
+
+## 検証方針
+
+- `base` / `sbcio` の両方で `MAP` 出力が profile 定義と一致することを smoke test で確認する。
+- `MAP` 後にユーザーRAM内容が変化しないことを、`F` と `D` を使って確認する。
+- 既存の `M0100` などメモリ変更コマンドが壊れていないことを既存テストで維持する。

--- a/docs/usage/monitor_commands.md
+++ b/docs/usage/monitor_commands.md
@@ -21,6 +21,7 @@
 | `Dssss-eeee` | `ssss` から `eeee` までをダンプする |
 | `DIR` | SDカード上のroot directoryにある8.3通常ファイルを表示する |
 | `Mssss` | `ssss` からメモリを変更する |
+| `MAP` | 現在のビルドが想定する主要メモリ配置を表示する |
 | `Gssss` | `ssss` へジャンプして実行する |
 | `L` | S-Record または Intel HEX をロードする |
 | `LF filename` | SDカード上の8.3名ファイルを検索して開く |
@@ -99,6 +100,26 @@
 `.` を入力するとメモリ変更を終了する。
 不正な値や 3 桁以上の値を入力すると `?` を表示して終了する。
 
+## メモリマップ表示
+
+`MAP` は現在のROMビルドが想定する主要メモリ配置を表示する。RAMを書き換えず、実機上にRAMが存在するかの破壊テストもしない。
+
+```text
+] MAP
+MAP BASE
+RAM 0000-1FFF
+USER 0000-1FFF
+WORK 1C00-1FFF
+SD 1C00
+MON 1E00
+MIK 1F00
+STK 1F42
+ROM E000-FFFF
+]
+```
+
+SBC-IO拡張ROMでは `MAP SBCIO` と表示され、`WORK C000-DFFF`、`SD C000`、`MON C200` などの拡張RAM前提の配置になる。
+
 ## 実行
 
 `Gssss` は指定アドレスへジャンプして実行する。
@@ -163,7 +184,7 @@ MULTI.BIN A 00000400
 
 ```text
 ] H
-D DIR M G L LF B C R U H F
+D DIR M MAP G L LF B C R U H F
 ]
 ```
 

--- a/src/main.asm
+++ b/src/main.asm
@@ -74,6 +74,10 @@ MAIN_DISPATCH_DUMP:
 CHK_CMD_MOD:
         cmpa    #'M'
         bne     CHK_CMD_GO
+        jsr     IS_CMD_MAP
+        bcs     MAIN_DISPATCH_MOD
+        jmp     CMD_MAP
+MAIN_DISPATCH_MOD:
         jmp     CMD_MOD
 CHK_CMD_GO:
         cmpa    #'G'
@@ -125,6 +129,22 @@ IS_CMD_DIR:
         clc
         rts
 IS_CMD_DIR_FAIL:
+        sec
+        rts
+
+IS_CMD_MAP:
+        ldab    LINE_LEN
+        cmpb    #3
+        bne     IS_CMD_MAP_FAIL
+        ldaa    LINE_BUF+1
+        cmpa    #'A'
+        bne     IS_CMD_MAP_FAIL
+        ldaa    LINE_BUF+2
+        cmpa    #'P'
+        bne     IS_CMD_MAP_FAIL
+        clc
+        rts
+IS_CMD_MAP_FAIL:
         sec
         rts
 
@@ -838,6 +858,17 @@ CMD_HELP:
         jmp     MAIN_LOOP
 CMD_HELP_ERR:
         jmp     MAIN_LOOP_ERROR
+
+CMD_MAP:
+        ldaa    #MONITOR_PROFILE_SBCIO
+        beq     CMD_MAP_BASE
+        ldx     #TXT_MAP_SBCIO
+        bra     CMD_MAP_PRINT
+CMD_MAP_BASE:
+        ldx     #TXT_MAP_BASE
+CMD_MAP_PRINT:
+        jsr     PDATA1
+        jmp     MAIN_LOOP
 
 CMD_FILL:
         ldab    LINE_LEN
@@ -1700,9 +1731,47 @@ TXT_BRK:        fcc     "BRK "
                 fcb     $04
 TXT_WELCOME:    fcc     "MC6800 MONITOR"
                 fcb     $04
-TXT_HELP:       fcc     "D DIR M G L LF B C R U H F"
+TXT_HELP:       fcc     "D DIR M MAP G L LF B C R U H F"
                 fcb     $04
 TXT_OK:         fcc     "OK"
+                fcb     $04
+TXT_MAP_BASE:   fcc     "MAP BASE"
+                fcb     CHR_CR
+                fcc     "RAM 0000-1FFF"
+                fcb     CHR_CR
+                fcc     "USER 0000-1FFF"
+                fcb     CHR_CR
+                fcc     "WORK 1C00-1FFF"
+                fcb     CHR_CR
+                fcc     "SD 1C00"
+                fcb     CHR_CR
+                fcc     "MON 1E00"
+                fcb     CHR_CR
+                fcc     "MIK 1F00"
+                fcb     CHR_CR
+                fcc     "STK 1F42"
+                fcb     CHR_CR
+                fcc     "ROM E000-FFFF"
+                fcb     CHR_CR
+                fcb     $04
+TXT_MAP_SBCIO:  fcc     "MAP SBCIO"
+                fcb     CHR_CR
+                fcc     "RAM 0000-7FFF"
+                fcb     CHR_CR
+                fcc     "USER 0000-7FFF"
+                fcb     CHR_CR
+                fcc     "WORK C000-DFFF"
+                fcb     CHR_CR
+                fcc     "SD C000"
+                fcb     CHR_CR
+                fcc     "MON C200"
+                fcb     CHR_CR
+                fcc     "MIK 1F00"
+                fcb     CHR_CR
+                fcc     "STK 1F42"
+                fcb     CHR_CR
+                fcc     "ROM E000-FFFF"
+                fcb     CHR_CR
                 fcb     $04
 TXT_BP:         fcc     "BP "
                 fcb     $04

--- a/src/main.asm
+++ b/src/main.asm
@@ -863,12 +863,44 @@ CMD_MAP:
         ldaa    #MONITOR_PROFILE_SBCIO
         beq     CMD_MAP_BASE
         ldx     #TXT_MAP_SBCIO
-        bra     CMD_MAP_PRINT
+        jsr     MAP_PRINT_LINE
+        ldx     #TXT_MAP_SBCIO_RAM
+        jsr     MAP_PRINT_LINE
+        ldx     #TXT_MAP_SBCIO_USER
+        jsr     MAP_PRINT_LINE
+        ldx     #TXT_MAP_SBCIO_WORK
+        jsr     MAP_PRINT_LINE
+        ldx     #TXT_MAP_SBCIO_SD
+        jsr     MAP_PRINT_LINE
+        ldx     #TXT_MAP_SBCIO_MON
+        jsr     MAP_PRINT_LINE
+        bra     CMD_MAP_COMMON
 CMD_MAP_BASE:
         ldx     #TXT_MAP_BASE
-CMD_MAP_PRINT:
-        jsr     PDATA1
+        jsr     MAP_PRINT_LINE
+        ldx     #TXT_MAP_BASE_RAM
+        jsr     MAP_PRINT_LINE
+        ldx     #TXT_MAP_BASE_USER
+        jsr     MAP_PRINT_LINE
+        ldx     #TXT_MAP_BASE_WORK
+        jsr     MAP_PRINT_LINE
+        ldx     #TXT_MAP_BASE_SD
+        jsr     MAP_PRINT_LINE
+        ldx     #TXT_MAP_BASE_MON
+        jsr     MAP_PRINT_LINE
+CMD_MAP_COMMON:
+        ldx     #TXT_MAP_MIK
+        jsr     MAP_PRINT_LINE
+        ldx     #TXT_MAP_STK
+        jsr     MAP_PRINT_LINE
+        ldx     #TXT_MAP_ROM
+        jsr     MAP_PRINT_LINE
         jmp     MAIN_LOOP
+
+MAP_PRINT_LINE:
+        jsr     PDATA1
+        jsr     PRINT_CRLF
+        rts
 
 CMD_FILL:
         ldab    LINE_LEN
@@ -1735,44 +1767,36 @@ TXT_HELP:       fcc     "D DIR M MAP G L LF B C R U H F"
                 fcb     $04
 TXT_OK:         fcc     "OK"
                 fcb     $04
-TXT_MAP_BASE:   fcc     "MAP BASE"
-                fcb     CHR_CR
-                fcc     "RAM 0000-1FFF"
-                fcb     CHR_CR
-                fcc     "USER 0000-1FFF"
-                fcb     CHR_CR
-                fcc     "WORK 1C00-1FFF"
-                fcb     CHR_CR
-                fcc     "SD 1C00"
-                fcb     CHR_CR
-                fcc     "MON 1E00"
-                fcb     CHR_CR
-                fcc     "MIK 1F00"
-                fcb     CHR_CR
-                fcc     "STK 1F42"
-                fcb     CHR_CR
-                fcc     "ROM E000-FFFF"
-                fcb     CHR_CR
-                fcb     $04
-TXT_MAP_SBCIO:  fcc     "MAP SBCIO"
-                fcb     CHR_CR
-                fcc     "RAM 0000-7FFF"
-                fcb     CHR_CR
-                fcc     "USER 0000-7FFF"
-                fcb     CHR_CR
-                fcc     "WORK C000-DFFF"
-                fcb     CHR_CR
-                fcc     "SD C000"
-                fcb     CHR_CR
-                fcc     "MON C200"
-                fcb     CHR_CR
-                fcc     "MIK 1F00"
-                fcb     CHR_CR
-                fcc     "STK 1F42"
-                fcb     CHR_CR
-                fcc     "ROM E000-FFFF"
-                fcb     CHR_CR
-                fcb     $04
+TXT_MAP_BASE:       fcc     "MAP BASE"
+                    fcb     $04
+TXT_MAP_BASE_RAM:   fcc     "RAM 0000-1FFF"
+                    fcb     $04
+TXT_MAP_BASE_USER:  fcc     "USER 0000-1FFF"
+                    fcb     $04
+TXT_MAP_BASE_WORK:  fcc     "WORK 1C00-1FFF"
+                    fcb     $04
+TXT_MAP_BASE_SD:    fcc     "SD 1C00"
+                    fcb     $04
+TXT_MAP_BASE_MON:   fcc     "MON 1E00"
+                    fcb     $04
+TXT_MAP_SBCIO:      fcc     "MAP SBCIO"
+                    fcb     $04
+TXT_MAP_SBCIO_RAM:  fcc     "RAM 0000-7FFF"
+                    fcb     $04
+TXT_MAP_SBCIO_USER: fcc     "USER 0000-7FFF"
+                    fcb     $04
+TXT_MAP_SBCIO_WORK: fcc     "WORK C000-DFFF"
+                    fcb     $04
+TXT_MAP_SBCIO_SD:   fcc     "SD C000"
+                    fcb     $04
+TXT_MAP_SBCIO_MON:  fcc     "MON C200"
+                    fcb     $04
+TXT_MAP_MIK:        fcc     "MIK 1F00"
+                    fcb     $04
+TXT_MAP_STK:        fcc     "STK 1F42"
+                    fcb     $04
+TXT_MAP_ROM:        fcc     "ROM E000-FFFF"
+                    fcb     $04
 TXT_BP:         fcc     "BP "
                 fcb     $04
 TXT_NONE:       fcc     "NONE"

--- a/tests/test_sd_fixture.py
+++ b/tests/test_sd_fixture.py
@@ -499,6 +499,39 @@ def test_rom_profile_memory_layout() -> None:
     print("[PASS] test_rom_profile_memory_layout")
 
 
+def test_rom_map_command_matches_profile_symbols() -> None:
+    symbols = _load_symbol_addresses(
+        "RAM_START",
+        "RAM_END",
+        "USER_RAM_END",
+        "WORK_RAM_START",
+        "WORK_RAM_END",
+        "SD_SECTOR_BUF",
+        "MONITOR_RAM_BASE",
+        "MIKBUG_VAR_BASE",
+        "STACK_TOP",
+        "ROM_BASE",
+        "ROM_END",
+    )
+    stdout, stderr, rc = _run_emu_with_sd("MAP\r\r", build_fat32_image(with_mbr=True))
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    profile = "SBCIO" if _is_sbcio_build() else "BASE"
+    expected_lines = [
+        f"MAP {profile}",
+        f"RAM {symbols['RAM_START']:04X}-{symbols['RAM_END']:04X}",
+        f"USER {symbols['RAM_START']:04X}-{symbols['USER_RAM_END']:04X}",
+        f"WORK {symbols['WORK_RAM_START']:04X}-{symbols['WORK_RAM_END']:04X}",
+        f"SD {symbols['SD_SECTOR_BUF']:04X}",
+        f"MON {symbols['MONITOR_RAM_BASE']:04X}",
+        f"MIK {symbols['MIKBUG_VAR_BASE']:04X}",
+        f"STK {symbols['STACK_TOP']:04X}",
+        f"ROM {symbols['ROM_BASE']:04X}-{symbols['ROM_END']:04X}",
+    ]
+    for line in expected_lines:
+        assert line in stdout, f"missing MAP line {line!r}: {stdout!r}"
+    print("[PASS] test_rom_map_command_matches_profile_symbols")
+
+
 def assert_rom_fat32_mount_layout(with_mbr: bool) -> None:
     image = build_fat32_image(with_mbr=with_mbr)
     layout = layout_for_image(with_mbr=with_mbr)
@@ -778,6 +811,7 @@ def main() -> None:
         test_pia_bitbang_reads_known_sector,
         test_rom_sd_read_sector_reads_known_fixture_sector,
         test_rom_profile_memory_layout,
+        test_rom_map_command_matches_profile_symbols,
         test_rom_fat32_mount_reads_mbr_bpb_layout,
         test_rom_fat32_mount_reads_superfloppy_bpb_layout,
         test_rom_fat32_find_and_read_multicluster_file,

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -140,8 +140,40 @@ def test_error_display():
 
 def test_help_command():
     stdout, stderr, rc = run_emu("H\r\r")
-    assert "D DIR M G L LF B C R U H F" in stdout, f"missing help command list: {stdout!r}"
+    assert "D DIR M MAP G L LF B C R U H F" in stdout, f"missing help command list: {stdout!r}"
     print("[PASS] test_help_command")
+
+
+def is_sbcio_build() -> bool:
+    return "-sbcio" in BUILD_ROM_PATH.stem or os.environ.get("MONITOR_PROFILE") == "sbcio"
+
+
+def test_map_command():
+    stdout, stderr, rc = run_emu("F0100-0103 5A\rMAP\rD0100-0103\r\r", max_cycles=5_000_000)
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    if is_sbcio_build():
+        expected = [
+            "MAP SBCIO",
+            "RAM 0000-7FFF",
+            "USER 0000-7FFF",
+            "WORK C000-DFFF",
+            "SD C000",
+            "MON C200",
+        ]
+    else:
+        expected = [
+            "MAP BASE",
+            "RAM 0000-1FFF",
+            "USER 0000-1FFF",
+            "WORK 1C00-1FFF",
+            "SD 1C00",
+            "MON 1E00",
+        ]
+    expected.extend(["MIK 1F00", "STK 1F42", "ROM E000-FFFF"])
+    for text in expected:
+        assert text in stdout, f"missing MAP output {text!r}: {stdout!r}"
+    assert "0100 5A 5A 5A 5A" in stdout, f"MAP should not modify user RAM: {stdout!r}"
+    print("[PASS] test_map_command")
 
 
 def test_breakpoint_query():
@@ -294,6 +326,7 @@ def main():
         test_ihex_load,
         test_error_display,
         test_help_command,
+        test_map_command,
         test_breakpoint_query,
         test_breakpoint_resume_and_clear,
         test_resume_requires_active_breakpoint,


### PR DESCRIPTION
## 対応Issue

Closes #74
Refs #70
Refs #72

## 変更内容

- MAP コマンドを追加し、現在ビルドの主要メモリ配置を表示できるようにしました。
- M との衝突を避けるため、MAP 完全一致だけを CMD_MAP に分岐し、それ以外は従来どおり CMD_MOD に渡します。
- MAP 出力は ase / sbcio profileごとの固定文字列にし、コマンド本体でRAMを書き換えない形にしました。
- H のヘルプと docs/usage/monitor_commands.md を更新しました。
- smoke test と SD fixture test に MAP の確認を追加しました。

## テスト結果

- make bin : PASS
- $env:REQUIRE_BUILD_ROM='1'; python tests/test_smoke.py : 19 passed
- python tests/test_sd_fixture.py : 25 passed
- make bin MONITOR_PROFILE=sbcio : PASS
- $env:MONITOR_PROFILE='sbcio'; ='build/mc6800-monitor-sbcio.bin'; ='build/mc6800-monitor-sbcio.lst'; python tests/test_smoke.py : 19 passed
- $env:MONITOR_PROFILE='sbcio'; ='build/mc6800-monitor-sbcio.bin'; ='build/mc6800-monitor-sbcio.lst'; python tests/test_sd_fixture.py : 25 passed
- python -m py_compile tests\test_smoke.py tests\test_sd_fixture.py emu\sbc6800_emu.py : PASS
- git diff --check : PASS

## 追加/更新したテスト

- MAP 出力の ase / sbcio 差分を smoke test で確認します。
- F0100-0103 5A 後に MAP を実行し、ユーザーRAM内容が変わらないことを確認します。
- SD fixture test で MAP 出力がlistingのprofileシンボル値と一致することを確認します。

## 影響範囲

- M0100 など既存メモリ変更コマンドは維持します。
- DIR / LF / H の既存テストは引き続き通っています。

## 未対応事項

- RAMTEST は Issue #75 で扱います。
- 実機上でRAMが存在するかの確認はこのPRでは行いません。

## 関連リンク

- Issue #70: https://github.com/kuninet/mc6800-rom-monitor/issues/70
- Issue #72: https://github.com/kuninet/mc6800-rom-monitor/issues/72
- PR #73: https://github.com/kuninet/mc6800-rom-monitor/pull/73