### PR TITLE
feat: SDFS/68 システムSDイメージ生成ツールを追加

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@
 - [design/memory_map.md](design/memory_map.md)
 - [design/architecture.md](design/architecture.md)
 - [plans/implementation_plan.md](plans/implementation_plan.md)
+- [plans/issue-103_mk_sdfs_image.md](plans/issue-103_mk_sdfs_image.md): SDFS/68 システムSDイメージ生成ツールの実装計画
 - [plans/issue-107_fixed_sector_boot_eval.md](plans/issue-107_fixed_sector_boot_eval.md): 固定セクタ版SDFS/68 loaderのROM削減評価
 - [plans/issue-109_stage1_boot_services.md](plans/issue-109_stage1_boot_services.md): SDFS/68 stage1 boot services設計
 - [testing/sbc6800_bringup.md](testing/sbc6800_bringup.md)

--- a/docs/plans/issue-103_mk_sdfs_image.md
+++ b/docs/plans/issue-103_mk_sdfs_image.md
@@ -1,0 +1,51 @@
+# Issue #103 mk-sdfs システムSDイメージ生成ツール
+
+## 関連リンク
+
+- Issue #103: https://github.com/kuninet/mc6800-rom-monitor/issues/103
+- Issue #111: https://github.com/kuninet/mc6800-rom-monitor/issues/111
+- Issue #82: https://github.com/kuninet/mc6800-rom-monitor/issues/82
+- Issue #109: https://github.com/kuninet/mc6800-rom-monitor/issues/109
+
+## 方針
+
+`mk-sdfs` は SDFS/68 用のシステムSDイメージをPC上で生成するツールである。実SDデバイスへ直接書き込まず、Mac / Windows / Linux で同じ Python コードを使って FAT32 イメージファイルを作る。
+
+固定 boot area は FAT32 reserved sector ではなく、partition開始前の physical LBA `16` 以降に置く。FAT32 partition は既存SD fixtureと同じ physical LBA `32` から開始する。stage1 loader と root の `SDFS.BIN` は別内容であり、同一コピーとして扱わない。
+
+## 実装内容
+
+- `tools/mk_sdfs_image.py` を追加する。
+- CLI は `--stage1 STAGE1.BIN --sdfs SDFS.BIN --output IMAGE.img [files...]` を最小形にする。
+- stage1 loader は physical LBA `16` 以降へ sector padding 付きで連続配置する。
+- FAT root には `SDFS.BIN` と追加ファイルを 8.3 short filename で配置する。
+- 既定出力はホストOSがFAT32として扱えるクラスタ数にする。小型fixtureはテストで明示指定する。
+- 既存 `tests/sd_fixtures.py` の低層FAT32生成処理を `tools/fat32_image.py` に切り出し、fixtureと `mk-sdfs` の両方で使う。
+
+## エラー条件
+
+- stage1 loader が空。
+- `SDFS.BIN` が空。
+- stage1 boot area が MBR または FAT32 partition と衝突する。
+- 追加ファイル名が 8.3 short filename として扱えない。
+- root内で8.3名が重複する。
+- 入力ファイルが存在しない、または読めない。
+
+## 対象外
+
+- 実SDデバイスへの直接書き込み。
+- 既存FATカードへの追記。
+- LFN、subdirectory、FAT write。
+- stage1 loader本体の実装。これは #111 で扱う。
+- ROM `BOOT` の実装。これは #101 で扱う。
+- SDFS/68 本体の実装。これは #102 で扱う。
+
+## 検証方針
+
+- 同一入力から同一bytesのイメージを生成できることを確認する。
+- MBR、FAT32 BPB、FSInfo、FAT、root directoryを検査する。
+- 既定出力のdata cluster数がFAT32判定の下限を満たすことを確認する。
+- physical LBA `16` にstage1 loaderが配置されることを確認する。
+- rootの `SDFS.BIN` と追加ファイルのcluster chain、file size、内容を検査する。
+- 異常入力でエラー終了することを確認する。
+- 既存 `test_sd_fixture.py` を維持し、共通writer化で既存fixtureが壊れていないことを確認する。

--- a/docs/usage/sdfs68_system_sd.md
+++ b/docs/usage/sdfs68_system_sd.md
@@ -18,6 +18,18 @@ SDFS/68 は、ROM モニタの `BOOT` から起動する第2段システムで�
 
 ツールは Mac / Windows / Linux で同じ Python コードを使い、FAT32 SDイメージファイルを生成する。実SDカードへの直接書き込みは行わない。
 
+基本形:
+
+```console
+python3 tools/mk_sdfs_image.py --stage1 STAGE1.BIN --sdfs SDFS.BIN --output sdfs.img HELLO.S HELLO.HEX
+```
+
+Windows では `python` コマンドを使う環境もある。
+
+```powershell
+python tools\mk_sdfs_image.py --stage1 STAGE1.BIN --sdfs SDFS.BIN --output sdfs.img HELLO.S HELLO.HEX
+```
+
 入力候補:
 
 - stage1 loader binary
@@ -30,9 +42,13 @@ SDFS/68 は、ROM モニタの `BOOT` から起動する第2段システムで�
 出力:
 
 - FAT32 形式の SDイメージファイル。
-- 固定LBA boot area にstage1 loaderを配置する。
+- partition開始前の physical LBA `16` 以降にstage1 loaderを配置する。
+- FAT32 partition は既定で physical LBA `32` から開始する。
+- 既定出力はホストOSがFAT32として扱えるクラスタ数を持つ。
 - root directory に `SDFS.BIN` と指定ファイルを配置する。
 - テスト用には小さい決定的イメージを生成できるようにする。
+
+stage1 boot area は FAT32 reserved sector ではない。ROMはFATを見ずに physical LBA `16` からstage1を読み、stage1がFAT rootの `SDFS.BIN` を読む。
 
 ## 実SDカードへの書き込み
 

--- a/tests/sd_fixtures.py
+++ b/tests/sd_fixtures.py
@@ -2,10 +2,31 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import sys
+from pathlib import Path
 
 
-SECTOR_SIZE = 512
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "tools"))
+
+from fat32_image import (  # noqa: E402
+    EOC,
+    SECTOR_SIZE,
+    Fat32Layout,
+    layout_for_image as _layout_for_image,
+    root_entry,
+    sector,
+    write_cluster as _write_cluster_common,
+    write_file_data as _write_file_data_common,
+    write_fsinfo as _write_fsinfo_common,
+    write_mbr as _write_mbr_common,
+    write_sector as _write_sector_common,
+    write_vbr as _write_vbr_common,
+    cluster_count_for_size as _cluster_count_for_size,
+    sector_count_for_size as _sector_count_for_size,
+)
+
+
 PARTITION_START_LBA = 32
 TOTAL_VOLUME_SECTORS = 64
 RESERVED_SECTORS = 4
@@ -23,7 +44,6 @@ BIG_S_CLUSTER_1 = 9
 BIG_S_CLUSTER_2 = 10
 BIG_S_CLUSTER_3 = 11
 BIG_S_CLUSTER_4 = 12
-EOC = 0x0FFFFFFF
 
 TEST_S_CONTENT = b"S1060200010203F1\r\nS9030000FC\r\n"
 TEST_HEX_CONTENT = b":03030000AABBCCC9\r\n:00000001FF\r\n"
@@ -53,18 +73,6 @@ BIG_S_CONTENT = _make_big_s_content()
 BIG_S_CLUSTERS = (BIG_S_CLUSTER_1, BIG_S_CLUSTER_2, BIG_S_CLUSTER_3, BIG_S_CLUSTER_4)
 
 
-@dataclass(frozen=True)
-class Fat32Layout:
-    volume_start_lba: int
-    fat_lba: int
-    root_dir_lba: int
-    data_start_lba: int
-    sectors_per_cluster: int = SECTORS_PER_CLUSTER
-
-    def cluster_lba(self, cluster: int) -> int:
-        return self.data_start_lba + (cluster - 2) * self.sectors_per_cluster
-
-
 def build_fat32_image(with_mbr: bool, root_chain: bool = False, sectors_per_cluster: int = SECTORS_PER_CLUSTER) -> bytes:
     volume_start = PARTITION_START_LBA if with_mbr else 0
     total_sectors = volume_start + TOTAL_VOLUME_SECTORS
@@ -83,79 +91,37 @@ def build_fat32_image(with_mbr: bool, root_chain: bool = False, sectors_per_clus
 
 
 def layout_for_image(with_mbr: bool, sectors_per_cluster: int = SECTORS_PER_CLUSTER) -> Fat32Layout:
-    volume_start = PARTITION_START_LBA if with_mbr else 0
-    fat_lba = volume_start + RESERVED_SECTORS
-    data_start = volume_start + RESERVED_SECTORS + FAT_COUNT * FAT_SIZE_SECTORS
-    return Fat32Layout(
-        volume_start_lba=volume_start,
-        fat_lba=fat_lba,
-        root_dir_lba=data_start,
-        data_start_lba=data_start,
+    return _layout_for_image(
+        with_mbr=with_mbr,
+        partition_start_lba=PARTITION_START_LBA,
+        total_volume_sectors=TOTAL_VOLUME_SECTORS,
+        reserved_sectors=RESERVED_SECTORS,
+        fat_count=FAT_COUNT,
+        fat_size_sectors=FAT_SIZE_SECTORS,
         sectors_per_cluster=sectors_per_cluster,
+        root_cluster=ROOT_CLUSTER,
     )
 
 
-def sector(image: bytes, lba: int) -> bytes:
-    start = lba * SECTOR_SIZE
-    return image[start:start + SECTOR_SIZE]
-
-
-def root_entry(name: bytes, attr: int, cluster: int, size: int) -> bytes:
-    if len(name) != 11:
-        raise ValueError("FAT 8.3 directory name must be 11 bytes")
-    entry = bytearray(32)
-    entry[0:11] = name
-    entry[11] = attr
-    entry[20:22] = ((cluster >> 16) & 0xFFFF).to_bytes(2, "little")
-    entry[26:28] = (cluster & 0xFFFF).to_bytes(2, "little")
-    entry[28:32] = size.to_bytes(4, "little")
-    return bytes(entry)
-
-
 def _write_mbr(image: bytearray, start_lba: int, sector_count: int) -> None:
-    mbr = bytearray(SECTOR_SIZE)
-    entry = 446
-    mbr[entry + 4] = 0x0C
-    mbr[entry + 8:entry + 12] = start_lba.to_bytes(4, "little")
-    mbr[entry + 12:entry + 16] = sector_count.to_bytes(4, "little")
-    mbr[510:512] = b"\x55\xAA"
-    image[0:SECTOR_SIZE] = mbr
+    _write_mbr_common(image, start_lba, sector_count)
 
 
 def _write_vbr(image: bytearray, lba: int, sectors_per_cluster: int) -> None:
-    vbr = bytearray(SECTOR_SIZE)
-    vbr[0:3] = b"\xEB\x58\x90"
-    vbr[3:11] = b"MSDOS5.0"
-    vbr[11:13] = SECTOR_SIZE.to_bytes(2, "little")
-    vbr[13] = sectors_per_cluster
-    vbr[14:16] = RESERVED_SECTORS.to_bytes(2, "little")
-    vbr[16] = FAT_COUNT
-    vbr[17:19] = (0).to_bytes(2, "little")
-    vbr[19:21] = (0).to_bytes(2, "little")
-    vbr[21] = 0xF8
-    vbr[22:24] = (0).to_bytes(2, "little")
-    vbr[32:36] = TOTAL_VOLUME_SECTORS.to_bytes(4, "little")
-    vbr[36:40] = FAT_SIZE_SECTORS.to_bytes(4, "little")
-    vbr[44:48] = ROOT_CLUSTER.to_bytes(4, "little")
-    vbr[48:50] = (1).to_bytes(2, "little")
-    vbr[50:52] = (0).to_bytes(2, "little")
-    vbr[64] = 0x80
-    vbr[66] = 0x29
-    vbr[67:71] = (0x68004800).to_bytes(4, "little")
-    vbr[71:82] = b"MC6800 SD  "
-    vbr[82:90] = b"FAT32   "
-    vbr[510:512] = b"\x55\xAA"
-    _write_sector(image, lba, vbr)
+    _write_vbr_common(
+        image,
+        lba,
+        total_volume_sectors=TOTAL_VOLUME_SECTORS,
+        reserved_sectors=RESERVED_SECTORS,
+        fat_count=FAT_COUNT,
+        fat_size_sectors=FAT_SIZE_SECTORS,
+        sectors_per_cluster=sectors_per_cluster,
+        root_cluster=ROOT_CLUSTER,
+    )
 
 
 def _write_fsinfo(image: bytearray, lba: int) -> None:
-    fsinfo = bytearray(SECTOR_SIZE)
-    fsinfo[0:4] = b"RRaA"
-    fsinfo[484:488] = b"rrAa"
-    fsinfo[488:492] = (0xFFFFFFFF).to_bytes(4, "little")
-    fsinfo[492:496] = (0xFFFFFFFF).to_bytes(4, "little")
-    fsinfo[510:512] = b"\x55\xAA"
-    _write_sector(image, lba, fsinfo)
+    _write_fsinfo_common(image, lba)
 
 
 def _write_fats(image: bytearray, layout: Fat32Layout, root_chain: bool) -> None:
@@ -227,36 +193,18 @@ def _write_file_clusters(image: bytearray, layout: Fat32Layout, root_chain: bool
 
 
 def _write_cluster(image: bytearray, layout: Fat32Layout, cluster: int, data: bytes) -> None:
-    _write_sector(image, layout.cluster_lba(cluster), data)
+    if len(data) == SECTOR_SIZE:
+        _write_sector(image, layout.cluster_lba(cluster), data)
+        return
+    _write_cluster_common(image, layout, cluster, data)
 
 
 def _write_sector(image: bytearray, lba: int, data: bytes | bytearray) -> None:
-    if len(data) != SECTOR_SIZE:
-        raise ValueError("sector data must be exactly 512 bytes")
-    start = lba * SECTOR_SIZE
-    image[start:start + SECTOR_SIZE] = data
+    _write_sector_common(image, lba, data)
 
 
 def _write_file_data(image: bytearray, layout: Fat32Layout, clusters: tuple[int, ...], data: bytes, fill: int) -> None:
-    sector_count = _sector_count_for_size(len(data))
-    cluster_count = _cluster_count_for_size(len(data), layout.sectors_per_cluster)
-    if cluster_count > len(clusters):
-        raise ValueError("not enough clusters for file data")
-    for sector_index in range(sector_count):
-        chunk = data[sector_index * SECTOR_SIZE:(sector_index + 1) * SECTOR_SIZE]
-        sector_data = chunk + bytes([fill]) * (SECTOR_SIZE - len(chunk))
-        cluster_index = sector_index // layout.sectors_per_cluster
-        sector_in_cluster = sector_index % layout.sectors_per_cluster
-        lba = layout.cluster_lba(clusters[cluster_index]) + sector_in_cluster
-        _write_sector(image, lba, sector_data)
-
-
-def _sector_count_for_size(size: int) -> int:
-    return (size + SECTOR_SIZE - 1) // SECTOR_SIZE
-
-
-def _cluster_count_for_size(size: int, sectors_per_cluster: int) -> int:
-    return (_sector_count_for_size(size) + sectors_per_cluster - 1) // sectors_per_cluster
+    _write_file_data_common(image, layout, clusters, data, fill)
 
 
 def _padded(prefix: bytes, fill: int) -> bytes:

--- a/tests/test_mk_sdfs_image.py
+++ b/tests/test_mk_sdfs_image.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""mk-sdfs image generation tests."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "tools"))
+sys.path.insert(0, str(PROJECT_ROOT / "tests"))
+
+from fat32_image import DEFAULT_PARTITION_START_LBA, EOC, SECTOR_SIZE, sector  # noqa: E402
+from mk_sdfs_image import DEFAULT_STAGE1_LBA, build_sdfs_image, fat83_from_path  # noqa: E402
+
+
+def u16(data: bytes, offset: int) -> int:
+    return int.from_bytes(data[offset:offset + 2], "little")
+
+
+def u32(data: bytes, offset: int) -> int:
+    return int.from_bytes(data[offset:offset + 4], "little")
+
+
+def fat_entry(fat: bytes, cluster: int) -> int:
+    return u32(fat, cluster * 4) & 0x0FFFFFFF
+
+
+def entry_cluster(entry: bytes) -> int:
+    return (u16(entry, 20) << 16) | u16(entry, 26)
+
+
+def test_fat83_from_path_accepts_uppercase_83() -> None:
+    assert fat83_from_path(Path("HELLO.S")) == b"HELLO   S  "
+    assert fat83_from_path(Path("big.bin")) == b"BIG     BIN"
+    assert fat83_from_path(Path("A-B.S")) == b"A-B     S  "
+    assert fat83_from_path(Path("A!B#.DAT")) == b"A!B#    DAT"
+    print("[PASS] test_fat83_from_path_accepts_uppercase_83")
+
+
+def test_fat83_from_path_rejects_non_83() -> None:
+    for name in ("TOO-LONG-NAME.S", "HELLO.LONG", "A.B.C", "日本.S"):
+        try:
+            fat83_from_path(Path(name))
+        except ValueError:
+            continue
+        raise AssertionError(f"expected invalid 8.3 filename: {name}")
+    print("[PASS] test_fat83_from_path_rejects_non_83")
+
+
+def test_build_sdfs_image_places_stage1_and_root_files() -> None:
+    stage1 = b"S1API68" + bytes(range(32))
+    sdfs = b"SDFS68" + bytes(range(250)) * 3
+    hello = b"S1060200010203F1\r\nS9030000FC\r\n"
+    image = build_sdfs_image(
+        stage1_data=stage1,
+        sdfs_data=sdfs,
+        extra_files=[
+            _file("HELLO.S", hello),
+            _file("DATA.BIN", b"DATA" * 200),
+        ],
+    )
+
+    assert image == build_sdfs_image(
+        stage1_data=stage1,
+        sdfs_data=sdfs,
+        extra_files=[
+            _file("HELLO.S", hello),
+            _file("DATA.BIN", b"DATA" * 200),
+        ],
+    ), "same input must generate identical image bytes"
+
+    mbr = sector(image, 0)
+    assert mbr[510:512] == b"\x55\xAA"
+    assert mbr[450] == 0x0C
+    assert u32(mbr, 454) == DEFAULT_PARTITION_START_LBA
+
+    boot_area = sector(image, DEFAULT_STAGE1_LBA)
+    assert boot_area.startswith(stage1)
+    assert boot_area[len(stage1):] == bytes(SECTOR_SIZE - len(stage1))
+
+    bpb = sector(image, DEFAULT_PARTITION_START_LBA)
+    assert bpb[510:512] == b"\x55\xAA"
+    assert u16(bpb, 11) == SECTOR_SIZE
+    assert bpb[13] == 1
+    assert u16(bpb, 14) == 4
+    assert bpb[16] == 2
+    assert u32(bpb, 44) == 2
+    assert bpb[82:90] == b"FAT32   "
+    fat_size = u32(bpb, 36)
+    total_volume_sectors = u32(bpb, 32)
+    data_clusters = (total_volume_sectors - u16(bpb, 14) - bpb[16] * fat_size) // bpb[13]
+    assert data_clusters >= 65525
+
+    fat_lba = DEFAULT_PARTITION_START_LBA + u16(bpb, 14)
+    data_start_lba = fat_lba + bpb[16] * fat_size
+    root = sector(image, data_start_lba)
+    assert root[0:11] == b"SDFS    BIN"
+    assert root[32:43] == b"HELLO   S  "
+    assert root[64:75] == b"DATA    BIN"
+    assert u32(root, 28) == len(sdfs)
+    assert u32(root, 32 + 28) == len(hello)
+
+    fat = sector(image, fat_lba)
+    sdfs_cluster = entry_cluster(root[0:32])
+    data_cluster = entry_cluster(root[64:96])
+    assert sdfs_cluster == 3
+    assert fat_entry(fat, 2) == EOC
+    assert fat_entry(fat, sdfs_cluster) == 4
+    assert fat_entry(fat, 4) == EOC
+    assert fat_entry(fat, data_cluster) == 7
+    assert fat_entry(fat, 7) == EOC
+    assert sector(image, data_start_lba + (sdfs_cluster - 2)).startswith(sdfs[:SECTOR_SIZE])
+    assert sector(image, data_start_lba + (data_cluster - 2)).startswith((b"DATA" * 200)[:SECTOR_SIZE])
+    print("[PASS] test_build_sdfs_image_places_stage1_and_root_files")
+
+
+def test_build_sdfs_image_rejects_bad_inputs() -> None:
+    cases = [
+        dict(stage1_data=b"", sdfs_data=b"S", extra_files=[]),
+        dict(stage1_data=b"S", sdfs_data=b"", extra_files=[]),
+        dict(stage1_data=b"S" * (17 * SECTOR_SIZE), sdfs_data=b"S", extra_files=[]),
+        dict(stage1_data=b"S", sdfs_data=b"S", extra_files=[_file("SDFS.BIN", b"dup")]),
+    ]
+    for kwargs in cases:
+        try:
+            build_sdfs_image(**kwargs)
+        except ValueError:
+            continue
+        raise AssertionError(f"expected build_sdfs_image to reject: {kwargs!r}")
+    print("[PASS] test_build_sdfs_image_rejects_bad_inputs")
+
+
+def test_cli_writes_image_and_reports_missing_file() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        stage1 = root / "STAGE1.BIN"
+        sdfs = root / "SDFS.BIN"
+        out = root / "sdfs.img"
+        stage1.write_bytes(b"S1API68")
+        sdfs.write_bytes(b"SDFS68")
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(PROJECT_ROOT / "tools" / "mk_sdfs_image.py"),
+                "--stage1",
+                str(stage1),
+                "--sdfs",
+                str(sdfs),
+                "--output",
+                str(out),
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=PROJECT_ROOT,
+            timeout=10,
+        )
+        assert result.returncode == 0, result.stderr
+        assert out.read_bytes()[DEFAULT_STAGE1_LBA * SECTOR_SIZE:].startswith(b"S1API68")
+
+        missing = subprocess.run(
+            [
+                sys.executable,
+                str(PROJECT_ROOT / "tools" / "mk_sdfs_image.py"),
+                "--stage1",
+                str(root / "NOPE.BIN"),
+                "--sdfs",
+                str(sdfs),
+                "--output",
+                str(out),
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=PROJECT_ROOT,
+            timeout=10,
+        )
+        assert missing.returncode == 1
+        assert "mk-sdfs:" in missing.stderr
+    print("[PASS] test_cli_writes_image_and_reports_missing_file")
+
+
+def _file(name: str, data: bytes):
+    from fat32_image import Fat32File
+
+    return Fat32File(fat83_from_path(Path(name)), data)
+
+
+def main() -> None:
+    print("=" * 50)
+    print("mk-sdfs image tests")
+    print("=" * 50)
+    tests = [
+        test_fat83_from_path_accepts_uppercase_83,
+        test_fat83_from_path_rejects_non_83,
+        test_build_sdfs_image_places_stage1_and_root_files,
+        test_build_sdfs_image_rejects_bad_inputs,
+        test_cli_writes_image_and_reports_missing_file,
+    ]
+    passed = 0
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            passed += 1
+        except AssertionError as exc:
+            print(f"[FAIL] {test.__name__}: {exc}")
+            failed += 1
+        except Exception as exc:
+            print(f"[ERROR] {test.__name__}: {exc}")
+            failed += 1
+    print()
+    print(f"Result: {passed} passed, {failed} failed")
+    sys.exit(0 if failed == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/fat32_image.py
+++ b/tools/fat32_image.py
@@ -1,0 +1,342 @@
+"""Small deterministic FAT32 image writer used by tests and mk-sdfs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+SECTOR_SIZE = 512
+EOC = 0x0FFFFFFF
+DEFAULT_PARTITION_START_LBA = 32
+DEFAULT_RESERVED_SECTORS = 4
+DEFAULT_FAT_COUNT = 2
+DEFAULT_SECTORS_PER_CLUSTER = 1
+DEFAULT_ROOT_CLUSTER = 2
+DEFAULT_VOLUME_SERIAL = 0x68004800
+DEFAULT_VOLUME_LABEL = b"MC6800 SD  "
+MIN_FAT32_DATA_CLUSTERS = 65525
+
+
+@dataclass(frozen=True)
+class Fat32Layout:
+    volume_start_lba: int
+    fat_lba: int
+    root_dir_lba: int
+    data_start_lba: int
+    total_volume_sectors: int
+    reserved_sectors: int = DEFAULT_RESERVED_SECTORS
+    fat_count: int = DEFAULT_FAT_COUNT
+    fat_size_sectors: int = 1
+    sectors_per_cluster: int = DEFAULT_SECTORS_PER_CLUSTER
+    root_cluster: int = DEFAULT_ROOT_CLUSTER
+
+    def cluster_lba(self, cluster: int) -> int:
+        return self.data_start_lba + (cluster - 2) * self.sectors_per_cluster
+
+
+@dataclass(frozen=True)
+class Fat32File:
+    name: bytes
+    data: bytes
+    attr: int = 0x20
+
+    def __post_init__(self) -> None:
+        if len(self.name) != 11:
+            raise ValueError("FAT 8.3 directory name must be 11 bytes")
+
+
+def build_fat32_image_from_files(
+    files: list[Fat32File],
+    *,
+    with_mbr: bool = True,
+    partition_start_lba: int = DEFAULT_PARTITION_START_LBA,
+    total_volume_sectors: int | None = None,
+    reserved_sectors: int = DEFAULT_RESERVED_SECTORS,
+    fat_count: int = DEFAULT_FAT_COUNT,
+    sectors_per_cluster: int = DEFAULT_SECTORS_PER_CLUSTER,
+    root_cluster: int = DEFAULT_ROOT_CLUSTER,
+    volume_label: bytes = DEFAULT_VOLUME_LABEL,
+) -> tuple[bytes, Fat32Layout]:
+    """Build a simple read-only FAT32 image with root-directory files only."""
+    if not files:
+        raise ValueError("at least one root file is required")
+    if len(files) >= entries_per_cluster(sectors_per_cluster):
+        raise ValueError("too many root files for a single root directory cluster")
+    if len(volume_label) != 11:
+        raise ValueError("FAT volume label must be 11 bytes")
+
+    cluster_cursor = root_cluster + 1
+    file_clusters: list[tuple[Fat32File, list[int]]] = []
+    for file in files:
+        clusters_needed = max(1, cluster_count_for_size(len(file.data), sectors_per_cluster))
+        clusters = list(range(cluster_cursor, cluster_cursor + clusters_needed))
+        cluster_cursor += clusters_needed
+        file_clusters.append((file, clusters))
+
+    minimum_data_clusters = cluster_cursor - 2
+    if total_volume_sectors is None:
+        data_clusters = max(MIN_FAT32_DATA_CLUSTERS, minimum_data_clusters)
+        fat_size_sectors = sector_count_for_size((data_clusters + 2) * 4)
+        total_volume_sectors = (
+            reserved_sectors
+            + fat_count * fat_size_sectors
+            + data_clusters * sectors_per_cluster
+        )
+    else:
+        fat_size_sectors = fat_size_for_volume(
+            total_volume_sectors=total_volume_sectors,
+            reserved_sectors=reserved_sectors,
+            fat_count=fat_count,
+            sectors_per_cluster=sectors_per_cluster,
+        )
+    minimum_volume_sectors = (
+        reserved_sectors
+        + fat_count * fat_size_sectors
+        + minimum_data_clusters * sectors_per_cluster
+    )
+    if total_volume_sectors < minimum_volume_sectors:
+        raise ValueError("total volume sectors is too small for requested files")
+
+    volume_start = partition_start_lba if with_mbr else 0
+    image = bytearray((volume_start + total_volume_sectors) * SECTOR_SIZE)
+    layout = layout_for_image(
+        with_mbr=with_mbr,
+        partition_start_lba=partition_start_lba,
+        total_volume_sectors=total_volume_sectors,
+        reserved_sectors=reserved_sectors,
+        fat_count=fat_count,
+        fat_size_sectors=fat_size_sectors,
+        sectors_per_cluster=sectors_per_cluster,
+        root_cluster=root_cluster,
+    )
+
+    if with_mbr:
+        write_mbr(image, volume_start, total_volume_sectors)
+    write_vbr(
+        image,
+        volume_start,
+        total_volume_sectors=total_volume_sectors,
+        reserved_sectors=reserved_sectors,
+        fat_count=fat_count,
+        fat_size_sectors=fat_size_sectors,
+        sectors_per_cluster=sectors_per_cluster,
+        root_cluster=root_cluster,
+        volume_label=volume_label,
+    )
+    write_fsinfo(image, volume_start + 1)
+    _write_generated_fats(image, layout, file_clusters)
+    _write_generated_root_dir(image, layout, file_clusters)
+    for file, clusters in file_clusters:
+        write_file_data(image, layout, tuple(clusters), file.data, 0x00)
+    return bytes(image), layout
+
+
+def layout_for_image(
+    *,
+    with_mbr: bool,
+    partition_start_lba: int = DEFAULT_PARTITION_START_LBA,
+    total_volume_sectors: int = 64,
+    reserved_sectors: int = DEFAULT_RESERVED_SECTORS,
+    fat_count: int = DEFAULT_FAT_COUNT,
+    fat_size_sectors: int = 1,
+    sectors_per_cluster: int = DEFAULT_SECTORS_PER_CLUSTER,
+    root_cluster: int = DEFAULT_ROOT_CLUSTER,
+) -> Fat32Layout:
+    volume_start = partition_start_lba if with_mbr else 0
+    fat_lba = volume_start + reserved_sectors
+    data_start = volume_start + reserved_sectors + fat_count * fat_size_sectors
+    return Fat32Layout(
+        volume_start_lba=volume_start,
+        fat_lba=fat_lba,
+        root_dir_lba=data_start + (root_cluster - 2) * sectors_per_cluster,
+        data_start_lba=data_start,
+        total_volume_sectors=total_volume_sectors,
+        reserved_sectors=reserved_sectors,
+        fat_count=fat_count,
+        fat_size_sectors=fat_size_sectors,
+        sectors_per_cluster=sectors_per_cluster,
+        root_cluster=root_cluster,
+    )
+
+
+def sector(image: bytes, lba: int) -> bytes:
+    start = lba * SECTOR_SIZE
+    return image[start:start + SECTOR_SIZE]
+
+
+def root_entry(name: bytes, attr: int, cluster: int, size: int) -> bytes:
+    if len(name) != 11:
+        raise ValueError("FAT 8.3 directory name must be 11 bytes")
+    entry = bytearray(32)
+    entry[0:11] = name
+    entry[11] = attr
+    entry[20:22] = ((cluster >> 16) & 0xFFFF).to_bytes(2, "little")
+    entry[26:28] = (cluster & 0xFFFF).to_bytes(2, "little")
+    entry[28:32] = size.to_bytes(4, "little")
+    return bytes(entry)
+
+
+def write_mbr(image: bytearray, start_lba: int, sector_count: int) -> None:
+    mbr = bytearray(SECTOR_SIZE)
+    entry = 446
+    mbr[entry + 4] = 0x0C
+    mbr[entry + 8:entry + 12] = start_lba.to_bytes(4, "little")
+    mbr[entry + 12:entry + 16] = sector_count.to_bytes(4, "little")
+    mbr[510:512] = b"\x55\xAA"
+    write_sector(image, 0, mbr)
+
+
+def write_vbr(
+    image: bytearray,
+    lba: int,
+    *,
+    total_volume_sectors: int,
+    reserved_sectors: int,
+    fat_count: int,
+    fat_size_sectors: int,
+    sectors_per_cluster: int,
+    root_cluster: int,
+    volume_label: bytes = DEFAULT_VOLUME_LABEL,
+) -> None:
+    if len(volume_label) != 11:
+        raise ValueError("FAT volume label must be 11 bytes")
+    vbr = bytearray(SECTOR_SIZE)
+    vbr[0:3] = b"\xEB\x58\x90"
+    vbr[3:11] = b"MSDOS5.0"
+    vbr[11:13] = SECTOR_SIZE.to_bytes(2, "little")
+    vbr[13] = sectors_per_cluster
+    vbr[14:16] = reserved_sectors.to_bytes(2, "little")
+    vbr[16] = fat_count
+    vbr[17:19] = (0).to_bytes(2, "little")
+    vbr[19:21] = (0).to_bytes(2, "little")
+    vbr[21] = 0xF8
+    vbr[22:24] = (0).to_bytes(2, "little")
+    vbr[32:36] = total_volume_sectors.to_bytes(4, "little")
+    vbr[36:40] = fat_size_sectors.to_bytes(4, "little")
+    vbr[44:48] = root_cluster.to_bytes(4, "little")
+    vbr[48:50] = (1).to_bytes(2, "little")
+    vbr[50:52] = (0).to_bytes(2, "little")
+    vbr[64] = 0x80
+    vbr[66] = 0x29
+    vbr[67:71] = DEFAULT_VOLUME_SERIAL.to_bytes(4, "little")
+    vbr[71:82] = volume_label
+    vbr[82:90] = b"FAT32   "
+    vbr[510:512] = b"\x55\xAA"
+    write_sector(image, lba, vbr)
+
+
+def write_fsinfo(image: bytearray, lba: int) -> None:
+    fsinfo = bytearray(SECTOR_SIZE)
+    fsinfo[0:4] = b"RRaA"
+    fsinfo[484:488] = b"rrAa"
+    fsinfo[488:492] = (0xFFFFFFFF).to_bytes(4, "little")
+    fsinfo[492:496] = (0xFFFFFFFF).to_bytes(4, "little")
+    fsinfo[510:512] = b"\x55\xAA"
+    write_sector(image, lba, fsinfo)
+
+
+def write_sector(image: bytearray, lba: int, data: bytes | bytearray) -> None:
+    if len(data) != SECTOR_SIZE:
+        raise ValueError("sector data must be exactly 512 bytes")
+    start = lba * SECTOR_SIZE
+    image[start:start + SECTOR_SIZE] = data
+
+
+def write_cluster(image: bytearray, layout: Fat32Layout, cluster: int, data: bytes) -> None:
+    if len(data) != SECTOR_SIZE * layout.sectors_per_cluster:
+        raise ValueError("cluster data has an unexpected size")
+    for sector_index in range(layout.sectors_per_cluster):
+        start = sector_index * SECTOR_SIZE
+        write_sector(
+            image,
+            layout.cluster_lba(cluster) + sector_index,
+            data[start:start + SECTOR_SIZE],
+        )
+
+
+def write_file_data(
+    image: bytearray,
+    layout: Fat32Layout,
+    clusters: tuple[int, ...],
+    data: bytes,
+    fill: int,
+) -> None:
+    sector_count = max(1, sector_count_for_size(len(data)))
+    cluster_count = max(1, cluster_count_for_size(len(data), layout.sectors_per_cluster))
+    if cluster_count > len(clusters):
+        raise ValueError("not enough clusters for file data")
+    for sector_index in range(sector_count):
+        chunk = data[sector_index * SECTOR_SIZE:(sector_index + 1) * SECTOR_SIZE]
+        sector_data = chunk + bytes([fill]) * (SECTOR_SIZE - len(chunk))
+        cluster_index = sector_index // layout.sectors_per_cluster
+        sector_in_cluster = sector_index % layout.sectors_per_cluster
+        lba = layout.cluster_lba(clusters[cluster_index]) + sector_in_cluster
+        write_sector(image, lba, sector_data)
+
+
+def sector_count_for_size(size: int) -> int:
+    return (size + SECTOR_SIZE - 1) // SECTOR_SIZE
+
+
+def cluster_count_for_size(size: int, sectors_per_cluster: int) -> int:
+    return (sector_count_for_size(size) + sectors_per_cluster - 1) // sectors_per_cluster
+
+
+def entries_per_cluster(sectors_per_cluster: int) -> int:
+    return SECTOR_SIZE * sectors_per_cluster // 32
+
+
+def fat_size_for_volume(
+    *,
+    total_volume_sectors: int,
+    reserved_sectors: int,
+    fat_count: int,
+    sectors_per_cluster: int,
+) -> int:
+    fat_size = 1
+    while True:
+        data_sectors = total_volume_sectors - reserved_sectors - fat_count * fat_size
+        if data_sectors <= 0:
+            raise ValueError("total volume sectors is too small for FAT32 layout")
+        data_clusters = data_sectors // sectors_per_cluster
+        needed = sector_count_for_size((data_clusters + 2) * 4)
+        if needed == fat_size:
+            return fat_size
+        fat_size = needed
+
+
+def _write_generated_fats(
+    image: bytearray,
+    layout: Fat32Layout,
+    file_clusters: list[tuple[Fat32File, list[int]]],
+) -> None:
+    fat = bytearray(SECTOR_SIZE * layout.fat_size_sectors)
+    entries = {
+        0: 0x0FFFFFF8,
+        1: EOC,
+        layout.root_cluster: EOC,
+    }
+    for _file, clusters in file_clusters:
+        for index, cluster in enumerate(clusters):
+            entries[cluster] = clusters[index + 1] if index + 1 < len(clusters) else EOC
+    for cluster, value in entries.items():
+        offset = cluster * 4
+        fat[offset:offset + 4] = value.to_bytes(4, "little")
+    for copy_index in range(layout.fat_count):
+        base_lba = layout.fat_lba + copy_index * layout.fat_size_sectors
+        for sector_index in range(layout.fat_size_sectors):
+            start = sector_index * SECTOR_SIZE
+            write_sector(image, base_lba + sector_index, fat[start:start + SECTOR_SIZE])
+
+
+def _write_generated_root_dir(
+    image: bytearray,
+    layout: Fat32Layout,
+    file_clusters: list[tuple[Fat32File, list[int]]],
+) -> None:
+    root = bytearray(SECTOR_SIZE * layout.sectors_per_cluster)
+    for index, (file, clusters) in enumerate(file_clusters):
+        start = index * 32
+        root[start:start + 32] = root_entry(file.name, file.attr, clusters[0], len(file.data))
+    root[len(file_clusters) * 32] = 0x00
+    write_cluster(image, layout, layout.root_cluster, root)

--- a/tools/mk_sdfs_image.py
+++ b/tools/mk_sdfs_image.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Create a deterministic SDFS/68 system SD image."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from fat32_image import (
+    DEFAULT_PARTITION_START_LBA,
+    SECTOR_SIZE,
+    Fat32File,
+    build_fat32_image_from_files,
+    sector_count_for_size,
+)
+
+
+DEFAULT_STAGE1_LBA = 16
+SDFS_NAME_83 = b"SDFS    BIN"
+FAT83_EXTRA_CHARS = "$%'-_@~`!(){}^#&"
+
+
+def build_sdfs_image(
+    *,
+    stage1_data: bytes,
+    sdfs_data: bytes,
+    extra_files: list[Fat32File],
+    stage1_lba: int = DEFAULT_STAGE1_LBA,
+    partition_start_lba: int = DEFAULT_PARTITION_START_LBA,
+    total_volume_sectors: int | None = None,
+) -> bytes:
+    if not stage1_data:
+        raise ValueError("stage1 loader must not be empty")
+    if not sdfs_data:
+        raise ValueError("SDFS.BIN must not be empty")
+    stage1_sectors = sector_count_for_size(len(stage1_data))
+    if stage1_lba <= 0:
+        raise ValueError("stage1 LBA must not overlap the MBR")
+    if stage1_lba + stage1_sectors > partition_start_lba:
+        raise ValueError("stage1 boot area overlaps the FAT32 partition")
+
+    root_files = [Fat32File(SDFS_NAME_83, sdfs_data), *extra_files]
+    names = [file.name for file in root_files]
+    if len(names) != len(set(names)):
+        raise ValueError("duplicate FAT 8.3 root filename")
+
+    image, _layout = build_fat32_image_from_files(
+        root_files,
+        with_mbr=True,
+        partition_start_lba=partition_start_lba,
+        total_volume_sectors=total_volume_sectors,
+    )
+    mutable = bytearray(image)
+    start = stage1_lba * SECTOR_SIZE
+    padded_len = stage1_sectors * SECTOR_SIZE
+    mutable[start:start + padded_len] = stage1_data + bytes(padded_len - len(stage1_data))
+    return bytes(mutable)
+
+
+def fat83_from_path(path: Path) -> bytes:
+    name = path.name
+    if name in ("", ".", ".."):
+        raise ValueError(f"invalid filename: {name!r}")
+    if name.count(".") > 1:
+        raise ValueError(f"filename is not 8.3: {name}")
+    stem, dot, ext = name.partition(".")
+    if not stem or len(stem) > 8 or len(ext) > 3:
+        raise ValueError(f"filename is not 8.3: {name}")
+    stem = stem.upper()
+    ext = ext.upper() if dot else ""
+    if not _is_valid_83_part(stem) or not _is_valid_83_part(ext):
+        raise ValueError(f"filename contains unsupported FAT 8.3 characters: {name}")
+    return stem.encode("ascii").ljust(8, b" ") + ext.encode("ascii").ljust(3, b" ")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Create a SDFS/68 FAT32 SD image with fixed-LBA stage1.",
+    )
+    parser.add_argument("--stage1", required=True, type=Path, help="stage1 loader binary")
+    parser.add_argument("--sdfs", required=True, type=Path, help="SDFS.BIN body")
+    parser.add_argument("--output", required=True, type=Path, help="output image path")
+    parser.add_argument(
+        "--stage1-lba",
+        type=int,
+        default=DEFAULT_STAGE1_LBA,
+        help=f"physical LBA for stage1 boot area, default {DEFAULT_STAGE1_LBA}",
+    )
+    parser.add_argument(
+        "--partition-start-lba",
+        type=int,
+        default=DEFAULT_PARTITION_START_LBA,
+        help=f"FAT32 partition start LBA, default {DEFAULT_PARTITION_START_LBA}",
+    )
+    parser.add_argument(
+        "--total-volume-sectors",
+        type=int,
+        default=None,
+        help="FAT32 volume sector count; defaults to a host-compatible FAT32 image",
+    )
+    parser.add_argument("files", nargs="*", type=Path, help="additional root files")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        extra_files = [
+            Fat32File(fat83_from_path(path), _read_file(path), 0x20)
+            for path in args.files
+        ]
+        image = build_sdfs_image(
+            stage1_data=_read_file(args.stage1),
+            sdfs_data=_read_file(args.sdfs),
+            extra_files=extra_files,
+            stage1_lba=args.stage1_lba,
+            partition_start_lba=args.partition_start_lba,
+            total_volume_sectors=args.total_volume_sectors,
+        )
+        args.output.write_bytes(image)
+    except OSError as exc:
+        print(f"mk-sdfs: {exc}", file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        print(f"mk-sdfs: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+def _read_file(path: Path) -> bytes:
+    return path.read_bytes()
+
+
+def _is_valid_83_part(value: str) -> bool:
+    try:
+        value.encode("ascii")
+    except UnicodeEncodeError:
+        return False
+    return all(char.isalnum() or char in FAT83_EXTRA_CHARS for char in value)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 対応Issue

Closes #103
Refs #82 #101 #102 #109 #111

## 変更内容

- `tools/mk_sdfs_image.py` を追加し、fixed boot area のstage1とFAT rootの `SDFS.BIN` を持つSDFS/68 SDイメージを生成できるようにしました。
- FAT32生成の低層処理を `tools/fat32_image.py` に共通化し、既存 `tests/sd_fixtures.py` も同じwriterを使うようにしました。
- `tests/test_mk_sdfs_image.py` を追加し、固定LBA stage1、root `SDFS.BIN`、8.3名、FAT chain、異常系を検証しました。
- #111 としてstage1 loader本体の実装Issueを作成し、#103から参照できるようにしました。
- `docs/plans/issue-103_mk_sdfs_image.md` と `docs/usage/sdfs68_system_sd.md` を更新しました。

## レビュー反映

- 既定出力はホストOSがFAT32として扱えるdata cluster数を持つようにしました。
- FAT 8.3 short filenameで使える記号を過剰に拒否しないようにしました。

## 確認内容

- `git diff --check`
- `python3 -m py_compile tools/fat32_image.py tools/mk_sdfs_image.py tests/sd_fixtures.py tests/test_mk_sdfs_image.py`
- `python3 tests/test_mk_sdfs_image.py`
- `python3 tests/test_sd_fixture.py`
- `make bin`
- `REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py`
- `REQUIRE_BUILD_ROM=1 python3 tests/test_sd_fixture.py`

## 対象外

- 実SDデバイスへの直接書き込み
- stage1 loader本体の実装
- ROM `BOOT` の実装
- SDFS/68本体の実装
- LFN、subdirectory、FAT write