### PR TITLE
docs: I2C分割方針とROM容量監視を整理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.srec
 *.hex
 *.tmp
+.DS_Store
 __pycache__/
 build/
 sample/

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,7 @@ IHEX := $(OUTDIR)/$(TARGET).hex
 CONFIG_INC := $(OUTDIR)/monitor_config.inc
 ROM_KIND ?= 27C64
 ROM_FILL ?= 0xFF
+ROM_CODE_LIMIT ?= 8192
 
 ifeq ($(ROM_KIND),27C64)
 ROM_CHIP_SIZE := 0x2000
@@ -189,9 +190,9 @@ endif
 
 ASL_INCLUDE := $(CURDIR)/$(OUTDIR)$(ASL_PATHSEP)$(CURDIR)/include$(ASL_PATHSEP)$(CURDIR)/src
 
-.PHONY: all clean bin srec ihex rombin rombin-27c64 rombin-27c128 rombin-27c256 rombin-28c256 rombin-w27c512 program verify readback program-27c64 program-27c128 program-27c256 program-28c256 program-w27c512 program-upd28c256 FORCE
+.PHONY: all clean bin check-rom-size srec ihex rombin rombin-27c64 rombin-27c128 rombin-27c256 rombin-28c256 rombin-w27c512 program verify readback program-27c64 program-27c128 program-27c256 program-28c256 program-w27c512 program-upd28c256 FORCE
 
-all: srec ihex
+all: check-rom-size srec ihex
 
 $(OUTDIR):
 	$(MKDIR_P)
@@ -202,10 +203,13 @@ $(CONFIG_INC): FORCE tools/generate_monitor_config.py | $(OUTDIR)
 $(OBJ): FORCE $(TOPSRC) include/hardware.inc include/mikbug.inc $(CONFIG_INC) src/acia6850.asm src/sdcard.asm src/fat32.asm | $(OUTDIR)
 	"$(ASL)" -q -L -olist $(LST) -o $(OBJ) -i $(ASL_INCLUDE_ARG) $(TOPSRC)
 
-bin: $(BIN)
+bin: check-rom-size
 
 $(BIN): $(OBJ)
 	"$(P2BIN)" $(OBJ) $(BIN) -q
+
+check-rom-size: $(BIN)
+	"$(PYTHON)" -c "from pathlib import Path; import sys; p=Path('$(BIN)'); size=p.stat().st_size; limit=int('$(ROM_CODE_LIMIT)', 0); print(f'{p}: {size}/{limit} bytes'); sys.exit(0 if limit <= 0 or size <= limit else 1)"
 
 srec: $(SREC)
 
@@ -217,7 +221,7 @@ ihex: $(IHEX)
 $(IHEX): $(OBJ)
 	"$(P2HEX)" $(OBJ) $(IHEX) -q -F Intel -i 1
 
-rombin: $(ROMBIN)
+rombin: check-rom-size $(ROMBIN)
 
 $(ROMBIN): $(OBJ)
 	"$(P2BIN)" $(OBJ) $(ROMBIN) -q -r $(ROM_RANGE_START)-$(ROM_RANGE_END) -l $(ROM_FILL)
@@ -237,10 +241,10 @@ rombin-28c256:
 rombin-w27c512:
 	$(MAKE) rombin ROM_KIND=W27C512
 
-program: $(ROMBIN)
+program: check-rom-size $(ROMBIN)
 	$(MINIPRO) -p "$(MINIPRO_DEVICE)" -w $(ROMBIN)
 
-verify: $(ROMBIN)
+verify: check-rom-size $(ROMBIN)
 	$(MINIPRO) -p "$(MINIPRO_DEVICE)" -m $(ROMBIN)
 
 readback:

--- a/docs/development/build_configuration_axes.md
+++ b/docs/development/build_configuration_axes.md
@@ -51,6 +51,8 @@ SBC-IOを装備していてもメモリ配置は別軸で決めるため、`BOAR
 I2CはSBC-IOのPIAを前提にした将来機能として扱う。
 VDGはSBC-IOとは独立した外部表示装備として扱い、VRAM範囲は `MEMORY_CONFIG` とは別に明示する。
 
+ただし、I2CはRTC、EEPROM、OLED/LCDなど個別デバイス処理を含めるとROM容量を急速に消費する。8KB ROM互換を維持する間は、`FEATURE_I2C=1` を「I2C関連コードを無条件にROMへ押し込む入口」として使わない。ROM側へ入れる場合でも、最小BOOTや診断用の薄い入口に限定し、I2Cバスドライバ本体や個別デバイス機能はシリアル `L`、SD `LF`、または `SDFS.BIN` など第2段のRAMロード機能として検証する。
+
 ## 既存profileの展開
 
 既存の `MONITOR_PROFILE` は、当面は次のプリセットとして扱う。
@@ -117,7 +119,7 @@ make bin MEMORY_CONFIG=ram64_a000_work BOARD_IO=sbcio FEATURE_SD=1 FEATURE_VDG=1
 同時に、コマンド本体、内部ルーチン、関連文字列はROMから除外する。
 listingのsymbol tableでも、無効機能の内部ラベルは原則として出ないことを期待する。
 
-I2C本体は未実装であり、現時点では構成軸と `BOARD_IO=sbcio` 依存関係だけを導入する。
+I2C本体は未実装であり、現時点では構成軸と `BOARD_IO=sbcio` 依存関係だけを導入する。実装Issueを切る場合も、まずRAMロード可能なPoCとして作り、ROM常駐化はサイズ見積もりと第2段ロード方針を確認してから判断する。
 
 ## MAP表示方針
 

--- a/docs/plans/i2c_bus_overlay_evaluation.md
+++ b/docs/plans/i2c_bus_overlay_evaluation.md
@@ -19,6 +19,8 @@ SBC-IO の MC6821 PIA を介してビットバンギングで I2C バスを増�
 
 本メモは技術検証と推奨判断を残すものであり、I2C ドライバ本体や個別デバイスドライバの実装は別 Issue で扱う。
 
+Issue #80 は当初「PIA Port A I2C RTC PoC」として RTC まで含む広めの検討だったが、本メモで RTC/EEPROM/OLED と補助ライン活用まで整理したため、以後は #85 を I2C 配置検討の親 Issue とする。#80 は #85 配下の **Port A I2C bit-bang 基盤 PoC** に絞り、RTC デバイス依存処理、AUTOEXEC 連携、FAT timestamp 連携は後続 Issue へ分ける。
+
 ## 採用判断
 
 - **Port A 専用案を本命とする**。Issue #70 ロードマップ #6 の既定線と整合する。
@@ -26,6 +28,7 @@ SBC-IO の MC6821 PIA を介してビットバンギングで I2C バスを増�
 - I2C 速度は初期 PoC で約 10kHz を狙う。MC6800 1MHz の bit-bang で 100kHz 標準モード相当に届かせるかは PoC 後に判断する。
 - SCL は当面出力固定とし、クロックストレッチ対応は後段に分離する。
 - 5V PIA と 3.3V I2C デバイスの境界には双方向レベルシフタ (例 BSS138) を入れる。プルアップは 4.7kΩ 程度を共通化する。
+- 8KB ROM は既に逼迫しているため、I2C/RTC/EEPROM/OLED を ROM 常駐機能として厚く実装しない。初期 PoC はシリアル `L` または SD の `LF` で RAM へロードする小ハーネスを基本にし、将来は `SDFS.BIN` など第2段側の機能として育てる。
 
 ## 現状の Port B / Port A 使用状況
 
@@ -134,7 +137,7 @@ PIA はデータポート 8bit に加えて、ポートごとに 2 本ずつ補�
 | 候補 | 内容 | 優先 |
 | --- | --- | --- |
 | A | SBC-IO Rev02 拡張ヘッダの PA[7:0] / PB[6:7] / CA1 / CA2 / CB1 / CB2 引き出し確認 (実機 schematic レビュー) | 高 (両案の前提) |
-| B | I2C bit-bang ドライバ PoC (Port A、SCL 固定、~10kHz、START/STOP/書込/読出/ACK/NACK) | 高 |
+| B | I2C bit-bang ドライバ PoC (Port A、SCL 固定、~10kHz、START/STOP/書込/読出/ACK/NACK。ROM統合ではなくRAMロードハーネスで検証) | 高 |
 | C | DS3231 RTC ドライバ + AUTOEXEC からの時刻表示 | 中 |
 | C2 | DS3231 `INT/SQW` を CA1 (または CB1) に接続して RTC アラーム / 1Hz tick を IRQ 化 | 中 (C の後段) |
 | D | 24C32 EEPROM ドライバ (CONFIG.SYS 代替の起動パラメータ保存先候補) | 中 |
@@ -159,7 +162,7 @@ PIA はデータポート 8bit に加えて、ポートごとに 2 本ずつ補�
 
 このメモではドキュメント化のみを行う。以下は別 Issue で扱う。
 
-- `src/i2c.asm` の実装。
+- `src/i2c.asm` の ROM 常駐実装。
 - `include/hardware.inc` への I2C 関連定数追加。
 - `src/sdcard.asm` の改修 (Port B 共有案を採る場合のシャドウ拡張など)。
 - エミュレータへの I2C スレーブモデル追加。

--- a/docs/plans/issue-82_sd_bootstrap_dos.md
+++ b/docs/plans/issue-82_sd_bootstrap_dos.md
@@ -19,6 +19,8 @@
 | `SDFS.BIN` | DIR/LF などの SD/FAT 操作と、必要に応じた `AUTOEXEC.S` 処理を持つ第2段 |
 | `AUTOEXEC.S` | RTC、VDG、キーボード、BASIC 起動などを行う任意の起動スクリプト |
 
+ROM容量は8KB互換を前提にすると既に余裕が小さいため、I2C、RTC、EEPROM、OLED/LCD、AUTOEXEC 処理をROMへ常駐させて肥大化させない。これらの周辺機能は、まずRAMロード可能なPoCとして煮詰め、最終的には `SDFS.BIN` または将来の M6800 DOS 相当の第2段機能へ寄せる。
+
 ## 方式比較
 
 | 方式 | 位置づけ | 採用条件 |
@@ -29,7 +31,7 @@
 
 ## 採用保留条件
 
-- ROM 容量が FAT read-only、VDG、キーボード、RTC 対応で逼迫するまでは、reserved sector bootstrap 実装を急がない。
+- ROM 容量が FAT read-only、VDG、キーボード、RTC 対応で逼迫するまでは、reserved sector bootstrap 実装を急がない。ただし I2C/RTC/OLED などの周辺機能は、ROM常駐ではなく `SDFS.BIN` 側へ逃がす前提でIssueを切る。
 - `AUTOEXEC.S` は ROM 側 `BOOT` や第1段bootstrapの責務に含めない。
 - `CONFIG.SYS`、subdirectory、FAT write、SD イメージ作成ツールは #82 の設計整理では対象外にする。
 - 実装に入る場合は、`BOOT` で `SDFS.BIN` を起動する Issue と、`SDFS.BIN` 側で `AUTOEXEC.S` を処理する Issue を分ける。

--- a/docs/usage/build_commands.md
+++ b/docs/usage/build_commands.md
@@ -31,6 +31,12 @@ MONITOR_PROFILE=sbcio make program ROM_KIND=W27C512
 MONITOR_PROFILE=sbcio make program ROM_KIND=W27C512
 ```
 
+`make bin` は生成したROM本体のサイズを確認し、既定では `ROM_CODE_LIMIT=8192` を超えると失敗する。これは27C64互換の8KB ROMに収まらない変更を早期に検出するためである。`make rombin` と `make program` も同じ確認を通ってから容量合わせ済みイメージを作る。サイズ上限を一時的に無効化して調査したい場合だけ、明示的に `ROM_CODE_LIMIT=0` を指定する。
+
+```sh
+ROM_CODE_LIMIT=0 make bin
+```
+
 | 作りたいROM | コマンド | 主な出力 |
 | --- | --- | --- |
 | SBC6800互換の最小ROM | `make bin` | `build/mc6800-monitor.bin` |


### PR DESCRIPTION
## 対応 Issue
- Refs #85
- Refs #80
- Refs #97
- Refs #98
- Refs #99

## 変更内容
- #80 を Port A I2C bit-bang 基盤PoCへ再定義し、#85 を親Issueとして整理
- #97/#98/#99 を作成し、I2C実機引き出し確認、DS3231読み出し、DS3231 IRQ検証へ分割
- I2C/RTC/EEPROM/OLED はROM常駐ではなくRAMロードまたは `SDFS.BIN` 側へ寄せる方針を文書へ反映
- `ROM_CODE_LIMIT=8192` によるROM本体サイズ監視を追加し、`make` / `make bin` / `make rombin` / `make program` / `make verify` 経路で確認
- `.DS_Store` を `.gitignore` に追加

## テスト結果
- `make bin`
- `ROM_CODE_LIMIT=1 make bin` が期待どおり失敗することを確認
- `make`
- `make rombin ROM_KIND=27C64`
- `REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py`
- `MONITOR_PROFILE=sbcio make bin`
- `MONITOR_PROFILE=sbcio REQUIRE_BUILD_ROM=1 python3 tests/test_sd_fixture.py`

## 追加または更新したテスト
- 新規テストファイルは追加していない
- Makefile の異常系確認として `ROM_CODE_LIMIT=1 make bin` を手動実行

## 影響範囲
- ビルド時に8KB超過を早期検出する
- 既定の `make` でもサイズ監視を通すため、従来よりチェックが厳しくなる
- I2C実装方針は文書とIssue整理のみで、ROM本体のI2Cコードは追加しない

## 未対応事項
- #97 以降の実機確認とI2C基盤PoC実装
- 24C32 / SSD1306 / Port B共有案のIssue化は必要になった時点で実施

## 関連リンク
- #85
- #80
- #97
- #98
- #99