### PR TITLE
feat: stage1 1-sector file loadを実装

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,7 @@
 - [plans/issue-115_stage1_sd_read.md](plans/issue-115_stage1_sd_read.md): SDFS/68 stage1 SD raw sector read boot services
 - [plans/issue-117_stage1_fat_mount.md](plans/issue-117_stage1_fat_mount.md): SDFS/68 stage1 FAT32 mount boot service
 - [plans/issue-119_stage1_find_83.md](plans/issue-119_stage1_find_83.md): SDFS/68 stage1 root 8.3 find boot service
+- [plans/issue-121_stage1_load_file_1sector.md](plans/issue-121_stage1_load_file_1sector.md): SDFS/68 stage1 1-sector file load boot service
 - [testing/sbc6800_bringup.md](testing/sbc6800_bringup.md)
 - [testing/sbc_io_sd_bringup.md](testing/sbc_io_sd_bringup.md): SBC-IO と microSD SPI モジュールで SD/FAT を実機確認する手順
 - [testing/sbc6800_datapack.md](testing/sbc6800_datapack.md): SBC6800 データパックの扱いと互換確認

--- a/docs/plans/issue-121_stage1_load_file_1sector.md
+++ b/docs/plans/issue-121_stage1_load_file_1sector.md
@@ -1,0 +1,38 @@
+# Issue #121 stage1 SDFS.BIN 1-sector loader
+
+## 関連リンク
+
+- Issue #121: https://github.com/kuninet/mc6800-rom-monitor/issues/121
+- Issue #111: https://github.com/kuninet/mc6800-rom-monitor/issues/111
+- Issue #119: https://github.com/kuninet/mc6800-rom-monitor/issues/119
+
+## 方針
+
+#119 でstage1 boot servicesはFAT32 mountとroot 8.3検索まで対応した。次の `S1_LOAD_FILE_83` では、既存の汎用 `FAT32_READ_FILE` をそのままstage1へ入れない。現状のstage1は約1865 bytesで、汎用file APIを含めると2KB枠を超えるためである。
+
+このIssueでは、v1の最小loaderとして **1 sector / 512 byte以下の8.3ファイルだけ** を `SDFS_LOAD_BASE` へ読む。512 byte超、0 byte、cluster chainをたどるロードは後続Issueで扱う。
+
+## 実装内容
+
+- `S1_LOAD_FILE_83` を実装する。
+- 入力は `X` が11 byteのFAT 8.3名を指す。
+- 内部で `FAT32_FIND_83` を呼ぶ。
+- file size が `1..512` byte の場合だけ、開始clusterの先頭sectorを `SDFS_LOAD_BASE` へ読む。
+- file size が `0` または `512` byte超の場合は `FAT_ERR_SIZE` で失敗する。
+- `FAT32_READ_FILE`、`FAT32_STREAM_*`、汎用file copy APIはstage1へ含めない。
+
+## 対象外
+
+- 512 byte超の `SDFS.BIN` 対応。
+- cluster内複数sector対応。
+- FAT chainをたどるfile load。
+- SDFS/68 header検査。
+- SDFS/68 entry jump。
+- ROM `BOOT` 実装。
+
+## 検証方針
+
+- stage1 binaryが `S1_LIMIT` を超えないことを確認する。
+- stage1 binaryをRAMへロードし、root上の `TEST.S` を `SDFS_LOAD_BASE` へ読めることを確認する。
+- `MULTI.BIN` のような512 byte超ファイルは失敗することを確認する。
+- 存在しない8.3名で失敗し、ハングしないことを確認する。

--- a/include/hardware.inc
+++ b/include/hardware.inc
@@ -171,6 +171,7 @@ FAT_ERR_MBR      equ 3
 FAT_ERR_BPB      equ 4
 FAT_ERR_NOT_FOUND equ 5
 FAT_ERR_CHAIN    equ 6
+FAT_ERR_SIZE     equ 7
  endif
 
 LOAD_MODE_NONE   equ 0

--- a/src/stage1.asm
+++ b/src/stage1.asm
@@ -47,8 +47,47 @@ S1_FIND_83:
         jmp     FAT32_FIND_83
 
 S1_LOAD_FILE_83:
-        ldaa    #S1_ERR_UNIMPL
-        sec
+        jsr     FAT32_FIND_83
+        bcc     S1_LOAD_CHECK_SIZE
+        rts
+S1_LOAD_CHECK_SIZE:
+        ldaa    FAT_FILE_SIZE0
+        oraa    FAT_FILE_SIZE1
+        bne     S1_LOAD_SIZE_FAIL
+        ldaa    FAT_FILE_SIZE2
+        cmpa    #$02
+        bhi     S1_LOAD_SIZE_FAIL
+        bne     S1_LOAD_NONZERO
+        ldaa    FAT_FILE_SIZE3
+        bne     S1_LOAD_SIZE_FAIL
+S1_LOAD_NONZERO:
+        ldaa    FAT_FILE_SIZE2
+        oraa    FAT_FILE_SIZE3
+        beq     S1_LOAD_SIZE_FAIL
+        jsr     S1_COPY_FILE_TO_CUR
+        jsr     FAT_CLUSTER_TO_SD_LBA
+        ldx     #SDFS_LOAD_BASE
+        jsr     SD_READ_SECTOR
+        bcc     S1_LOAD_OK
+        ldaa    #FAT_ERR_SD
+        jmp     FAT_FAIL_A
+S1_LOAD_OK:
+        clr     FAT_ERROR
+        clc
+        rts
+S1_LOAD_SIZE_FAIL:
+        ldaa    #FAT_ERR_SIZE
+        jmp     FAT_FAIL_A
+
+S1_COPY_FILE_TO_CUR:
+        ldaa    FAT_FILE_CLUS0
+        staa    FAT_CUR_CLUS0
+        ldaa    FAT_FILE_CLUS1
+        staa    FAT_CUR_CLUS1
+        ldaa    FAT_FILE_CLUS2
+        staa    FAT_CUR_CLUS2
+        ldaa    FAT_FILE_CLUS3
+        staa    FAT_CUR_CLUS3
         rts
 
 S1_GET_ERROR:

--- a/tests/test_stage1_build.py
+++ b/tests/test_stage1_build.py
@@ -16,6 +16,7 @@ sys.path.insert(0, str(PROJECT_ROOT / "tests"))
 from sd_fixtures import (  # noqa: E402
     MULTI_CLUSTER_1,
     MULTI_CLUSTER_1_PREFIX,
+    TEST_S_CONTENT,
     build_fat32_image,
     layout_for_image,
 )
@@ -173,6 +174,34 @@ def test_stage1_find_83_service_rejects_missing_name() -> None:
     print("[PASS] test_stage1_find_83_service_rejects_missing_name")
 
 
+def test_stage1_load_file_83_service_loads_one_sector_file() -> None:
+    result, data = _run_stage1_load_harness(
+        build_fat32_image(with_mbr=True),
+        b"TEST    S  ",
+        len(TEST_S_CONTENT),
+    )
+    assert result == 0x42, f"S1_LOAD_FILE_83 failed to load TEST.S: {result:02X}"
+    assert bytes(data[:len(TEST_S_CONTENT)]) == TEST_S_CONTENT
+    print("[PASS] test_stage1_load_file_83_service_loads_one_sector_file")
+
+
+def test_stage1_load_file_83_service_rejects_unsupported_files() -> None:
+    result, _data = _run_stage1_load_harness(
+        build_fat32_image(with_mbr=True),
+        b"MULTI   BIN",
+        16,
+    )
+    assert result == 0xE1, f"S1_LOAD_FILE_83 accepted >512 byte file: {result:02X}"
+
+    result, _data = _run_stage1_load_harness(
+        build_fat32_image(with_mbr=True),
+        b"NOPE    BIN",
+        16,
+    )
+    assert result == 0xE1, f"S1_LOAD_FILE_83 accepted missing file: {result:02X}"
+    print("[PASS] test_stage1_load_file_83_service_rejects_unsupported_files")
+
+
 def _assert_stage1_header(data: bytes) -> None:
     assert data[0:7] == b"S1API68"
     assert data[7] == 1, "API version mismatch"
@@ -312,6 +341,71 @@ def _run_stage1_find_harness(sd_image: bytes, fat_name: bytes) -> int:
     return int(match.group(1), 16)
 
 
+def _run_stage1_load_harness(
+    sd_image: bytes,
+    fat_name: bytes,
+    dump_size: int,
+) -> tuple[int, list[int]]:
+    if len(fat_name) != 11:
+        raise AssertionError("FAT name must be exactly 11 bytes")
+    if dump_size <= 0:
+        raise AssertionError("dump_size must be positive")
+
+    profile = "sbcio_vdg"
+    _run_make(profile)
+    _run_make(profile, target="bin")
+    expected = EXPECTED[profile]
+    suffix = expected["suffix"]
+    stage1_data = (PROJECT_ROOT / "build" / f"stage1{suffix}.bin").read_bytes()
+    symbols = _load_symbols(
+        PROJECT_ROOT / "build" / f"stage1{suffix}.lst",
+        "S1_BASE",
+        "SDFS_LOAD_BASE",
+    )
+    dest = symbols["SDFS_LOAD_BASE"]
+    result_addr = dest + 0x0200
+    harness_addr = 0x0100
+    name_addr = harness_addr + 30
+    harness = [
+        0xBD, ((symbols["S1_BASE"] + 16) >> 8) & 0xFF, (symbols["S1_BASE"] + 16) & 0xFF,
+        0x25, 0x13,
+        0xBD, ((symbols["S1_BASE"] + 22) >> 8) & 0xFF, (symbols["S1_BASE"] + 22) & 0xFF,
+        0x25, 0x0E,
+        0xCE, (name_addr >> 8) & 0xFF, name_addr & 0xFF,
+        0xBD, ((symbols["S1_BASE"] + 28) >> 8) & 0xFF, (symbols["S1_BASE"] + 28) & 0xFF,
+        0x25, 0x06,
+        0x86, 0x42,
+        0xB7, (result_addr >> 8) & 0xFF, result_addr & 0xFF,
+        0x3F,
+        0x86, 0xE1,
+        0xB7, (result_addr >> 8) & 0xFF, result_addr & 0xFF,
+        0x3F,
+        *fat_name,
+    ]
+    input_text = (
+        f"M{symbols['S1_BASE']:04X}\r"
+        f"{_hex_bytes(list(stage1_data))}\r.\r"
+        f"M{harness_addr:04X}\r"
+        f"{_hex_bytes(harness)}\r.\r"
+        f"G{harness_addr:04X}\r"
+        f"D{result_addr:04X}-{result_addr:04X}\r"
+        f"D{dest:04X}-{dest + dump_size - 1:04X}\r"
+        "\r"
+    )
+    stdout, stderr, rc = _run_emu_with_sd(
+        rom_path=PROJECT_ROOT / "build" / "mc6800-monitor-sbcio-vdg.bin",
+        input_text=input_text,
+        sd_image=sd_image,
+        max_cycles=100_000_000,
+    )
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    result_line = _dump_line(stdout, result_addr)
+    match = re.search(rf"{result_addr:04X}\s+([0-9A-Fa-f]{{2}})", result_line)
+    if not match:
+        raise AssertionError(f"missing load result byte: {result_line!r}\nstdout={stdout!r}")
+    return int(match.group(1), 16), _parse_dump_bytes(stdout, dest)
+
+
 def _run_emu_with_sd(
     *,
     rom_path: Path,
@@ -365,6 +459,28 @@ def _dump_line(stdout: str, address: int) -> str:
     raise AssertionError(f"missing dump line {marker}: {stdout!r}")
 
 
+def _parse_dump_bytes(stdout: str, address: int) -> list[int]:
+    values: list[int] = []
+    current = address
+    while True:
+        try:
+            line = _dump_line(stdout, current)
+        except AssertionError:
+            break
+        fields = line.split()
+        line_values: list[int] = []
+        for field in fields[1:17]:
+            try:
+                line_values.append(int(field, 16))
+            except ValueError:
+                break
+        if not line_values:
+            break
+        values.extend(line_values)
+        current += len(line_values)
+    return values
+
+
 def _load_symbols(path: Path, *names: str) -> dict[str, int]:
     text = path.read_text(encoding="utf-8", errors="replace")
     result: dict[str, int] = {}
@@ -396,6 +512,8 @@ def main() -> None:
         test_stage1_mount_service_rejects_invalid_fat32,
         test_stage1_find_83_service_finds_root_entries,
         test_stage1_find_83_service_rejects_missing_name,
+        test_stage1_load_file_83_service_loads_one_sector_file,
+        test_stage1_load_file_83_service_rejects_unsupported_files,
     ]
     passed = 0
     failed = 0


### PR DESCRIPTION
## Summary
- `S1_LOAD_FILE_83` を1 sector / 512 byte以下のfile loaderとして実装
- `FAT32_READ_FILE` / stream APIをstage1へ含めず、2KB枠内を維持
- 0 byte / 512 byte超ファイル用に `FAT_ERR_SIZE` を追加
- stage1 RAMロード後に `TEST.S` を `SDFS_LOAD_BASE` へ読むテストを追加
- 512 byte超の `MULTI.BIN` と未検出名が失敗するテストを追加
- #121の実装方針を `docs/plans/` に記録

## 対象外
- 512 byte超の `SDFS.BIN` 対応
- cluster内複数sector対応
- FAT chainをたどるfile load
- SDFS/68 header検査とentry jump
- ROM `BOOT` 実装

## 確認内容
- `git diff --check`
- `python3 tests/test_stage1_build.py`
- `MONITOR_PROFILE=k6802_vdg make stage1`
- stage1 binary size: 1951 bytes / 2048 bytes
- `make bin`
- `REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py`
- `REQUIRE_BUILD_ROM=1 python3 tests/test_sd_fixture.py`
- `python3 tests/test_mk_sdfs_image.py`

Closes #121
Refs #82 #101 #102 #103 #109 #111 #113 #115 #117 #119