### PR TITLE
feat: stage1 FAT32 mountを実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ stage1: check-stage1-profile $(STAGE1_BIN)
 check-stage1-profile:
 	"$(PYTHON)" -c "import sys; profile='$(MONITOR_PROFILE)'; sys.exit(0 if profile in ('sbcio_vdg', 'k6802_vdg') else 1)" || (echo "stage1 target requires MONITOR_PROFILE=sbcio_vdg or MONITOR_PROFILE=k6802_vdg" && exit 1)
 
-$(STAGE1_OBJ): FORCE $(STAGE1_TOPSRC) include/hardware.inc $(CONFIG_INC) src/sdcard.asm | $(OUTDIR)
+$(STAGE1_OBJ): FORCE $(STAGE1_TOPSRC) include/hardware.inc $(CONFIG_INC) src/sdcard.asm src/fat32.asm | $(OUTDIR)
 	"$(ASL)" -q -L -olist $(STAGE1_LST) -o $(STAGE1_OBJ) -i $(ASL_INCLUDE_ARG) $(STAGE1_TOPSRC)
 
 $(STAGE1_BIN): $(STAGE1_OBJ)

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@
 - [plans/issue-109_stage1_boot_services.md](plans/issue-109_stage1_boot_services.md): SDFS/68 stage1 boot services設計
 - [plans/issue-113_stage1_header_build.md](plans/issue-113_stage1_header_build.md): SDFS/68 stage1 header / jump table とビルド基盤
 - [plans/issue-115_stage1_sd_read.md](plans/issue-115_stage1_sd_read.md): SDFS/68 stage1 SD raw sector read boot services
+- [plans/issue-117_stage1_fat_mount.md](plans/issue-117_stage1_fat_mount.md): SDFS/68 stage1 FAT32 mount boot service
 - [testing/sbc6800_bringup.md](testing/sbc6800_bringup.md)
 - [testing/sbc_io_sd_bringup.md](testing/sbc_io_sd_bringup.md): SBC-IO と microSD SPI モジュールで SD/FAT を実機確認する手順
 - [testing/sbc6800_datapack.md](testing/sbc6800_datapack.md): SBC6800 データパックの扱いと互換確認

--- a/docs/plans/issue-117_stage1_fat_mount.md
+++ b/docs/plans/issue-117_stage1_fat_mount.md
@@ -1,0 +1,36 @@
+# Issue #117 stage1 FAT32 mount
+
+## 関連リンク
+
+- Issue #117: https://github.com/kuninet/mc6800-rom-monitor/issues/117
+- Issue #111: https://github.com/kuninet/mc6800-rom-monitor/issues/111
+- Issue #115: https://github.com/kuninet/mc6800-rom-monitor/issues/115
+
+## 方針
+
+#115 でstage1 boot servicesにSD初期化とraw sector readを接続した。次の段階として、`S1_MOUNT` だけを実体化し、FAT32 volumeのBPBと基本LBA情報をstage1上で読める状態にする。
+
+このIssueでは `S1_FIND_83` と `S1_LOAD_FILE_83` には入らない。stage1の2KB枠を守るため、既存 `fat32.asm` のうち mount / BPB解析に必要な範囲だけをstage1へ含める。
+
+## 実装内容
+
+- `S1_MOUNT` を `FAT32_MOUNT` へ接続する。
+- `src/fat32.asm` に `FAT32_INCLUDE_FILE_API` を追加し、`FAT32_FIND_83` 以降のfile APIを条件アセンブル対象にする。
+- monitor本体では `FAT32_INCLUDE_FILE_API=1` とし、従来どおり `DIR` / `LF` が使うFAT APIを含める。
+- stage1では `FAT32_INCLUDE_FILE_API=0` とし、mount / BPB解析だけを含める。
+- `S1_GET_ERROR` は `FAT_ERROR` が非0ならそれを返し、そうでなければ `SD_ERROR` を返す。
+
+## 対象外
+
+- root 8.3検索。
+- `SDFS.BIN` 読み込み。
+- SDFS/68 header検査。
+- ROM `BOOT` 実装。
+- SDFS/68本体実装。
+
+## 検証方針
+
+- `sbcio_vdg` と `k6802_vdg` のstage1 binaryが `S1_LIMIT` 内に収まることを確認する。
+- stage1 binaryをRAMへロードし、MBRありFAT32 fixtureとsuperfloppy FAT32 fixtureで `S1_INIT` -> `S1_MOUNT` が成功することを確認する。
+- 不正FAT32 imageで `S1_MOUNT` が失敗し、ハングしないことを確認する。
+- 既存monitor側の `DIR` / `LF` 回帰として `test_sd_fixture.py` を維持する。

--- a/src/fat32.asm
+++ b/src/fat32.asm
@@ -333,6 +333,7 @@ FAT_FAIL_A:
         sec
         rts
 
+ if FAT32_INCLUDE_FILE_API
 FAT32_FIND_83:
         jsr     FAT_COPY_FIND_NAME
         jsr     FAT_COPY_ROOT_TO_CUR
@@ -841,3 +842,4 @@ FAT_DEC_REM_B2:
 FAT_DEC_REM_LO:
         dec     FAT_BYTES_REM3
         rts
+ endif

--- a/src/main.asm
+++ b/src/main.asm
@@ -2363,6 +2363,7 @@ SPURIOUS_IRQ:
 
         include "acia6850.asm"
  if MONITOR_FEATURE_SD
+FAT32_INCLUDE_FILE_API equ 1
         include "sdcard.asm"
         include "fat32.asm"
  endif

--- a/src/stage1.asm
+++ b/src/stage1.asm
@@ -33,15 +33,15 @@ S1_JUMP_TABLE:
         jmp     S1_GET_ERROR
 
 S1_INIT:
+        clr     FAT_ERROR
         jmp     SD_INIT
 
 S1_READ_SECTOR:
+        clr     FAT_ERROR
         jmp     SD_READ_SECTOR
 
 S1_MOUNT:
-        ldaa    #S1_ERR_UNIMPL
-        sec
-        rts
+        jmp     FAT32_MOUNT
 
 S1_FIND_83:
         ldaa    #S1_ERR_UNIMPL
@@ -54,11 +54,17 @@ S1_LOAD_FILE_83:
         rts
 
 S1_GET_ERROR:
+        ldaa    FAT_ERROR
+        bne     S1_GET_ERROR_DONE
         ldaa    SD_ERROR
+S1_GET_ERROR_DONE:
         clc
         rts
 
+FAT32_INCLUDE_FILE_API equ 0
+
         include "sdcard.asm"
+        include "fat32.asm"
 
 S1_END:
         if S1_END-1 > S1_LIMIT

--- a/tests/test_stage1_build.py
+++ b/tests/test_stage1_build.py
@@ -136,6 +136,19 @@ def test_stage1_read_sector_service_reads_known_fixture_sector() -> None:
     print("[PASS] test_stage1_read_sector_service_reads_known_fixture_sector")
 
 
+def test_stage1_mount_service_accepts_fat32_fixtures() -> None:
+    for with_mbr in (True, False):
+        value = _run_stage1_mount_harness(build_fat32_image(with_mbr=with_mbr))
+        assert value == 0x42, f"S1_MOUNT failed for with_mbr={with_mbr}: {value:02X}"
+    print("[PASS] test_stage1_mount_service_accepts_fat32_fixtures")
+
+
+def test_stage1_mount_service_rejects_invalid_fat32() -> None:
+    value = _run_stage1_mount_harness(bytes(512 * 64))
+    assert value == 0xE1, f"S1_MOUNT unexpectedly accepted invalid image: {value:02X}"
+    print("[PASS] test_stage1_mount_service_rejects_invalid_fat32")
+
+
 def _assert_stage1_header(data: bytes) -> None:
     assert data[0:7] == b"S1API68"
     assert data[7] == 1, "API version mismatch"
@@ -169,6 +182,54 @@ def _run_make(
             f"make stage1 failed for {profile}: stdout={result.stdout!r} stderr={result.stderr!r}"
         )
     return result
+
+
+def _run_stage1_mount_harness(sd_image: bytes) -> int:
+    profile = "sbcio_vdg"
+    _run_make(profile)
+    _run_make(profile, target="bin")
+    expected = EXPECTED[profile]
+    suffix = expected["suffix"]
+    stage1_data = (PROJECT_ROOT / "build" / f"stage1{suffix}.bin").read_bytes()
+    symbols = _load_symbols(
+        PROJECT_ROOT / "build" / f"stage1{suffix}.lst",
+        "S1_BASE",
+        "SDFS_LOAD_BASE",
+    )
+    dest = symbols["SDFS_LOAD_BASE"]
+    harness_addr = 0x0100
+    harness = [
+        0xBD, ((symbols["S1_BASE"] + 16) >> 8) & 0xFF, (symbols["S1_BASE"] + 16) & 0xFF,
+        0x25, 0x0B,
+        0xBD, ((symbols["S1_BASE"] + 22) >> 8) & 0xFF, (symbols["S1_BASE"] + 22) & 0xFF,
+        0x25, 0x06,
+        0x86, 0x42,
+        0xB7, (dest >> 8) & 0xFF, dest & 0xFF,
+        0x3F,
+        0x86, 0xE1,
+        0xB7, (dest >> 8) & 0xFF, dest & 0xFF,
+        0x3F,
+    ]
+    input_text = (
+        f"M{symbols['S1_BASE']:04X}\r"
+        f"{_hex_bytes(list(stage1_data))}\r.\r"
+        f"M{harness_addr:04X}\r"
+        f"{_hex_bytes(harness)}\r.\r"
+        f"G{harness_addr:04X}\r"
+        f"D{dest:04X}-{dest:04X}\r"
+        "\r"
+    )
+    stdout, stderr, rc = _run_emu_with_sd(
+        rom_path=PROJECT_ROOT / "build" / "mc6800-monitor-sbcio-vdg.bin",
+        input_text=input_text,
+        sd_image=sd_image,
+    )
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    line = _dump_line(stdout, dest)
+    match = re.search(rf"{dest:04X}\s+([0-9A-Fa-f]{{2}})", line)
+    if not match:
+        raise AssertionError(f"missing mount result byte: {line!r}\nstdout={stdout!r}")
+    return int(match.group(1), 16)
 
 
 def _run_emu_with_sd(
@@ -251,6 +312,8 @@ def main() -> None:
         test_stage1_rejects_base_profile,
         test_stage1_profiles_build_and_match_layout,
         test_stage1_read_sector_service_reads_known_fixture_sector,
+        test_stage1_mount_service_accepts_fat32_fixtures,
+        test_stage1_mount_service_rejects_invalid_fat32,
     ]
     passed = 0
     failed = 0


### PR DESCRIPTION
## Summary
- stage1の `S1_MOUNT` を既存 `FAT32_MOUNT` へ接続
- `fat32.asm` のfile API部分を条件アセンブル化し、stage1ではmount/BPB解析だけを含める
- `S1_GET_ERROR` でFATエラーを優先し、なければSDエラーを返すよう更新
- stage1 RAMロード後にMBRあり/なしFAT32 mount成功と不正FAT32失敗を確認するテストを追加
- #117の実装方針を `docs/plans/` に記録

## 対象外
- `S1_FIND_83` の実装
- `S1_LOAD_FILE_83` の実装
- `SDFS.BIN` 読み込みとheader検査
- ROM `BOOT` 実装
- SDFS/68本体

## 確認内容
- `git diff --check`
- `python3 tests/test_stage1_build.py`
- `MONITOR_PROFILE=sbcio_vdg make stage1`
- `MONITOR_PROFILE=k6802_vdg make stage1`
- stage1 binary size: 1339 bytes / 2048 bytes
- `make bin`
- `REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py`
- `REQUIRE_BUILD_ROM=1 python3 tests/test_sd_fixture.py`
- `python3 tests/test_mk_sdfs_image.py`

Closes #117
Refs #82 #101 #102 #103 #109 #111 #113 #115