### PR TITLE
feat: stage1 root 8.3検索を実装

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@
 - [plans/issue-113_stage1_header_build.md](plans/issue-113_stage1_header_build.md): SDFS/68 stage1 header / jump table とビルド基盤
 - [plans/issue-115_stage1_sd_read.md](plans/issue-115_stage1_sd_read.md): SDFS/68 stage1 SD raw sector read boot services
 - [plans/issue-117_stage1_fat_mount.md](plans/issue-117_stage1_fat_mount.md): SDFS/68 stage1 FAT32 mount boot service
+- [plans/issue-119_stage1_find_83.md](plans/issue-119_stage1_find_83.md): SDFS/68 stage1 root 8.3 find boot service
 - [testing/sbc6800_bringup.md](testing/sbc6800_bringup.md)
 - [testing/sbc_io_sd_bringup.md](testing/sbc_io_sd_bringup.md): SBC-IO と microSD SPI モジュールで SD/FAT を実機確認する手順
 - [testing/sbc6800_datapack.md](testing/sbc6800_datapack.md): SBC6800 データパックの扱いと互換確認

--- a/docs/plans/issue-119_stage1_find_83.md
+++ b/docs/plans/issue-119_stage1_find_83.md
@@ -1,0 +1,43 @@
+# Issue #119 stage1 root 8.3 find
+
+## 関連リンク
+
+- Issue #119: https://github.com/kuninet/mc6800-rom-monitor/issues/119
+- Issue #111: https://github.com/kuninet/mc6800-rom-monitor/issues/111
+- Issue #117: https://github.com/kuninet/mc6800-rom-monitor/issues/117
+
+## 方針
+
+#117 でstage1 boot servicesにFAT32 mountを接続した。次の段階として、`S1_FIND_83` を `FAT32_FIND_83` へ接続し、mount済みFAT32 root directoryから8.3 short filenameを検索できるようにする。
+
+このIssueでは検索だけに絞る。`S1_LOAD_FILE_83`、SDFS/68 header検査、entry jumpは後続Issueに残す。stage1の2KB枠はかなり狭くなっているため、file read / stream APIはまだstage1へ含めない。
+
+## 実装内容
+
+- `S1_FIND_83` を `FAT32_FIND_83` へ接続する。
+- `src/fat32.asm` に `FAT32_INCLUDE_FIND_API` を追加する。
+- stage1では mount API と find API までを含め、file read / stream APIは除外する。
+- monitor本体では従来どおり find API と file API の両方を含める。
+
+## API前提
+
+`S1_FIND_83` は既存 `FAT32_FIND_83` と同じ呼び出し規約を踏襲する。
+
+- 入力: `X` が11 byteのFAT 8.3名を指す。
+- 成功: carry clear、`FAT_FILE_CLUS*` と `FAT_FILE_SIZE*` に見つかったentryの情報を保持する。
+- 失敗: carry set、`FAT_ERROR` に既存FATエラーコードを保持する。
+
+## 対象外
+
+- `S1_LOAD_FILE_83` の実装。
+- `SDFS.BIN` 実ロード。
+- SDFS/68 header検査。
+- ROM `BOOT` 実装。
+- SDFS/68本体実装。
+
+## 検証方針
+
+- stage1 binaryが `S1_LIMIT` を超えないことを確認する。
+- stage1 binaryをRAMへロードし、`S1_INIT` -> `S1_MOUNT` -> `S1_FIND_83` でroot上の `TEST.S` を検索できることを確認する。
+- root directory cluster chain上の後続entryを検索できることを確認する。
+- 存在しない8.3名で `S1_FIND_83` が失敗し、ハングしないことを確認する。

--- a/src/fat32.asm
+++ b/src/fat32.asm
@@ -333,7 +333,7 @@ FAT_FAIL_A:
         sec
         rts
 
- if FAT32_INCLUDE_FILE_API
+ if FAT32_INCLUDE_FIND_API
 FAT32_FIND_83:
         jsr     FAT_COPY_FIND_NAME
         jsr     FAT_COPY_ROOT_TO_CUR
@@ -392,6 +392,7 @@ FAT_FIND_NOT_FOUND:
         ldaa    #FAT_ERR_NOT_FOUND
         jmp     FAT_FAIL_A
 
+ if FAT32_INCLUDE_FILE_API
 FAT32_READ_FILE:
         stx     FAT_READ_PTR
         jsr     FAT_COPY_FILE_TO_CUR
@@ -490,6 +491,7 @@ FAT_STREAM_LOAD_OK:
         stx     FAT_ENTRY_PTR
         clc
         rts
+ endif
 
 FAT_COPY_FIND_NAME:
         ldaa    0,x
@@ -527,6 +529,7 @@ FAT_COPY_ROOT_TO_CUR:
         staa    FAT_CUR_CLUS3
         rts
 
+ if FAT32_INCLUDE_FILE_API
 FAT_COPY_FILE_TO_CUR:
         ldaa    FAT_FILE_CLUS0
         staa    FAT_CUR_CLUS0
@@ -537,6 +540,7 @@ FAT_COPY_FILE_TO_CUR:
         ldaa    FAT_FILE_CLUS3
         staa    FAT_CUR_CLUS3
         rts
+ endif
 
 FAT_COPY_NEXT_TO_CUR:
         ldaa    FAT_NEXT_CLUS0
@@ -549,6 +553,7 @@ FAT_COPY_NEXT_TO_CUR:
         staa    FAT_CUR_CLUS3
         rts
 
+ if FAT32_INCLUDE_FILE_API
 FAT_COPY_FILE_SIZE_TO_REM:
         ldaa    FAT_FILE_SIZE0
         staa    FAT_BYTES_REM0
@@ -559,6 +564,7 @@ FAT_COPY_FILE_SIZE_TO_REM:
         ldaa    FAT_FILE_SIZE3
         staa    FAT_BYTES_REM3
         rts
+ endif
 
 FAT_COMPARE_ENTRY_NAME:
         ldx     FAT_ENTRY_PTR
@@ -656,6 +662,7 @@ FAT_CLUSTER_ADD_SECTOR_LOOP:
 FAT_CLUSTER_ADD_DONE:
         rts
 
+ if FAT32_INCLUDE_FILE_API
 FAT_SECTOR_TO_SD_LBA:
         jsr     FAT_CLUSTER_TO_SD_LBA
         ldab    FAT_SECTOR_IN_CLUS
@@ -666,6 +673,7 @@ FAT_SECTOR_TO_SD_LBA_LOOP:
         bne     FAT_SECTOR_TO_SD_LBA_LOOP
 FAT_SECTOR_TO_SD_LBA_DONE:
         rts
+ endif
 
 FAT_INC_SD_LBA:
         inc     SD_LBA3
@@ -733,6 +741,7 @@ FAT_NEXT_NOT_EOC:
         clc
         rts
 
+ if FAT32_INCLUDE_FILE_API
 FAT_ADVANCE_FILE_SECTOR:
         inc     FAT_SECTOR_IN_CLUS
         ldaa    FAT_SECTOR_IN_CLUS
@@ -842,4 +851,5 @@ FAT_DEC_REM_B2:
 FAT_DEC_REM_LO:
         dec     FAT_BYTES_REM3
         rts
+ endif
  endif

--- a/src/main.asm
+++ b/src/main.asm
@@ -2363,6 +2363,7 @@ SPURIOUS_IRQ:
 
         include "acia6850.asm"
  if MONITOR_FEATURE_SD
+FAT32_INCLUDE_FIND_API equ 1
 FAT32_INCLUDE_FILE_API equ 1
         include "sdcard.asm"
         include "fat32.asm"

--- a/src/stage1.asm
+++ b/src/stage1.asm
@@ -44,9 +44,7 @@ S1_MOUNT:
         jmp     FAT32_MOUNT
 
 S1_FIND_83:
-        ldaa    #S1_ERR_UNIMPL
-        sec
-        rts
+        jmp     FAT32_FIND_83
 
 S1_LOAD_FILE_83:
         ldaa    #S1_ERR_UNIMPL
@@ -61,6 +59,7 @@ S1_GET_ERROR_DONE:
         clc
         rts
 
+FAT32_INCLUDE_FIND_API equ 1
 FAT32_INCLUDE_FILE_API equ 0
 
         include "sdcard.asm"

--- a/tests/test_stage1_build.py
+++ b/tests/test_stage1_build.py
@@ -149,6 +149,30 @@ def test_stage1_mount_service_rejects_invalid_fat32() -> None:
     print("[PASS] test_stage1_mount_service_rejects_invalid_fat32")
 
 
+def test_stage1_find_83_service_finds_root_entries() -> None:
+    value = _run_stage1_find_harness(
+        build_fat32_image(with_mbr=True),
+        b"TEST    S  ",
+    )
+    assert value == 0x42, f"S1_FIND_83 failed to find TEST.S: {value:02X}"
+
+    value = _run_stage1_find_harness(
+        build_fat32_image(with_mbr=True, root_chain=True),
+        b"LATE    BIN",
+    )
+    assert value == 0x42, f"S1_FIND_83 failed to find chained root entry: {value:02X}"
+    print("[PASS] test_stage1_find_83_service_finds_root_entries")
+
+
+def test_stage1_find_83_service_rejects_missing_name() -> None:
+    value = _run_stage1_find_harness(
+        build_fat32_image(with_mbr=True),
+        b"NOPE    BIN",
+    )
+    assert value == 0xE1, f"S1_FIND_83 unexpectedly found missing file: {value:02X}"
+    print("[PASS] test_stage1_find_83_service_rejects_missing_name")
+
+
 def _assert_stage1_header(data: bytes) -> None:
     assert data[0:7] == b"S1API68"
     assert data[7] == 1, "API version mismatch"
@@ -229,6 +253,62 @@ def _run_stage1_mount_harness(sd_image: bytes) -> int:
     match = re.search(rf"{dest:04X}\s+([0-9A-Fa-f]{{2}})", line)
     if not match:
         raise AssertionError(f"missing mount result byte: {line!r}\nstdout={stdout!r}")
+    return int(match.group(1), 16)
+
+
+def _run_stage1_find_harness(sd_image: bytes, fat_name: bytes) -> int:
+    if len(fat_name) != 11:
+        raise AssertionError("FAT name must be exactly 11 bytes")
+
+    profile = "sbcio_vdg"
+    _run_make(profile)
+    _run_make(profile, target="bin")
+    expected = EXPECTED[profile]
+    suffix = expected["suffix"]
+    stage1_data = (PROJECT_ROOT / "build" / f"stage1{suffix}.bin").read_bytes()
+    symbols = _load_symbols(
+        PROJECT_ROOT / "build" / f"stage1{suffix}.lst",
+        "S1_BASE",
+        "SDFS_LOAD_BASE",
+    )
+    dest = symbols["SDFS_LOAD_BASE"]
+    harness_addr = 0x0100
+    name_addr = harness_addr + 30
+    harness = [
+        0xBD, ((symbols["S1_BASE"] + 16) >> 8) & 0xFF, (symbols["S1_BASE"] + 16) & 0xFF,
+        0x25, 0x13,
+        0xBD, ((symbols["S1_BASE"] + 22) >> 8) & 0xFF, (symbols["S1_BASE"] + 22) & 0xFF,
+        0x25, 0x0E,
+        0xCE, (name_addr >> 8) & 0xFF, name_addr & 0xFF,
+        0xBD, ((symbols["S1_BASE"] + 25) >> 8) & 0xFF, (symbols["S1_BASE"] + 25) & 0xFF,
+        0x25, 0x06,
+        0x86, 0x42,
+        0xB7, (dest >> 8) & 0xFF, dest & 0xFF,
+        0x3F,
+        0x86, 0xE1,
+        0xB7, (dest >> 8) & 0xFF, dest & 0xFF,
+        0x3F,
+        *fat_name,
+    ]
+    input_text = (
+        f"M{symbols['S1_BASE']:04X}\r"
+        f"{_hex_bytes(list(stage1_data))}\r.\r"
+        f"M{harness_addr:04X}\r"
+        f"{_hex_bytes(harness)}\r.\r"
+        f"G{harness_addr:04X}\r"
+        f"D{dest:04X}-{dest:04X}\r"
+        "\r"
+    )
+    stdout, stderr, rc = _run_emu_with_sd(
+        rom_path=PROJECT_ROOT / "build" / "mc6800-monitor-sbcio-vdg.bin",
+        input_text=input_text,
+        sd_image=sd_image,
+    )
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    line = _dump_line(stdout, dest)
+    match = re.search(rf"{dest:04X}\s+([0-9A-Fa-f]{{2}})", line)
+    if not match:
+        raise AssertionError(f"missing find result byte: {line!r}\nstdout={stdout!r}")
     return int(match.group(1), 16)
 
 
@@ -314,6 +394,8 @@ def main() -> None:
         test_stage1_read_sector_service_reads_known_fixture_sector,
         test_stage1_mount_service_accepts_fat32_fixtures,
         test_stage1_mount_service_rejects_invalid_fat32,
+        test_stage1_find_83_service_finds_root_entries,
+        test_stage1_find_83_service_rejects_missing_name,
     ]
     passed = 0
     failed = 0


### PR DESCRIPTION
## Summary
- stage1の `S1_FIND_83` を既存 `FAT32_FIND_83` へ接続
- `fat32.asm` を find API と file API の2段階条件アセンブルに分割
- stage1ではmount/findまでを含め、file read / stream APIはまだ除外
- rootの `TEST.S`、root chain上の `LATE.BIN`、未検出名のstage1テストを追加
- #119の実装方針を `docs/plans/` に記録

## 対象外
- `S1_LOAD_FILE_83` の実装
- `SDFS.BIN` 読み込みとheader検査
- ROM `BOOT` 実装
- SDFS/68本体

## 確認内容
- `git diff --check`
- `python3 tests/test_stage1_build.py`
- `MONITOR_PROFILE=k6802_vdg make stage1`
- stage1 binary size: 1865 bytes / 2048 bytes
- `make bin`
- `REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py`
- `REQUIRE_BUILD_ROM=1 python3 tests/test_sd_fixture.py`
- `python3 tests/test_mk_sdfs_image.py`

Closes #119
Refs #82 #101 #102 #103 #109 #111 #113 #115 #117