### PR TITLE
docs: BOOTとAUTOEXECの責務を整理

### DIFF
--- a/docs/plans/issue-70_next_monitor_roadmap.md
+++ b/docs/plans/issue-70_next_monitor_roadmap.md
@@ -77,7 +77,7 @@ SBC-IO の MC6821 PIA 経由で SD/FAT read-only の `DIR` と `LF filename` が
 | 4 | 2nd ACIAキーボード | PC保守コンソールを残したままキーボード入力を追加 | PS/2かUSB+MCUかの選定 |
 | 5 | PTMタイマ | timeout、tick、キー入力補助の土台を作る | 最初から割り込み前提にしない |
 | 6 | PIA Port A I2C RTC | SDボード+RTCボード構想を検証する | PIA共有、I2Cプルアップ、レベル変換 |
-| 7 | AUTOEXEC.S と BOOT | SDから起動時初期化やBASIC起動を自動化する | 自動実行アドレス規約を決める |
+| 7 | BOOT / SDFS.BIN / AUTOEXEC.S | SDから第2段を起動し、起動時初期化やBASIC起動を自動化する | BOOTとAUTOEXEC.Sの責務を分ける |
 | 8 | SD bootstrap / M6800 DOS | ROM容量逼迫時に機能をRAM側へ逃がす | 専用SD作成手順が必要 |
 | 9 | SAVE/write | スタンドアロン運用でSDへ保存できるようにする | FAT更新の安全性と電源断耐性 |
 
@@ -138,12 +138,13 @@ PTMは最初から割り込み前提にせず、まずは待ち時間やtick用�
 - RTCは `AUTOEXEC.S` や将来のDOS相当機能から時刻を読む用途を想定する。
 - Port B の余りビット (bit 6/7) を I2C に流用する代替案と、RTC/EEPROM/OLED の同居検討は [i2c_bus_overlay_evaluation.md](i2c_bus_overlay_evaluation.md) にまとめてある。
 
-### 7. AUTOEXEC.S と BOOT
+### 7. BOOT / SDFS.BIN / AUTOEXEC.S
 
 SD LOADが実機動作したため、起動自動化は有力な次期機能。
 
-- `BOOT` コマンドで root の `AUTOEXEC.S` を探してLOADする。
-- 初期はS-Recordのみを対象にする。
+- `BOOT` は root の `AUTOEXEC.S` を直接 LOAD するコマンドではなく、SD上の第2段システムを起動する入口として扱う。
+- 第2段の初期候補は root directory の `SDFS.BIN` とし、`BOOT` は `SDFS.BIN` の LOAD/RUN までを担当する。
+- `AUTOEXEC.S` は `SDFS.BIN` または将来の M6800 DOS 相当が起動後に任意で探す起動スクリプト相当として扱う。
 - AUTOEXECからRTC初期化、VDG初期化、BASIC起動を行う構成にする。
 
 ### 8. SDシステム領域bootstrapとオリジナルDOS構想
@@ -152,6 +153,7 @@ ROM容量が FAT read-only と VDG 対応で厳しくなる場合、SDカード�
 
 - ROMにはSD初期化と第1段bootstrap readだけを残し、FAT/DIR/LF/VDG/キーボードなどをRAM上の第2段へ逃がす。
 - 第2段はrootの `SDFS.BIN` など通常ファイルに置く案を優先し、固定sectorは最小bootstrapに限定する。
+- `AUTOEXEC.S` は第2段起動後の処理であり、ROM側 `BOOT` や第1段bootstrapが直接扱う対象にはしない。
 - SD予約領域を使う場合は、専用SD作成ツールとsignature検査が必要になる。
 - 通常のモニタ拡張というより、M6800 DOS相当の別構想として扱う。
 - 初期ロードマップでは実装対象外だが、ROM容量が逼迫した時の退避先として残す。
@@ -172,7 +174,7 @@ FAT write は便利だが、実装ミスでSDカードを壊しやすい。VDG/�
 5. 2nd ACIAキーボード入力。
 6. PTMタイマ。
 7. PIA Port A I2C RTCのPoC。
-8. `BOOT` / `AUTOEXEC.S`。
+8. `BOOT` / `SDFS.BIN` / `AUTOEXEC.S`。
 9. SDシステム領域bootstrapとオリジナルDOS構想の再評価。
 10. SAVE/write。
 

--- a/docs/plans/issue-82_sd_bootstrap_dos.md
+++ b/docs/plans/issue-82_sd_bootstrap_dos.md
@@ -1,0 +1,39 @@
+# Issue #82 SD bootstrap / M6800 DOS 構想整理
+
+## 関連リンク
+
+- Issue #82: https://github.com/kuninet/mc6800-rom-monitor/issues/82
+- Issue #89: https://github.com/kuninet/mc6800-rom-monitor/issues/89
+- Issue #81: https://github.com/kuninet/mc6800-rom-monitor/issues/81
+
+## 方針
+
+`BOOT` は root の `AUTOEXEC.S` を直接 LOAD するコマンドではなく、SD 上の第2段システムを起動する入口として扱う。第2段の初期候補は root directory の `SDFS.BIN` とし、`AUTOEXEC.S` は `SDFS.BIN` または将来の M6800 DOS 相当が起動後に任意で処理する起動スクリプト相当とする。
+
+責務は次のように分ける。
+
+| 要素 | 責務 |
+| --- | --- |
+| `BOOT` | SD 上の第2段システムを探して LOAD/RUN する入口 |
+| 第1段bootstrap | reserved sector などから最小 loader を起動する将来候補 |
+| `SDFS.BIN` | DIR/LF などの SD/FAT 操作と、必要に応じた `AUTOEXEC.S` 処理を持つ第2段 |
+| `AUTOEXEC.S` | RTC、VDG、キーボード、BASIC 起動などを行う任意の起動スクリプト |
+
+## 方式比較
+
+| 方式 | 位置づけ | 採用条件 |
+| --- | --- | --- |
+| ROM 直 FAT から `SDFS.BIN` 起動 | 初期検討の現実路線 | ROM 容量に収まり、root directory から通常ファイルを読めること |
+| FAT32 reserved sector bootstrap | ROM 削減案 | 専用 SD 作成手順、signature 検査、復旧手順を用意できること |
+| 外部 MCU 経由 | 将来の性能改善案 | SD/FAT 処理を外部 firmware に逃がす価値が実装コストを上回ること |
+
+## 採用保留条件
+
+- ROM 容量が FAT read-only、VDG、キーボード、RTC 対応で逼迫するまでは、reserved sector bootstrap 実装を急がない。
+- `AUTOEXEC.S` は ROM 側 `BOOT` や第1段bootstrapの責務に含めない。
+- `CONFIG.SYS`、subdirectory、FAT write、SD イメージ作成ツールは #82 の設計整理では対象外にする。
+- 実装に入る場合は、`BOOT` で `SDFS.BIN` を起動する Issue と、`SDFS.BIN` 側で `AUTOEXEC.S` を処理する Issue を分ける。
+
+## 検証方針
+
+#82 では設計整理を成果物とし、実装テストは後続 Issue に分ける。後続 PoC では、`SDFS.BIN` 未検出、signature 不一致、サイズ不正、FAT chain read error、`AUTOEXEC.S` なしの各ケースで安全に対話モードまたはシリアル `L` fallback へ戻れることを確認する。

--- a/docs/requirements/2026-04-25_sdcard_spi_fat_requirements.md
+++ b/docs/requirements/2026-04-25_sdcard_spi_fat_requirements.md
@@ -104,7 +104,7 @@ PIA 直結の初期目標は、PC で通常の FAT32 として読める SD カ�
 
 既存の `L` はシリアル受信 LOAD として維持する。`L filename` は入力互換性を崩す可能性があるため、初期候補は `LF filename` とする。
 
-## Root配置とAUTOEXEC.S
+## 第2段起動とAUTOEXEC.S
 
 初期実装では subdirectory をサポートしないため、第2段 SD/FAT driver または M6800 DOS 相当の本体は root directory の `SDFS.BIN` に固定する。`/MC6800/SDFS.BIN` や `/MC6800/BOOT.SYS` は、subdirectory 対応後の将来候補とする。
 
@@ -117,10 +117,12 @@ Root directory の初期構成例は次の通り。
 | `TEST.S` | 手動 LOAD 用 S-Record サンプル |
 | `TEST.HEX` | 手動 LOAD 用 Intel HEX サンプル |
 
+`BOOT` は `AUTOEXEC.S` を直接読むコマンドではなく、SD上の第2段システムを起動する入口として扱う。`AUTOEXEC.S` は `SDFS.BIN` または将来の M6800 DOS 相当が起動後に扱う任意の起動スクリプト相当とし、ROM側 `BOOT` や第1段bootstrapの直接責務には含めない。
+
 ROM 直 FAT 案の起動順序は次の通り。
 
 1. ROM が SDHC 初期化と BPB 最小読取を行う。
-2. ROM が root directory から `SDFS.BIN` を探す。
+2. `BOOT` 相当処理が root directory から `SDFS.BIN` を探す。
 3. ROM が `SDFS.BIN` を `$C000` などへ読み込み、signature または最小ヘッダを確認して実行する。
 4. `SDFS.BIN` が DIR/LF などの SD/FAT 操作を提供する。
 5. `SDFS.BIN` が root directory の `AUTOEXEC.S` を探し、存在する場合だけ既存 S-Record ローダ相当で RAM へ LOAD する。
@@ -135,7 +137,7 @@ Reserved sector bootstrap 案の起動順序は次の通り。
 5. 第1段 bootstrap が `SDFS.BIN` の signature または最小ヘッダを確認して制御を渡す。
 6. `SDFS.BIN` が DIR/LF と `AUTOEXEC.S` 処理を提供する。
 
-`AUTOEXEC.S` は初期必須ではない。用途例は次の通り。
+`AUTOEXEC.S` は第2段起動の初期必須ではない。用途例は次の通り。
 
 - RTC 読み出しルーチン。
 - MC6847 画面初期化。


### PR DESCRIPTION
## 対応 Issue

Closes #89
Refs #81
Refs #82
Refs #70

## 変更内容

- #81 を整理コメント付きで close し、BOOT/AUTOEXEC の実装Issueとしては進めない方針に変更
- ロードマップ上の `BOOT / AUTOEXEC.S` を `BOOT / SDFS.BIN / AUTOEXEC.S` の三段構成に整理
- SD/FAT 要件文書に、`BOOT` は第2段起動入口、`AUTOEXEC.S` は第2段側の任意起動処理であることを明記
- #82 の設計整理用に `docs/plans/issue-82_sd_bootstrap_dos.md` を追加

## テスト結果

- `rg -n "BOOT|AUTOEXEC|SDFS\.BIN|DOS|bootstrap" docs README.md`
- `git diff --check`

## 追加または更新したテスト

- 文書変更のみのため、テスト追加なし

## 影響範囲

- ドキュメントのみ
- ROM 実装、BOOT コマンド追加、AUTOEXEC 処理追加、SD イメージ作成ツール追加は含まない

## 未対応事項

- ROM ビルドとエミュレータ smoke test は未実施
- `BOOT` で `SDFS.BIN` を起動する実装Issueは未作成
- `SDFS.BIN` 側で `AUTOEXEC.S` を処理する実装Issueは未作成

## レビュー

- チーム内の批判的レビューで、`BOOT = AUTOEXEC.S 直LOAD` と読める表現が残っていないこと、#82 対象外の実装が混入していないことを確認済み