### PR TITLE
docs: SDFS/68 第2段ブート設計を整理

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@
 - [development/workflow.md](development/workflow.md): Issue/PR、テスト、レビューの開発運用ルール
 - [development/project_context.md](development/project_context.md): 新規コンテキスト向けのプロジェクト引き継ぎ情報
 - [usage/monitor_commands.md](usage/monitor_commands.md): ROM モニタのコマンドリファレンス
+- [usage/sdfs68_system_sd.md](usage/sdfs68_system_sd.md): SDFS/68 システムSDカードの初期方針
 - [design/memory_map.md](design/memory_map.md)
 - [design/architecture.md](design/architecture.md)
 - [plans/implementation_plan.md](plans/implementation_plan.md)

--- a/docs/plans/issue-82_sd_bootstrap_dos.md
+++ b/docs/plans/issue-82_sd_bootstrap_dos.md
@@ -1,23 +1,29 @@
-# Issue #82 SD bootstrap / M6800 DOS 構想整理
+# Issue #82 SDFS/68 第2段ブート構想整理
 
 ## 関連リンク
 
 - Issue #82: https://github.com/kuninet/mc6800-rom-monitor/issues/82
 - Issue #89: https://github.com/kuninet/mc6800-rom-monitor/issues/89
 - Issue #81: https://github.com/kuninet/mc6800-rom-monitor/issues/81
+- Issue #85: https://github.com/kuninet/mc6800-rom-monitor/issues/85
 
 ## 方針
 
-`BOOT` は root の `AUTOEXEC.S` を直接 LOAD するコマンドではなく、SD 上の第2段システムを起動する入口として扱う。第2段の初期候補は root directory の `SDFS.BIN` とし、`AUTOEXEC.S` は `SDFS.BIN` または将来の M6800 DOS 相当が起動後に任意で処理する起動スクリプト相当とする。
+第2段システムの名称は **SDFS/68** とし、SD カード上の実ファイル名は既存方針どおり `SDFS.BIN` とする。`BOOT` は root の `AUTOEXEC.S` を直接 LOAD するコマンドではなく、root directory の通常ファイル `SDFS.BIN` を RAM へ読み込んで起動する入口として扱う。
+
+初期方式は **root directory の通常ファイル `SDFS.BIN` 起動**を本線にする。FAT32 reserved sector bootstrap は、ROM をさらに小さくしたい段階の将来候補として文書に残すだけにする。
+
+`AUTOEXEC.S` は SDFS/68 が起動後に任意で処理する起動スクリプト相当とし、ROM 側 `BOOT` の直接責務には含めない。
 
 責務は次のように分ける。
 
 | 要素 | 責務 |
 | --- | --- |
-| `BOOT` | SD 上の第2段システムを探して LOAD/RUN する入口 |
-| 第1段bootstrap | reserved sector などから最小 loader を起動する将来候補 |
-| `SDFS.BIN` | DIR/LF などの SD/FAT 操作と、必要に応じた `AUTOEXEC.S` 処理を持つ第2段 |
+| `BOOT` | root の `SDFS.BIN` を探して RAM へ LOAD/RUN するROM側の最小入口 |
+| `SDFS/68` (`SDFS.BIN`) | HEX/S-record ロード、DIR、TYPE、AUTOEXEC.S、将来の周辺機能を持つ第2段 |
 | `AUTOEXEC.S` | RTC、VDG、キーボード、BASIC 起動などを行う任意の起動スクリプト |
+| `mk-sdfs` | Mac / Windows / Linux で同じ結果を作るシステムSDイメージ生成ツール |
+| reserved sector bootstrap | 将来の高速/小型ブート候補。初期実装では採らない |
 
 ROM容量は8KB互換を前提にすると既に余裕が小さいため、I2C、RTC、EEPROM、OLED/LCD、AUTOEXEC 処理をROMへ常駐させて肥大化させない。これらの周辺機能は、まずRAMロード可能なPoCとして煮詰め、最終的には `SDFS.BIN` または将来の M6800 DOS 相当の第2段機能へ寄せる。
 
@@ -25,17 +31,104 @@ ROM容量は8KB互換を前提にすると既に余裕が小さいため、I2C�
 
 | 方式 | 位置づけ | 採用条件 |
 | --- | --- | --- |
-| ROM 直 FAT から `SDFS.BIN` 起動 | 初期検討の現実路線 | ROM 容量に収まり、root directory から通常ファイルを読めること |
-| FAT32 reserved sector bootstrap | ROM 削減案 | 専用 SD 作成手順、signature 検査、復旧手順を用意できること |
+| root 通常ファイル `SDFS.BIN` 起動 | 初期本線 | PC で通常ファイルとして配置でき、既存 FAT32 read-only 実装を活かせること |
+| FAT32 reserved sector bootstrap | 将来の ROM 削減案 | 専用 SD 作成手順、signature 検査、復旧手順を用意できること |
 | 外部 MCU 経由 | 将来の性能改善案 | SD/FAT 処理を外部 firmware に逃がす価値が実装コストを上回ること |
 
-## 採用保留条件
+## ROM側 `BOOT` の境界
 
-- ROM 容量が FAT read-only、VDG、キーボード、RTC 対応で逼迫するまでは、reserved sector bootstrap 実装を急がない。ただし I2C/RTC/OLED などの周辺機能は、ROM常駐ではなく `SDFS.BIN` 側へ逃がす前提でIssueを切る。
-- `AUTOEXEC.S` は ROM 側 `BOOT` や第1段bootstrapの責務に含めない。
-- `CONFIG.SYS`、subdirectory、FAT write、SD イメージ作成ツールは #82 の設計整理では対象外にする。
-- 実装に入る場合は、`BOOT` で `SDFS.BIN` を起動する Issue と、`SDFS.BIN` 側で `AUTOEXEC.S` を処理する Issue を分ける。
+ROM 側には次だけを残す。
+
+- SD 初期化。
+- FAT32 mount。
+- root directory から 8.3 名 `SDFS    BIN` を探す処理。
+- `SDFS.BIN` を固定RAMアドレスへ読み込む処理。
+- SDFS/68 header / signature / size の最小検査。
+- 成功時に SDFS/68 entry へジャンプし、失敗時は必ず既存モニタの対話モードへ戻る処理。
+
+ROM 側には次を入れない。
+
+- `AUTOEXEC.S` 直接処理。
+- SDFS/68 シェル。
+- サブディレクトリ、LFN、wildcard。
+- FAT write / SAVE。
+- 画像や大きなデータの direct access API。
+- RTC / I2C / VDG / キーボードの高機能処理。
+
+`SDFS.BIN` の初期ロード先は SBC-IO 拡張 RAM 前提で **`$C400` 以降**を候補にする。`$C000-$C1FF` は SD sector buffer、`$C200` 以降はモニタ/FATワークの候補があるため、実装Issueでは listing で実際のワーク終端を確認してから最終値を決める。
+
+`SDFS.BIN` には短い header を置く。初期案は次の最小情報にする。
+
+| offset | 内容 |
+| --- | --- |
+| `+0` | signature: ASCII `SDFS68` |
+| `+6` | header version |
+| `+7` | flags |
+| `+8` | entry address high |
+| `+9` | entry address low |
+| `+10` | payload size high |
+| `+11` | payload size low |
+
+ROM 側は signature、header version、entry address、size が許容範囲内かだけを見る。checksum は v1 では必須にせず、必要なら v2 で追加する。
+
+## SDFS/68 の段階
+
+| 段階 | 内容 |
+| --- | --- |
+| v1 | ROM `BOOT`、SDFS/68 最小シェル、`LF` 相当の HEX/S-record ロード、SDイメージ生成 |
+| v2 | SDFS/68 側 `DIR`、`TYPE`、簡易ファイル情報、`AUTOEXEC.S` 相当 |
+| v3 | サブディレクトリ、設定ファイル、I2C/RTC/VDG/キーボード連携 |
+| v4 | 画像や固定バイナリデータの direct read API。ファイル全体LOADではなく sector / offset 単位で読む |
+| v5 | bit-bang SPI の性能限界が問題になった時点で外部MCUや高速I/O案を再評価 |
+
+v1 の優先機能は HEX / S-record ロードとする。既存 ROM の `DIR` / `LF` はすぐ削除せず、SDFS/68 v1 が通ってから ROM 削減 Issue で扱う。
+
+## システムSDイメージ生成ツール
+
+初期ツール名は `tools/mk_sdfs_image.py` とする。
+
+初期スコープは **FAT32 SDイメージファイル生成**までに限定する。直接SDカードへ書き込む機能は、管理者権限、デバイス指定ミス、OS差分のリスクが大きいため対象外にする。
+
+入力:
+
+- `SDFS.BIN`
+- 任意の `.S`
+- 任意の `.HEX`
+- 任意の `.BIN`
+- 将来の画像や固定データファイル
+
+出力:
+
+- FAT32 形式の SDイメージファイル。
+- root directory に `SDFS.BIN` と指定ファイルを 8.3 short filename で配置する。
+- テスト用には既存 `tests/sd_fixtures.py` と同じく、小さい決定的イメージを生成できるようにする。
+
+運用:
+
+- Mac / Windows / Linux で同じ Python コードを使う。
+- 実SDへの書き込みは、Mac / Linux では `dd` や OS 標準手段、Windows では既存イメージライタを使う手順を文書化する。
+- 既存 FAT32 カードへファイルコピーする補助は後続候補にする。
+
+## 後続Issue分割
+
+#82 は設計親 Issue として扱い、実装は次の Issue に分ける。
+
+| 候補 | 内容 | 備考 |
+| --- | --- | --- |
+| #101 ROM `BOOT` | `SDFS.BIN` を root から読み、header 検査後に第2段へジャンプする | 失敗時は必ず既存モニタへ戻る |
+| #102 SDFS/68 v1 | RAM上の第2段として、最小シェルと HEX/S-record ロードを実装する | ROM常駐ではなく `SDFS.BIN` |
+| #103 `mk-sdfs` | Python製のシステムSDイメージ生成ツールを追加する | 直接SD書き込みは対象外 |
+| #104 SDFS/68 data API | 画像/バイナリデータ direct read 用APIを設計する | VDG向けデータ利用を想定 |
+| #105 SDFS/68 dirs | サブディレクトリ対応 | v2 以降 |
+| ROM削減 | SDFS/68 v1 が安定した後、ROM側 `DIR` / `LF` の削減を検討する | 互換性を確認してから |
 
 ## 検証方針
 
-#82 では設計整理を成果物とし、実装テストは後続 Issue に分ける。後続 PoC では、`SDFS.BIN` 未検出、signature 不一致、サイズ不正、FAT chain read error、`AUTOEXEC.S` なしの各ケースで安全に対話モードまたはシリアル `L` fallback へ戻れることを確認する。
+#82 では設計整理を成果物とし、実装テストは後続 Issue に分ける。後続 PoC では次を確認する。
+
+- `SDFS.BIN` ありで signature 確認後に第2段へジャンプする。
+- `SDFS.BIN` なし、signature 不一致、size 不正、FAT chain read error で安全に既存モニタへ戻る。
+- SDFS/68 v1 で root 上の `.S` と `.HEX` をロードできる。
+- 壊れた HEX、終端なしファイル、存在しないファイルでハングしない。
+- `tools/mk_sdfs_image.py` が Mac / Windows / Linux で同一入力から同じ構造の FAT32 イメージを作れる。
+- 既存 `test_smoke.py` と `test_sd_fixture.py` を維持する。

--- a/docs/usage/sdfs68_system_sd.md
+++ b/docs/usage/sdfs68_system_sd.md
@@ -1,0 +1,63 @@
+# SDFS/68 システムSDカード方針
+
+この文書は、SDFS/68 用のシステムSDカードを作るための初期方針をまとめる。
+
+SDFS/68 は、ROM モニタの `BOOT` から起動する第2段システムである。SDカード上の実ファイル名は root directory の `SDFS.BIN` とする。
+
+## 基本方針
+
+- 初期方式は root directory の通常ファイル `SDFS.BIN` 起動とする。
+- FAT32 reserved sector bootstrap は将来候補として残すが、初期ツールでは扱わない。
+- 初期 SDFS/68 は read-only とし、FAT write や SAVE は別Issueで扱う。
+- 8.3 short filename を前提にする。LFN とサブディレクトリは後続段階で扱う。
+
+## システムSDイメージ生成
+
+初期ツール名は `tools/mk_sdfs_image.py` とする。
+
+ツールは Mac / Windows / Linux で同じ Python コードを使い、FAT32 SDイメージファイルを生成する。実SDカードへの直接書き込みは行わない。
+
+入力候補:
+
+- `SDFS.BIN`
+- S-Record ファイル (`.S`)
+- Intel HEX ファイル (`.HEX`)
+- バイナリファイル (`.BIN`)
+- 将来の画像や固定データファイル
+
+出力:
+
+- FAT32 形式の SDイメージファイル。
+- root directory に `SDFS.BIN` と指定ファイルを配置する。
+- テスト用には小さい決定的イメージを生成できるようにする。
+
+## 実SDカードへの書き込み
+
+実SDカードへの書き込みは、初期ツールの責務に含めない。
+
+Mac / Linux では `dd` や OS 標準のディスク操作でイメージを書き込む。Windows では既存のイメージ書き込みツールを使う。
+
+直接デバイス書き込みをツールに含めない理由:
+
+- 管理者権限が必要になる。
+- デバイス指定ミスで別ディスクを破壊する危険がある。
+- Mac / Windows / Linux でデバイス列挙と権限モデルが大きく違う。
+
+## 初期ファイル配置
+
+v1 の root directory は次を想定する。
+
+| ファイル | 用途 |
+| --- | --- |
+| `SDFS.BIN` | SDFS/68 本体 |
+| `HELLO.S` | S-Record LOAD 確認用 |
+| `HELLO.HEX` | Intel HEX LOAD 確認用 |
+| `AUTOEXEC.S` | v2 以降の任意起動スクリプト候補 |
+
+`AUTOEXEC.S` は v1 の必須ファイルではない。ROM 側 `BOOT` は `AUTOEXEC.S` を直接読まない。
+
+## 将来拡張
+
+SDFS/68 v2 以降では、既存 FAT32 カードへ必要ファイルをコピーする補助ツールを追加できる。
+
+SDFS/68 v4 以降では、画像や固定バイナリデータをSD上に置き、ファイル全体をLOADせずに sector / offset 単位で読む direct read API を検討する。


### PR DESCRIPTION
## 対応Issue

Closes #82
Refs #101 #102 #103 #104 #105

## 変更内容

- 第2段システム名を SDFS/68、実ファイル名を `SDFS.BIN` として #82 の計画文書を更新
- root directory の通常ファイル `SDFS.BIN` 起動を初期本線にし、reserved sector bootstrap は将来候補として整理
- ROM側 `BOOT`、SDFS/68、`mk-sdfs`、direct read API、サブディレクトリ対応の責務境界を文書化
- SDFS/68 システムSDカード方針を `docs/usage/` に追加し、docs目次から参照できるようにした

## テスト結果

- `git diff --check`
- `make bin`
- `REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py`
- `REQUIRE_BUILD_ROM=1 python3 tests/test_sd_fixture.py`

## 追加または更新したテスト

- ドキュメント整理のみのため、テスト追加はなし

## 影響範囲

- ドキュメントのみ
- ROMバイナリ、既存コマンド、SD/FAT実装の動作変更なし

## 未対応事項

- ROM `BOOT` 実装は #101 で扱う
- SDFS/68 v1 実装は #102 で扱う
- システムSDイメージ生成ツールは #103 で扱う
- direct read API とサブディレクトリ対応は #104 / #105 で扱う