### PR TITLE
docs: stage1 boot services設計を整理

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@
 - [design/architecture.md](design/architecture.md)
 - [plans/implementation_plan.md](plans/implementation_plan.md)
 - [plans/issue-107_fixed_sector_boot_eval.md](plans/issue-107_fixed_sector_boot_eval.md): 固定セクタ版SDFS/68 loaderのROM削減評価
+- [plans/issue-109_stage1_boot_services.md](plans/issue-109_stage1_boot_services.md): SDFS/68 stage1 boot services設計
 - [testing/sbc6800_bringup.md](testing/sbc6800_bringup.md)
 - [testing/sbc_io_sd_bringup.md](testing/sbc_io_sd_bringup.md): SBC-IO と microSD SPI モジュールで SD/FAT を実機確認する手順
 - [testing/sbc6800_datapack.md](testing/sbc6800_datapack.md): SBC6800 データパックの扱いと互換確認

--- a/docs/plans/issue-107_fixed_sector_boot_eval.md
+++ b/docs/plans/issue-107_fixed_sector_boot_eval.md
@@ -6,6 +6,7 @@
 - Issue #82: https://github.com/kuninet/mc6800-rom-monitor/issues/82
 - Issue #101: https://github.com/kuninet/mc6800-rom-monitor/issues/101
 - Issue #103: https://github.com/kuninet/mc6800-rom-monitor/issues/103
+- Issue #109: https://github.com/kuninet/mc6800-rom-monitor/issues/109
 
 ## 結論
 
@@ -13,7 +14,7 @@
 
 現行の `FEATURE_SD=1` は、SD sector read だけでなく FAT32 mount、root directory scan、cluster chain、`DIR`、`LF` までROMに含める。listing で見ると、KBD+VDGのみ構成から KBD+VDG+現行SD/FAT構成への増分は約 **2.9KB** ある。8KB ROMでこの増分は大きく、VDGコンソールやKKBD-USB入力の常駐余地を圧迫する。
 
-今後の方針は、ROM側を **raw SD sector boot + SDFS/68 header確認 + fallback** に寄せ、FAT操作はSDFS/68側へ逃がすのがよい。
+今後の方針は、ROM側を **raw SD sector boot + stage1 header確認 + fallback** に寄せ、FAT操作は固定LBAから読んだstage1とSDFS/68側へ逃がすのがよい。
 
 ## 試算
 
@@ -36,7 +37,7 @@
 
 raw固定セクタBOOTは、SD初期化とsector readの下回りを残すため、SD部分をゼロにはできない。ただし FAT32処理、root検索、cluster chain、`DIR`、`LF` をROMから外せるため、現行SD/FAT構成から **おおむね2KB前後** のROM削減余地がある。
 
-実際の固定セクタBOOTでは、連続sector load、SDFS/68 header確認、entry range確認、fallback表示が追加されるため、raw SD readだけとの差分は増える。それでもFAT版BOOTより小さくなる見込みが高い。
+実際の固定セクタBOOTでは、連続sector load、stage1 header確認、entry range確認、fallback表示が追加されるため、raw SD readだけとの差分は増える。それでもFAT版BOOTより小さくなる見込みが高い。
 
 ## 方式比較
 
@@ -48,24 +49,24 @@ raw固定セクタBOOTは、SD初期化とsector readの下回りを残すため
 
 ## 推奨仕様
 
-固定セクタ版の初期候補は **固定物理LBA版** とする。
+固定セクタ版の初期候補は **固定物理LBA版 stage1 loader** とする。
 
-- `mk-sdfs` 生成イメージでは、MBR partitionの外側にSDFS/68 boot areaを置く。
+- `mk-sdfs` 生成イメージでは、MBR partitionの外側にstage1 boot areaを置く。
 - 初期候補は physical LBA `16` 以降とする。
-- ROMはFATを見ず、固定LBAからheader sectorを読み、signatureとsizeを確認してからpayloadを連続sectorとしてRAMへ読む。
-- root directory には確認用として同じ `SDFS.BIN` を置く。
-- `mk-sdfs` は root `SDFS.BIN` と固定boot areaの内容が一致するように生成する。
+- ROMはFATを見ず、固定LBAからstage1 header sectorを読み、signatureとsizeを確認してからstage1を連続sectorとしてRAMへ読む。
+- root directory にはSDFS/68本体として `SDFS.BIN` を置く。
+- fixed boot area のstage1とroot `SDFS.BIN` は同一内容にしない。
 - 手動コピーだけでは固定boot areaは更新されないため、起動用SDは `mk-sdfs` で作る運用にする。
 
-SDFS/68 headerは #82 の案を維持し、固定セクタBOOTでは少なくとも次を確認する。
+stage1 headerは #109 の案に従い、固定セクタBOOTでは少なくとも次を確認する。
 
-- signature: `SDFS68`
-- header version
-- entry address
-- payload size
-- payloadがSDFS/68ロード領域内に収まること
+- signature: `S1API68`
+- API version
+- API count
+- stage1 entry
+- stage1がprofile別ロード領域内に収まること
 
-checksumはv1では必須にしない。必要ならSDFS/68 v2以降で追加する。
+SDFS/68 header確認はstage1側で行う。checksumはv1では必須にしない。必要ならSDFS/68 v2以降で追加する。
 
 ## ROM責務
 
@@ -76,8 +77,8 @@ ROMに残す:
 - VDG最小出力または診断。
 - monitor core。
 - SD初期化とraw sector read。
-- 固定LBAからSDFS/68をRAMへロードする最小 `BOOT`。
-- SDFS/68 signature / size / entry確認。
+- 固定LBAからstage1をRAMへロードする最小 `BOOT`。
+- stage1 signature / size / entry確認。
 
 ROMから外す:
 
@@ -102,7 +103,7 @@ ROMから外す:
 - entry address不正。
 - payload途中read失敗。
 
-FATが壊れていても、固定boot areaが読めてheaderが正しければSDFS/68起動を試みる。SDFS/68起動後にFAT mountへ失敗した場合は、SDFS/68側の対話モードまたはROM fallback方針で扱う。
+FATが壊れていても、固定boot areaが読めてstage1 headerが正しければstage1起動を試みる。stage1起動後にFAT mountへ失敗した場合は、stage1の短いエラー表示後に既存monitorへ戻るか、SDFS/68実装Issueで定めるfallback方針で扱う。
 
 ## 後続方針
 
@@ -110,9 +111,10 @@ FATが壊れていても、固定boot areaが読めてheaderが正しければSD
 
 推奨する後続分割:
 
-- 固定セクタBOOT実装: ROM側に `BOOT` を追加し、physical LBA `16` からSDFS/68をロードする。
-- `mk-sdfs` 固定boot area対応: root `SDFS.BIN` と固定boot areaを同期してイメージ生成する。
-- SDFS/68 v1: 起動後にFATをmountし、HEX/S-recordロードを提供する。
+- 固定セクタBOOT実装: ROM側に `BOOT` を追加し、physical LBA `16` からstage1をロードする。
+- stage1 boot services実装: stage1がFAT rootの `SDFS.BIN` をロードし、header + jump tableを公開する。
+- `mk-sdfs` 固定boot area対応: fixed boot areaへstage1を置き、rootへ `SDFS.BIN` を配置する。
+- SDFS/68 v1: stage1 boot servicesを使い、HEX/S-recordロードを提供する。
 - ROM削減: SDFS/68 v1が成立した後、ROM側 `DIR` / `LF` を削る。
 
 ## 検証方針
@@ -124,4 +126,4 @@ FATが壊れていても、固定boot areaが読めてheaderが正しければSD
 - `REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py`
 - `REQUIRE_BUILD_ROM=1 python3 tests/test_sd_fixture.py`
 
-固定セクタBOOT実装Issueでは、SD fixtureに固定boot areaを持つイメージを追加し、正常起動、signature不一致、size不正、途中read失敗を確認する。
+固定セクタBOOT実装Issueでは、SD fixtureにstage1 boot areaを持つイメージを追加し、正常起動、signature不一致、size不正、途中read失敗を確認する。

--- a/docs/plans/issue-109_stage1_boot_services.md
+++ b/docs/plans/issue-109_stage1_boot_services.md
@@ -1,0 +1,91 @@
+# Issue #109 SDFS/68 stage1 boot services設計
+
+## 関連リンク
+
+- Issue #109: https://github.com/kuninet/mc6800-rom-monitor/issues/109
+- Issue #82: https://github.com/kuninet/mc6800-rom-monitor/issues/82
+- Issue #101: https://github.com/kuninet/mc6800-rom-monitor/issues/101
+- Issue #102: https://github.com/kuninet/mc6800-rom-monitor/issues/102
+- Issue #103: https://github.com/kuninet/mc6800-rom-monitor/issues/103
+- Issue #107: https://github.com/kuninet/mc6800-rom-monitor/issues/107
+
+## 方針
+
+固定LBA boot area には `SDFS.BIN` 本体ではなく **stage1 loader** を置く。ROM はFATを読まず、固定LBAからstage1をRAMへ読み込んで起動する。stage1 はFAT32 read-only の最小実装を持ち、FAT root の `SDFS.BIN` を読み込んで SDFS/68 本体へ制御を渡す。
+
+stage1 は SDFS/68 起動後もRAMに常駐し、固定baseの header + jump table を `boot services` として公開する。SDFS/68 はこの boot services を使って、stage1 の SD/FAT 低層処理を再利用できる。
+
+この方針により、ROMからFAT I/Oを外しつつ、stage1を使い捨てにしない。
+
+## 起動の流れ
+
+1. ROM `BOOT` が SD を初期化する。
+2. ROM `BOOT` が固定LBAからstage1を `S1_BASE` へ読み込む。
+3. ROM `BOOT` が `S1API68` header、API version、entryを確認する。
+4. ROM `BOOT` がstage1 entryへジャンプする。
+5. stage1 がFAT32を最小mountする。
+6. stage1 がroot directoryから8.3名 `SDFS    BIN` を探す。
+7. stage1 が `SDFS.BIN` を `SDFS_LOAD_BASE` へロードする。
+8. stage1 がSDFS/68 headerを確認し、SDFS/68 entryへジャンプする。
+9. SDFS/68 は必要に応じてstage1 boot servicesを呼び出す。
+
+## Stage1 API
+
+stage1 header は `S1_BASE` から始まる。
+
+| offset | 内容 |
+| --- | --- |
+| `+0` | signature: ASCII `S1API68` |
+| `+7` | API version。v1は `1` |
+| `+8` | API count |
+| `+9` | flags |
+| `+10` - `+15` | reserved |
+| `+16` | jump table開始 |
+
+MC6800には便利な間接 `JSR` がないため、APIはポインタ列ではなく固定offsetの `jmp` 命令列にする。
+
+| offset | 命令 | 用途 |
+| --- | --- | --- |
+| `+16` | `jmp S1_INIT` | stage1再初期化または状態確認 |
+| `+19` | `jmp S1_READ_SECTOR` | LBA指定の1 sector read |
+| `+22` | `jmp S1_MOUNT` | FAT32最小mount |
+| `+25` | `jmp S1_FIND_83` | root 8.3名検索 |
+| `+28` | `jmp S1_LOAD_FILE_83` | 8.3名ファイルを指定RAMへロード |
+| `+31` | `jmp S1_GET_ERROR` | stage1エラー取得 |
+
+v1のAPIは boot services に限定する。汎用DOS API、複数open、seek、write、subdirectory、LFNは扱わない。
+
+## メモリ配置
+
+stage1配置はprofile別に分ける。
+
+| profile | sector buffer | monitor / stage1 work予約 | stage1候補 | SDFS/68候補 | VDG VRAM |
+| --- | --- | --- | --- | --- | --- |
+| `sbcio_vdg` | `$C000-$C1FF` | `$C200-$C3FF` | `$C400-$CBFF` | `$CC00` 以降 | `$A000-$BFFF` |
+| `k6802_vdg` | `$A000-$A1FF` | `$A200-$A3FF` | `$A400-$ABFF` | `$AC00` 以降 | `$C000-$DFFF` |
+
+実装Issueでは `S1_BASE`、`S1_LIMIT`、`SDFS_LOAD_BASE` をprofile別定数として追加し、stack、VRAM、monitor workと衝突しないことをlistingとテストで確認する。
+
+## Issueへの影響
+
+- #82 は、SDFS/68ブート構想の親Issueとして、ROM直FAT方式ではなく stage1方式を現方針として扱う。
+- #101 は、ROMからFAT rootの `SDFS.BIN` を読むIssueではなく、固定LBAからstage1を読むROM `BOOT` Issueへ再定義する。
+- #103 は、FAT32 rootファイル配置だけでなく、固定LBA boot areaへ `STAGE1.BIN` 相当を書き込むツールIssueへ拡張する。
+- #107 は、固定LBAにSDFS/68本体を置く評価ではなく、stage1 loaderを置く評価として読み替える。
+
+## 後続実装分割
+
+- ROM stage1 loader: ROMに `BOOT` を追加し、固定LBAからstage1を `S1_BASE` へロードする。
+- stage1 FAT loader: stage1に最小FAT32 readerと `SDFS.BIN` ロード処理を実装する。
+- `mk-sdfs`: 固定LBA boot areaへstage1を書き込み、FAT rootへ `SDFS.BIN` とデータファイルを配置する。
+- SDFS/68 v1: stage1 boot servicesを利用し、HEX/S-recordロードを提供する。
+
+## 検証方針
+
+このIssueでは設計整理を成果物とする。後続実装では次を確認する。
+
+- ROM `BOOT` が固定LBAからstage1を読める。
+- stage1 signature不一致、read失敗、size不正、entry不正でmonitorへ戻る。
+- stage1がroot `SDFS.BIN` をロードできる。
+- `SDFS.BIN` 未検出、壊れたFAT、壊れたSDFS headerでハングしない。
+- SDFS/68起動後にstage1 header / jump tableを確認できる。

--- a/docs/plans/issue-82_sd_bootstrap_dos.md
+++ b/docs/plans/issue-82_sd_bootstrap_dos.md
@@ -7,12 +7,13 @@
 - Issue #81: https://github.com/kuninet/mc6800-rom-monitor/issues/81
 - Issue #85: https://github.com/kuninet/mc6800-rom-monitor/issues/85
 - Issue #107: https://github.com/kuninet/mc6800-rom-monitor/issues/107
+- Issue #109: https://github.com/kuninet/mc6800-rom-monitor/issues/109
 
 ## 方針
 
-第2段システムの名称は **SDFS/68** とし、SD カード上の実ファイル名は既存方針どおり `SDFS.BIN` とする。`BOOT` は root の `AUTOEXEC.S` を直接 LOAD するコマンドではなく、root directory の通常ファイル `SDFS.BIN` を RAM へ読み込んで起動する入口として扱う。
+第2段システムの名称は **SDFS/68** とし、SD カード上の実ファイル名は `SDFS.BIN` とする。`BOOT` は root の `AUTOEXEC.S` を直接 LOAD するコマンドではなく、SD上の第2段システムを起動する入口として扱う。
 
-初期方式は **root directory の通常ファイル `SDFS.BIN` 起動**を本線として整理した。ただし、8KB ROM内でKKBD-USB入力とVDG出力を重視する場合はFAT処理をROMに残す負担が大きいため、#107 で固定セクタ版SDFS/68 loaderのROM削減効果を評価する。
+当初は **root directory の通常ファイル `SDFS.BIN` をROMが直接読む方式**を本線として整理した。しかし、8KB ROM内でKKBD-USB入力とVDG出力を重視する場合はFAT処理をROMに残す負担が大きい。#107 の評価を受け、現方針は **ROMが固定LBAからstage1 loaderを読み、stage1がFAT rootの `SDFS.BIN` を読む方式**へ寄せる。
 
 `AUTOEXEC.S` は SDFS/68 が起動後に任意で処理する起動スクリプト相当とし、ROM 側 `BOOT` の直接責務には含めない。
 
@@ -20,11 +21,12 @@
 
 | 要素 | 責務 |
 | --- | --- |
-| `BOOT` | root の `SDFS.BIN` を探して RAM へ LOAD/RUN するROM側の最小入口 |
+| ROM `BOOT` | 固定LBAからstage1 loaderをRAMへ LOAD/RUNするROM側の最小入口 |
+| stage1 loader | FAT32 read-only最小実装でrootの `SDFS.BIN` を読み、boot servicesを公開するRAM常駐コード |
 | `SDFS/68` (`SDFS.BIN`) | HEX/S-record ロード、DIR、TYPE、AUTOEXEC.S、将来の周辺機能を持つ第2段 |
 | `AUTOEXEC.S` | RTC、VDG、キーボード、BASIC 起動などを行う任意の起動スクリプト |
 | `mk-sdfs` | Mac / Windows / Linux で同じ結果を作るシステムSDイメージ生成ツール |
-| reserved sector bootstrap | 将来の高速/小型ブート候補。初期実装では採らない |
+| fixed LBA boot area | stage1 loaderを置く固定領域。ROMはここだけを読む |
 
 ROM容量は8KB互換を前提にすると既に余裕が小さいため、I2C、RTC、EEPROM、OLED/LCD、AUTOEXEC 処理をROMへ常駐させて肥大化させない。これらの周辺機能は、まずRAMロード可能なPoCとして煮詰め、最終的には `SDFS.BIN` または将来の M6800 DOS 相当の第2段機能へ寄せる。
 
@@ -32,9 +34,9 @@ ROM容量は8KB互換を前提にすると既に余裕が小さいため、I2C�
 
 | 方式 | 位置づけ | 採用条件 |
 | --- | --- | --- |
-| root 通常ファイル `SDFS.BIN` 起動 | 初期本線 | PC で通常ファイルとして配置でき、既存 FAT32 read-only 実装を活かせること |
+| root 通常ファイル `SDFS.BIN` をROMが読む方式 | 初期検討の履歴 | PCで通常ファイルとして配置できるが、ROMにFAT I/Oが残る |
 | FAT32 reserved sector bootstrap | 将来の ROM 削減案 | 専用 SD 作成手順、signature 検査、復旧手順を用意できること |
-| 固定物理LBA `SDFS.BIN` boot area | ROM 削減案 | `mk-sdfs` 生成イメージを前提に、ROMからFATを外す価値があること |
+| 固定物理LBA stage1 boot area | 現方針 | `mk-sdfs` 生成イメージを前提に、ROMからFATを外すこと |
 | 外部 MCU 経由 | 将来の性能改善案 | SD/FAT 処理を外部 firmware に逃がす価値が実装コストを上回ること |
 
 ## ROM側 `BOOT` の境界
@@ -42,42 +44,46 @@ ROM容量は8KB互換を前提にすると既に余裕が小さいため、I2C�
 ROM 側には次だけを残す。
 
 - SD 初期化。
-- FAT32 mount。
-- root directory から 8.3 名 `SDFS    BIN` を探す処理。
-- `SDFS.BIN` を固定RAMアドレスへ読み込む処理。
-- SDFS/68 header / signature / size の最小検査。
-- 成功時に SDFS/68 entry へジャンプし、失敗時は必ず既存モニタの対話モードへ戻る処理。
+- 固定LBAからstage1 loaderを固定RAMアドレスへ読み込む処理。
+- stage1 header / signature / size / entry の最小検査。
+- 成功時にstage1 entryへジャンプし、失敗時は必ず既存モニタの対話モードへ戻る処理。
 
 ROM 側には次を入れない。
 
+- FAT32 mount。
+- root directory から 8.3 名 `SDFS    BIN` を探す処理。
+- `SDFS.BIN` を直接読み込む処理。
 - `AUTOEXEC.S` 直接処理。
 - SDFS/68 シェル。
 - サブディレクトリ、LFN、wildcard。
 - FAT write / SAVE。
 - 画像や大きなデータの direct access API。
-- RTC / I2C / VDG / キーボードの高機能処理。
+- RTC / I2C / OLED / VDG高機能処理。
 
-`SDFS.BIN` の初期ロード先は SBC-IO 拡張 RAM 前提で **`$C400` 以降**を候補にする。`$C000-$C1FF` は SD sector buffer、`$C200` 以降はモニタ/FATワークの候補があるため、実装Issueでは listing で実際のワーク終端を確認してから最終値を決める。
+stage1 loader の初期ロード先は、SBC-IO + VDG では **`$C400` 以降**、K6802-SBC + VDG では **`$A400` 以降**を候補にする。`$C000/$A000` 先頭はsector buffer、`$C200/$A200` 以降はモニタ/stage1ワークの候補があるため、実装Issueでは listing で実際のワーク終端を確認してから最終値を決める。
 
-`SDFS.BIN` には短い header を置く。初期案は次の最小情報にする。
+stage1 loader には短い header と jump table を置く。初期案は次の最小情報にする。
 
 | offset | 内容 |
 | --- | --- |
-| `+0` | signature: ASCII `SDFS68` |
-| `+6` | header version |
-| `+7` | flags |
-| `+8` | entry address high |
-| `+9` | entry address low |
-| `+10` | payload size high |
-| `+11` | payload size low |
+| `+0` | signature: ASCII `S1API68` |
+| `+7` | API version |
+| `+8` | API count |
+| `+9` | flags |
+| `+16` | `jmp S1_INIT` |
+| `+19` | `jmp S1_READ_SECTOR` |
+| `+22` | `jmp S1_MOUNT` |
+| `+25` | `jmp S1_FIND_83` |
+| `+28` | `jmp S1_LOAD_FILE_83` |
+| `+31` | `jmp S1_GET_ERROR` |
 
-ROM 側は signature、header version、entry address、size が許容範囲内かだけを見る。checksum は v1 では必須にせず、必要なら v2 で追加する。
+SDFS/68 本体の header は `SDFS.BIN` 側に残す。stage1 は `SDFS.BIN` を読み込んだ後、SDFS/68 signature、entry address、size が許容範囲内かを確認してから制御を渡す。checksum は v1 では必須にせず、必要なら v2 で追加する。
 
 ## SDFS/68 の段階
 
 | 段階 | 内容 |
 | --- | --- |
-| v1 | ROM `BOOT`、SDFS/68 最小シェル、`LF` 相当の HEX/S-record ロード、SDイメージ生成 |
+| v1 | ROM `BOOT`、stage1 loader、SDFS/68 最小シェル、`LF` 相当の HEX/S-record ロード、SDイメージ生成 |
 | v2 | SDFS/68 側 `DIR`、`TYPE`、簡易ファイル情報、`AUTOEXEC.S` 相当 |
 | v3 | サブディレクトリ、設定ファイル、I2C/RTC/VDG/キーボード連携 |
 | v4 | 画像や固定バイナリデータの direct read API。ファイル全体LOADではなく sector / offset 単位で読む |
@@ -94,6 +100,7 @@ v1 の優先機能は HEX / S-record ロードとする。既存 ROM の `DIR` /
 入力:
 
 - `SDFS.BIN`
+- stage1 loader binary
 - 任意の `.S`
 - 任意の `.HEX`
 - 任意の `.BIN`
@@ -102,6 +109,7 @@ v1 の優先機能は HEX / S-record ロードとする。既存 ROM の `DIR` /
 出力:
 
 - FAT32 形式の SDイメージファイル。
+- 固定LBA boot area にstage1 loaderを配置する。
 - root directory に `SDFS.BIN` と指定ファイルを 8.3 short filename で配置する。
 - テスト用には既存 `tests/sd_fixtures.py` と同じく、小さい決定的イメージを生成できるようにする。
 
@@ -117,20 +125,23 @@ v1 の優先機能は HEX / S-record ロードとする。既存 ROM の `DIR` /
 
 | 候補 | 内容 | 備考 |
 | --- | --- | --- |
-| #101 ROM `BOOT` | `SDFS.BIN` を root から読み、header 検査後に第2段へジャンプする | 失敗時は必ず既存モニタへ戻る |
+| #101 ROM `BOOT` | 固定LBAからstage1を読み、header検査後にstage1へジャンプする | 失敗時は必ず既存モニタへ戻る |
 | #102 SDFS/68 v1 | RAM上の第2段として、最小シェルと HEX/S-record ロードを実装する | ROM常駐ではなく `SDFS.BIN` |
-| #103 `mk-sdfs` | Python製のシステムSDイメージ生成ツールを追加する | 直接SD書き込みは対象外 |
+| #103 `mk-sdfs` | Python製のシステムSDイメージ生成ツールを追加し、固定LBA stage1とroot `SDFS.BIN` を配置する | 直接SD書き込みは対象外 |
 | #104 SDFS/68 data API | 画像/バイナリデータ direct read 用APIを設計する | VDG向けデータ利用を想定 |
 | #105 SDFS/68 dirs | サブディレクトリ対応 | v2 以降 |
 | #107 固定セクタBOOT評価 | ROMからFATを外す場合の削減効果と運用負荷を評価する | #101 実装前の判断材料 |
+| #109 stage1 boot services | stage1常駐API、jump table、profile別配置を設計する | #101/#103/#107の前提を揃える |
 | ROM削減 | SDFS/68 v1 が安定した後、ROM側 `DIR` / `LF` の削減を検討する | 互換性を確認してから |
 
 ## 検証方針
 
 #82 では設計整理を成果物とし、実装テストは後続 Issue に分ける。後続 PoC では次を確認する。
 
-- `SDFS.BIN` ありで signature 確認後に第2段へジャンプする。
-- `SDFS.BIN` なし、signature 不一致、size 不正、FAT chain read error で安全に既存モニタへ戻る。
+- 固定LBAにstage1ありで signature 確認後にstage1へジャンプする。
+- stage1がroot上の `SDFS.BIN` を読み、SDFS/68 signature確認後に第2段へジャンプする。
+- stage1なし、stage1 signature不一致、stage1 read errorで安全に既存モニタへ戻る。
+- `SDFS.BIN` なし、SDFS/68 signature不一致、size不正、FAT chain read errorでstage1またはSDFS/68がハングしない。
 - SDFS/68 v1 で root 上の `.S` と `.HEX` をロードできる。
 - 壊れた HEX、終端なしファイル、存在しないファイルでハングしない。
 - `tools/mk_sdfs_image.py` が Mac / Windows / Linux で同一入力から同じ構造の FAT32 イメージを作れる。

--- a/docs/usage/sdfs68_system_sd.md
+++ b/docs/usage/sdfs68_system_sd.md
@@ -2,12 +2,13 @@
 
 この文書は、SDFS/68 用のシステムSDカードを作るための初期方針をまとめる。
 
-SDFS/68 は、ROM モニタの `BOOT` から起動する第2段システムである。SDカード上の実ファイル名は root directory の `SDFS.BIN` とする。
+SDFS/68 は、ROM モニタの `BOOT` から起動する第2段システムである。ROM は固定LBAからstage1 loaderを読み、stage1がFAT root の `SDFS.BIN` を読み込む。
 
 ## 基本方針
 
-- 初期方式は root directory の通常ファイル `SDFS.BIN` 起動とする。
-- FAT32 reserved sector bootstrap は将来候補として残すが、初期ツールでは扱わない。
+- 初期方式は fixed boot area のstage1 loader起動とする。
+- SDFS/68本体は root directory の通常ファイル `SDFS.BIN` とする。
+- ROMはFATを読まず、stage1がFAT32 read-only最小実装で `SDFS.BIN` を読む。
 - 初期 SDFS/68 は read-only とし、FAT write や SAVE は別Issueで扱う。
 - 8.3 short filename を前提にする。LFN とサブディレクトリは後続段階で扱う。
 
@@ -19,6 +20,7 @@ SDFS/68 は、ROM モニタの `BOOT` から起動する第2段システムで�
 
 入力候補:
 
+- stage1 loader binary
 - `SDFS.BIN`
 - S-Record ファイル (`.S`)
 - Intel HEX ファイル (`.HEX`)
@@ -28,6 +30,7 @@ SDFS/68 は、ROM モニタの `BOOT` から起動する第2段システムで�
 出力:
 
 - FAT32 形式の SDイメージファイル。
+- 固定LBA boot area にstage1 loaderを配置する。
 - root directory に `SDFS.BIN` と指定ファイルを配置する。
 - テスト用には小さい決定的イメージを生成できるようにする。
 
@@ -49,7 +52,8 @@ v1 の root directory は次を想定する。
 
 | ファイル | 用途 |
 | --- | --- |
-| `SDFS.BIN` | SDFS/68 本体 |
+| fixed boot area | stage1 loader。ROMが固定LBAから読む |
+| `SDFS.BIN` | SDFS/68 本体。stage1がFAT rootから読む |
 | `HELLO.S` | S-Record LOAD 確認用 |
 | `HELLO.HEX` | Intel HEX LOAD 確認用 |
 | `AUTOEXEC.S` | v2 以降の任意起動スクリプト候補 |


### PR DESCRIPTION
## 概要
- 固定LBA boot areaをSDFS/68本体ではなくstage1 loaderとして扱う方針を設計文書に追加
- stage1のRAM常駐header/jump table、profile別メモリ配置、SDFS.BINロード責務を整理
- #82親計画、#107固定セクタ評価、システムSD作成手順をstage1方針へ更新
- GitHub Issue #82/#101/#103/#107 の本文もstage1方針へ更新済み

## 確認内容
- `git diff --check`
- `make bin`
- `REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py`
- `REQUIRE_BUILD_ROM=1 python3 tests/test_sd_fixture.py`

## 注意
- このPRは #108 (`codex/issue-107-fixed-sector-boot-eval`) の上に積んでいます。#106/#108 がmainへ入った後にbaseをmainへ戻す想定です。
- 実装コードは入れず、Issue整理と設計文書のみです。

Closes #109
Refs #82 #101 #102 #103 #107