### PR TITLE
feat: stage1 SD sector readを実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ stage1: check-stage1-profile $(STAGE1_BIN)
 check-stage1-profile:
 	"$(PYTHON)" -c "import sys; profile='$(MONITOR_PROFILE)'; sys.exit(0 if profile in ('sbcio_vdg', 'k6802_vdg') else 1)" || (echo "stage1 target requires MONITOR_PROFILE=sbcio_vdg or MONITOR_PROFILE=k6802_vdg" && exit 1)
 
-$(STAGE1_OBJ): FORCE $(STAGE1_TOPSRC) include/hardware.inc $(CONFIG_INC) | $(OUTDIR)
+$(STAGE1_OBJ): FORCE $(STAGE1_TOPSRC) include/hardware.inc $(CONFIG_INC) src/sdcard.asm | $(OUTDIR)
 	"$(ASL)" -q -L -olist $(STAGE1_LST) -o $(STAGE1_OBJ) -i $(ASL_INCLUDE_ARG) $(STAGE1_TOPSRC)
 
 $(STAGE1_BIN): $(STAGE1_OBJ)

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@
 - [plans/issue-107_fixed_sector_boot_eval.md](plans/issue-107_fixed_sector_boot_eval.md): 固定セクタ版SDFS/68 loaderのROM削減評価
 - [plans/issue-109_stage1_boot_services.md](plans/issue-109_stage1_boot_services.md): SDFS/68 stage1 boot services設計
 - [plans/issue-113_stage1_header_build.md](plans/issue-113_stage1_header_build.md): SDFS/68 stage1 header / jump table とビルド基盤
+- [plans/issue-115_stage1_sd_read.md](plans/issue-115_stage1_sd_read.md): SDFS/68 stage1 SD raw sector read boot services
 - [testing/sbc6800_bringup.md](testing/sbc6800_bringup.md)
 - [testing/sbc_io_sd_bringup.md](testing/sbc_io_sd_bringup.md): SBC-IO と microSD SPI モジュールで SD/FAT を実機確認する手順
 - [testing/sbc6800_datapack.md](testing/sbc6800_datapack.md): SBC6800 データパックの扱いと互換確認

--- a/docs/plans/issue-115_stage1_sd_read.md
+++ b/docs/plans/issue-115_stage1_sd_read.md
@@ -1,0 +1,43 @@
+# Issue #115 stage1 S1_INIT / S1_READ_SECTOR
+
+## 関連リンク
+
+- Issue #115: https://github.com/kuninet/mc6800-rom-monitor/issues/115
+- Issue #111: https://github.com/kuninet/mc6800-rom-monitor/issues/111
+- Issue #113: https://github.com/kuninet/mc6800-rom-monitor/issues/113
+
+## 方針
+
+#113 で固定したstage1 header / jump tableを維持したまま、stage1 boot servicesの最初の実体としてSD初期化とraw sector readだけを接続する。このIssueではFAT32 mountや `SDFS.BIN` ロードは実装しない。
+
+## 実装内容
+
+- `src/stage1.asm` から既存 `src/sdcard.asm` をincludeする。
+- `S1_INIT` は `SD_INIT` へ接続する。
+- `S1_READ_SECTOR` は `SD_READ_SECTOR` へ接続する。
+- `S1_GET_ERROR` は `SD_ERROR` を返す。
+- `S1_MOUNT`、`S1_FIND_83`、`S1_LOAD_FILE_83` は未実装stubのまま残す。
+- `Makefile` のstage1依存に `src/sdcard.asm` を追加する。
+
+## API前提
+
+`S1_READ_SECTOR` は既存 `SD_READ_SECTOR` と同じ低層APIを踏襲する。
+
+- 入力: `SD_LBA0..3` に読み出しLBA、`X` に転送先アドレス。
+- 成功: carry clear、`SD_ERROR=0`。
+- 失敗: carry set、`SD_ERROR` に既存SDエラーコード。
+
+## 対象外
+
+- FAT32 mount。
+- root 8.3検索。
+- `SDFS.BIN` 実ロード。
+- ROM `BOOT` 実装。
+- SDFS/68本体実装。
+
+## 検証方針
+
+- `sbcio_vdg` stage1 binaryをRAMへロードする。
+- RAM上の小ハーネスから `S1_INIT`、`S1_READ_SECTOR` を呼ぶ。
+- 既存SD fixtureの既知sectorを `SDFS_LOAD_BASE` へ読み、先頭bytesが期待値と一致することを確認する。
+- stage1 binaryが `S1_LIMIT` を超えないことを維持する。

--- a/src/stage1.asm
+++ b/src/stage1.asm
@@ -33,14 +33,10 @@ S1_JUMP_TABLE:
         jmp     S1_GET_ERROR
 
 S1_INIT:
-        ldaa    #S1_ERR_NONE
-        clc
-        rts
+        jmp     SD_INIT
 
 S1_READ_SECTOR:
-        ldaa    #S1_ERR_UNIMPL
-        sec
-        rts
+        jmp     SD_READ_SECTOR
 
 S1_MOUNT:
         ldaa    #S1_ERR_UNIMPL
@@ -58,9 +54,11 @@ S1_LOAD_FILE_83:
         rts
 
 S1_GET_ERROR:
-        ldaa    #S1_ERR_UNIMPL
+        ldaa    SD_ERROR
         clc
         rts
+
+        include "sdcard.asm"
 
 S1_END:
         if S1_END-1 > S1_LIMIT

--- a/tests/test_stage1_build.py
+++ b/tests/test_stage1_build.py
@@ -6,10 +6,21 @@ from __future__ import annotations
 import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "tests"))
+
+from sd_fixtures import (  # noqa: E402
+    MULTI_CLUSTER_1,
+    MULTI_CLUSTER_1_PREFIX,
+    build_fat32_image,
+    layout_for_image,
+)
+
+EMU_PATH = PROJECT_ROOT / "emu" / "sbc6800_emu.py"
 
 
 EXPECTED = {
@@ -42,7 +53,19 @@ def test_stage1_profiles_build_and_match_layout() -> None:
         bin_path = PROJECT_ROOT / "build" / f"stage1{suffix}.bin"
         lst_path = PROJECT_ROOT / "build" / f"stage1{suffix}.lst"
         data = bin_path.read_bytes()
-        symbols = _load_symbols(lst_path, "S1_BASE", "S1_LIMIT", "SDFS_LOAD_BASE", "S1_END")
+        symbols = _load_symbols(
+            lst_path,
+            "S1_BASE",
+            "S1_LIMIT",
+            "SDFS_LOAD_BASE",
+            "S1_INIT",
+            "S1_READ_SECTOR",
+            "S1_MOUNT",
+            "S1_FIND_83",
+            "S1_LOAD_FILE_83",
+            "S1_GET_ERROR",
+            "S1_END",
+        )
         assert symbols["S1_BASE"] == expected["S1_BASE"], f"{profile} S1_BASE mismatch"
         assert symbols["S1_LIMIT"] == expected["S1_LIMIT"], f"{profile} S1_LIMIT mismatch"
         assert symbols["SDFS_LOAD_BASE"] == expected["SDFS_LOAD_BASE"], (
@@ -50,13 +73,67 @@ def test_stage1_profiles_build_and_match_layout() -> None:
         )
         assert len(data) <= symbols["S1_LIMIT"] - symbols["S1_BASE"] + 1
         _assert_stage1_header(data)
-        _assert_jump(data, 16, symbols["S1_BASE"] + 0x22)
-        _assert_jump(data, 19, symbols["S1_BASE"] + 0x26)
-        _assert_jump(data, 22, symbols["S1_BASE"] + 0x2A)
-        _assert_jump(data, 25, symbols["S1_BASE"] + 0x2E)
-        _assert_jump(data, 28, symbols["S1_BASE"] + 0x32)
-        _assert_jump(data, 31, symbols["S1_BASE"] + 0x36)
+        _assert_jump(data, 16, symbols["S1_INIT"])
+        _assert_jump(data, 19, symbols["S1_READ_SECTOR"])
+        _assert_jump(data, 22, symbols["S1_MOUNT"])
+        _assert_jump(data, 25, symbols["S1_FIND_83"])
+        _assert_jump(data, 28, symbols["S1_LOAD_FILE_83"])
+        _assert_jump(data, 31, symbols["S1_GET_ERROR"])
     print("[PASS] test_stage1_profiles_build_and_match_layout")
+
+
+def test_stage1_read_sector_service_reads_known_fixture_sector() -> None:
+    profile = "sbcio_vdg"
+    _run_make(profile)
+    _run_make(profile, target="bin")
+    expected = EXPECTED[profile]
+    suffix = expected["suffix"]
+    stage1_data = (PROJECT_ROOT / "build" / f"stage1{suffix}.bin").read_bytes()
+    symbols = _load_symbols(
+        PROJECT_ROOT / "build" / f"stage1{suffix}.lst",
+        "S1_BASE",
+        "SDFS_LOAD_BASE",
+        "SD_LBA0",
+        "SD_LBA1",
+        "SD_LBA2",
+        "SD_LBA3",
+    )
+    layout = layout_for_image(with_mbr=True)
+    lba = layout.cluster_lba(MULTI_CLUSTER_1)
+    dest = symbols["SDFS_LOAD_BASE"]
+    harness_addr = 0x0100
+    harness = [
+        0xBD, ((symbols["S1_BASE"] + 16) >> 8) & 0xFF, (symbols["S1_BASE"] + 16) & 0xFF,
+        0x25, 0x1D,
+        0x86, (lba >> 24) & 0xFF, 0xB7, (symbols["SD_LBA0"] >> 8) & 0xFF, symbols["SD_LBA0"] & 0xFF,
+        0x86, (lba >> 16) & 0xFF, 0xB7, (symbols["SD_LBA1"] >> 8) & 0xFF, symbols["SD_LBA1"] & 0xFF,
+        0x86, (lba >> 8) & 0xFF, 0xB7, (symbols["SD_LBA2"] >> 8) & 0xFF, symbols["SD_LBA2"] & 0xFF,
+        0x86, lba & 0xFF, 0xB7, (symbols["SD_LBA3"] >> 8) & 0xFF, symbols["SD_LBA3"] & 0xFF,
+        0xCE, (dest >> 8) & 0xFF, dest & 0xFF,
+        0xBD, ((symbols["S1_BASE"] + 19) >> 8) & 0xFF, (symbols["S1_BASE"] + 19) & 0xFF,
+        0x25, 0x01,
+        0x3F,
+        0x3F,
+    ]
+    input_text = (
+        f"M{symbols['S1_BASE']:04X}\r"
+        f"{_hex_bytes(list(stage1_data))}\r.\r"
+        f"M{harness_addr:04X}\r"
+        f"{_hex_bytes(harness)}\r.\r"
+        f"G{harness_addr:04X}\r"
+        f"D{dest:04X}-{dest + 0x0F:04X}\r"
+        "\r"
+    )
+    stdout, stderr, rc = _run_emu_with_sd(
+        rom_path=PROJECT_ROOT / "build" / "mc6800-monitor-sbcio-vdg.bin",
+        input_text=input_text,
+        sd_image=build_fat32_image(with_mbr=True),
+    )
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    line = _dump_line(stdout, dest)
+    expected_prefix = " ".join(f"{value:02X}" for value in MULTI_CLUSTER_1_PREFIX[:16])
+    assert expected_prefix in line, f"stage1 read mismatch: {line!r}\nstdout={stdout!r}"
+    print("[PASS] test_stage1_read_sector_service_reads_known_fixture_sector")
 
 
 def _assert_stage1_header(data: bytes) -> None:
@@ -73,9 +150,13 @@ def _assert_jump(data: bytes, offset: int, target: int) -> None:
     assert actual == target, f"JMP target mismatch at +{offset}: {actual:04X} != {target:04X}"
 
 
-def _run_make(profile: str, expect_success: bool = True) -> subprocess.CompletedProcess[str]:
+def _run_make(
+    profile: str,
+    target: str = "stage1",
+    expect_success: bool = True,
+) -> subprocess.CompletedProcess[str]:
     result = subprocess.run(
-        ["make", "stage1", f"MONITOR_PROFILE={profile}"],
+        ["make", target, f"MONITOR_PROFILE={profile}"],
         cwd=PROJECT_ROOT,
         capture_output=True,
         text=True,
@@ -88,6 +169,59 @@ def _run_make(profile: str, expect_success: bool = True) -> subprocess.Completed
             f"make stage1 failed for {profile}: stdout={result.stdout!r} stderr={result.stderr!r}"
         )
     return result
+
+
+def _run_emu_with_sd(
+    *,
+    rom_path: Path,
+    input_text: str,
+    sd_image: bytes,
+    max_cycles: int = 60_000_000,
+) -> tuple[str, str, int]:
+    with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as input_file:
+        input_file.write(input_text.encode("ascii"))
+        input_path = Path(input_file.name)
+    with tempfile.NamedTemporaryFile(suffix=".img", delete=False) as sd_file:
+        sd_file.write(sd_image)
+        sd_path = Path(sd_file.name)
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(EMU_PATH),
+                str(rom_path),
+                "--input",
+                str(input_path),
+                "--max-cycles",
+                str(max_cycles),
+                "--sd",
+                str(sd_path),
+            ],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=20,
+        )
+        return result.stdout, result.stderr, result.returncode
+    except subprocess.TimeoutExpired as exc:
+        return exc.stdout or "", (exc.stderr or "") + "[TIMEOUT]", -1
+    finally:
+        input_path.unlink(missing_ok=True)
+        sd_path.unlink(missing_ok=True)
+
+
+def _hex_bytes(values: list[int]) -> str:
+    return "\r".join(f"{value:02X}" for value in values)
+
+
+def _dump_line(stdout: str, address: int) -> str:
+    marker = f"{address:04X}"
+    for line in stdout.splitlines():
+        if line.lstrip().startswith(marker):
+            return line
+    raise AssertionError(f"missing dump line {marker}: {stdout!r}")
 
 
 def _load_symbols(path: Path, *names: str) -> dict[str, int]:
@@ -116,6 +250,7 @@ def main() -> None:
     tests = [
         test_stage1_rejects_base_profile,
         test_stage1_profiles_build_and_match_layout,
+        test_stage1_read_sector_service_reads_known_fixture_sector,
     ]
     passed = 0
     failed = 0


### PR DESCRIPTION
## Summary
- stage1に既存のSD低層処理を組み込み、`S1_INIT` と `S1_READ_SECTOR` をboot servicesとして接続
- `S1_GET_ERROR` から `SD_ERROR` を返すようにし、FAT/SDFSロード系APIは未実装stubのまま維持
- stage1をRAMへロードして既知SD fixture sectorを読むエミュレータテストを追加
- #115の実装方針を `docs/plans/` に記録

## 対象外
- FAT32 mount
- root `SDFS.BIN` 検索
- `SDFS.BIN` 実ロード
- ROM `BOOT` 実装
- SDFS/68本体

## 確認内容
- `git diff --check`
- `make bin`
- `python3 tests/test_stage1_build.py`
- `REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py`
- `REQUIRE_BUILD_ROM=1 python3 tests/test_sd_fixture.py`
- `python3 tests/test_mk_sdfs_image.py`

Closes #115
Refs #82 #101 #102 #103 #109 #111 #113