### PR TITLE
feat: stage1にSDFS起動入口を追加

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@
 - [plans/issue-119_stage1_find_83.md](plans/issue-119_stage1_find_83.md): SDFS/68 stage1 root 8.3 find boot service
 - [plans/issue-121_stage1_load_file_1sector.md](plans/issue-121_stage1_load_file_1sector.md): SDFS/68 stage1 1-sector file load boot service
 - [plans/issue-123_stage1_memory_3kb.md](plans/issue-123_stage1_memory_3kb.md): SDFS/68 stage1 3KB配置
+- [plans/issue-125_stage1_sdfs_entry.md](plans/issue-125_stage1_sdfs_entry.md): SDFS/68 stage1 header検査とentry jump
 - [testing/sbc6800_bringup.md](testing/sbc6800_bringup.md)
 - [testing/sbc_io_sd_bringup.md](testing/sbc_io_sd_bringup.md): SBC-IO と microSD SPI モジュールで SD/FAT を実機確認する手順
 - [testing/sbc6800_datapack.md](testing/sbc6800_datapack.md): SBC6800 データパックの扱いと互換確認

--- a/docs/plans/issue-113_stage1_header_build.md
+++ b/docs/plans/issue-113_stage1_header_build.md
@@ -20,7 +20,9 @@ stage1 binaryは `S1_BASE` から始まる。
 | `+7` | API version。v1は `1` |
 | `+8` | API count。v1は `6` |
 | `+9` | flags。v1は `0` |
-| `+10` - `+15` | reserved。すべて `0` |
+| `+10` - `+11` | stage1 boot entry address |
+| `+12` - `+13` | stage1 image size |
+| `+14` - `+15` | reserved。すべて `0` |
 | `+16` | jump table開始 |
 
 jump tableはMC6800の3byte `jmp` 命令列にする。

--- a/docs/plans/issue-125_stage1_sdfs_entry.md
+++ b/docs/plans/issue-125_stage1_sdfs_entry.md
@@ -1,0 +1,38 @@
+# Issue #125 stage1 SDFS/68 header検査とentry jump
+
+## 関連リンク
+
+- Issue #125: https://github.com/kuninet/mc6800-rom-monitor/issues/125
+- Issue #111: https://github.com/kuninet/mc6800-rom-monitor/issues/111
+- Issue #123: https://github.com/kuninet/mc6800-rom-monitor/issues/123
+
+## 方針
+
+#121 で stage1 は root の8.3ファイルを1 sectorだけ `SDFS_LOAD_BASE` へ読めるようになった。#123 で3KB枠へ拡張したため、このIssueでは `SDFS.BIN` を第2段として起動する最小入口を追加する。
+
+ROM側 #101 は固定LBAからstage1を読むだけに寄せるため、FAT rootの `SDFS.BIN` 検索、SDFS/68 header検査、entry jumpはstage1側の責務にする。
+
+## 実装内容
+
+- stage1 headerの既存reserved領域 `+10` - `+15` を次の用途に固定する。
+  - `+10` - `+11`: stage1 boot entry address。
+  - `+12` - `+13`: stage1 image size。
+  - `+14` - `+15`: reserved。v1では `0`。
+- `S1_BOOT_SDFS` を追加し、stage1 headerからROM側が参照できるようにする。
+- `S1_BOOT_SDFS` は `S1_MOUNT`、root 8.3名 `SDFS    BIN` のロード、SDFS/68 header検査を順に行う。
+- SDFS/68 headerは `SDFS68` signature、version `1`、header size `16`、load size、entry addressを検査する。
+- 正常時はSDFS/68 entryへ `jmp` する。
+- 失敗時はcarry setで呼び出し元へ戻る。
+
+## v1制約
+
+現時点の `S1_LOAD_FILE_83` は1 sector loaderなので、`SDFS.BIN` は1..512 bytesのみ対応する。512 byte超ロード、cluster chain対応、SDFS/68本体の実装は後続Issueで扱う。
+
+entry addressは `SDFS_LOAD_BASE` から、SDFS/68 headerが宣言するload sizeの範囲内であることを確認する。v1では現行loaderに合わせてload sizeが512 byte以内であることも確認する。
+
+## 検証方針
+
+- stage1 headerのboot entryとimage sizeをbinaryから確認する。
+- 正しい `SDFS.BIN` headerで、entryへ制御が渡ることをエミュレータで確認する。
+- signature、version、header size、entry、sizeが不正な場合にcarry setで戻ることを確認する。
+- 既存のstage1 SD read / mount / find / 1-sector loadテストを維持する。

--- a/docs/plans/issue-82_sd_bootstrap_dos.md
+++ b/docs/plans/issue-82_sd_bootstrap_dos.md
@@ -70,6 +70,9 @@ stage1 loader には短い header と jump table を置く。初期案は次の�
 | `+7` | API version |
 | `+8` | API count |
 | `+9` | flags |
+| `+10` - `+11` | stage1 boot entry address |
+| `+12` - `+13` | stage1 image size |
+| `+14` - `+15` | reserved |
 | `+16` | `jmp S1_INIT` |
 | `+19` | `jmp S1_READ_SECTOR` |
 | `+22` | `jmp S1_MOUNT` |

--- a/src/stage1.asm
+++ b/src/stage1.asm
@@ -7,6 +7,8 @@ S1_API_COUNT    equ 6
 S1_FLAG_NONE    equ 0
 S1_ERR_NONE     equ 0
 S1_ERR_UNIMPL   equ 1
+S1_LOAD_MAX_HI  equ 2
+S1_LOAD_MAX_LO  equ 0
 
 SDFS_VERSION    equ 1
 SDFS_HDR_SIZE   equ 16
@@ -22,7 +24,9 @@ S1_HEADER:
         fcb     S1_API_VERSION
         fcb     S1_API_COUNT
         fcb     S1_FLAG_NONE
-        fcb     0,0,0,0,0,0
+        fdb     S1_BOOT_SDFS
+        fdb     S1_END-S1_BASE
+        fcb     0,0
 
 S1_JUMP_TABLE:
         jmp     S1_INIT
@@ -79,6 +83,82 @@ S1_LOAD_SIZE_FAIL:
         ldaa    #FAT_ERR_SIZE
         jmp     FAT_FAIL_A
 
+S1_BOOT_SDFS:
+        jsr     S1_MOUNT
+        bcs     S1_BOOT_DONE
+        ldx     #S1_SDFS_NAME
+        jsr     S1_LOAD_FILE_83
+        bcs     S1_BOOT_DONE
+        jsr     S1_VALIDATE_SDFS
+        bcs     S1_BOOT_DONE
+        ldx     SDFS_LOAD_BASE+8
+        jmp     0,x
+S1_BOOT_DONE:
+        rts
+
+S1_VALIDATE_SDFS:
+        ldx     #SDFS_LOAD_BASE
+        ldaa    0,x
+        cmpa    #'S'
+        bne     S1_SDFS_SIG_FAIL
+        ldaa    1,x
+        cmpa    #'D'
+        bne     S1_SDFS_SIG_FAIL
+        ldaa    2,x
+        cmpa    #'F'
+        bne     S1_SDFS_SIG_FAIL
+        ldaa    3,x
+        cmpa    #'S'
+        bne     S1_SDFS_SIG_FAIL
+        ldaa    4,x
+        cmpa    #'6'
+        bne     S1_SDFS_SIG_FAIL
+        ldaa    5,x
+        cmpa    #'8'
+        bne     S1_SDFS_SIG_FAIL
+        ldaa    6,x
+        cmpa    #SDFS_VERSION
+        bne     S1_SDFS_SIG_FAIL
+        ldaa    7,x
+        cmpa    #SDFS_HDR_SIZE
+        bne     S1_SDFS_SIG_FAIL
+
+        ldaa    10,x
+        oraa    11,x
+        beq     S1_SDFS_SIZE_FAIL
+        ldaa    10,x
+        cmpa    #S1_LOAD_MAX_HI
+        bhi     S1_SDFS_SIZE_FAIL
+        blo     S1_SDFS_CHECK_ENTRY
+        ldaa    11,x
+        cmpa    #S1_LOAD_MAX_LO
+        bhi     S1_SDFS_SIZE_FAIL
+
+S1_SDFS_CHECK_ENTRY:
+        ldaa    8,x
+        suba    #SDFS_LOAD_BASE/256
+        bcs     S1_SDFS_SIZE_FAIL
+        staa    FAT_TMP
+        cmpa    #S1_LOAD_MAX_HI
+        bhs     S1_SDFS_SIZE_FAIL
+        ldaa    FAT_TMP
+        cmpa    10,x
+        bhi     S1_SDFS_SIZE_FAIL
+        blo     S1_SDFS_ENTRY_OK
+        ldaa    9,x
+        cmpa    11,x
+        bhs     S1_SDFS_SIZE_FAIL
+S1_SDFS_ENTRY_OK:
+        clr     FAT_ERROR
+        clc
+        rts
+S1_SDFS_SIG_FAIL:
+        ldaa    #FAT_ERR_SIG
+        jmp     FAT_FAIL_A
+S1_SDFS_SIZE_FAIL:
+        ldaa    #FAT_ERR_SIZE
+        jmp     FAT_FAIL_A
+
 S1_COPY_FILE_TO_CUR:
         ldaa    FAT_FILE_CLUS0
         staa    FAT_CUR_CLUS0
@@ -97,6 +177,9 @@ S1_GET_ERROR:
 S1_GET_ERROR_DONE:
         clc
         rts
+
+S1_SDFS_NAME:
+        fcc     "SDFS    BIN"
 
 FAT32_INCLUDE_FIND_API equ 1
 FAT32_INCLUDE_FILE_API equ 0

--- a/tests/test_stage1_build.py
+++ b/tests/test_stage1_build.py
@@ -20,6 +20,7 @@ from sd_fixtures import (  # noqa: E402
     build_fat32_image,
     layout_for_image,
 )
+from fat32_image import Fat32File, build_fat32_image_from_files  # noqa: E402
 
 EMU_PATH = PROJECT_ROOT / "emu" / "sbc6800_emu.py"
 
@@ -68,6 +69,7 @@ def test_stage1_profiles_build_and_match_layout() -> None:
             "S1_FIND_83",
             "S1_LOAD_FILE_83",
             "S1_GET_ERROR",
+            "S1_BOOT_SDFS",
             "S1_END",
         )
         assert symbols["S1_BASE"] == expected["S1_BASE"], f"{profile} S1_BASE mismatch"
@@ -79,7 +81,7 @@ def test_stage1_profiles_build_and_match_layout() -> None:
             f"{profile} SDFS_LOAD_LIMIT mismatch"
         )
         assert len(data) <= symbols["S1_LIMIT"] - symbols["S1_BASE"] + 1
-        _assert_stage1_header(data)
+        _assert_stage1_header(data, symbols["S1_BOOT_SDFS"])
         _assert_jump(data, 16, symbols["S1_INIT"])
         _assert_jump(data, 19, symbols["S1_READ_SECTOR"])
         _assert_jump(data, 22, symbols["S1_MOUNT"])
@@ -208,12 +210,39 @@ def test_stage1_load_file_83_service_rejects_unsupported_files() -> None:
     print("[PASS] test_stage1_load_file_83_service_rejects_unsupported_files")
 
 
-def _assert_stage1_header(data: bytes) -> None:
+def test_stage1_boot_sdfs_jumps_to_valid_entry() -> None:
+    result = _run_stage1_boot_harness(lambda dest, result_addr: _make_sdfs_bin(dest, result_addr))
+    assert result == 0x42, f"S1_BOOT_SDFS did not jump to SDFS entry: {result:02X}"
+    print("[PASS] test_stage1_boot_sdfs_jumps_to_valid_entry")
+
+
+def test_stage1_boot_sdfs_rejects_invalid_headers() -> None:
+    cases = [
+        ("bad signature", lambda data: data.__setitem__(0, ord("X"))),
+        ("bad version", lambda data: data.__setitem__(6, 2)),
+        ("bad header size", lambda data: data.__setitem__(7, 15)),
+        ("bad entry", lambda data: data.__setitem__(slice(8, 10), b"\x00\x00")),
+        ("entry outside size", lambda data: data.__setitem__(slice(8, 10), b"\xD1\x00")),
+        ("bad size", lambda data: data.__setitem__(slice(10, 12), b"\x02\x01")),
+    ]
+    for label, mutate in cases:
+        result = _run_stage1_boot_harness(
+            lambda dest, result_addr, mutate=mutate: _make_sdfs_bin(dest, result_addr, mutate=mutate)
+        )
+        assert result == 0xE1, f"S1_BOOT_SDFS accepted {label}: {result:02X}"
+    print("[PASS] test_stage1_boot_sdfs_rejects_invalid_headers")
+
+
+def _assert_stage1_header(data: bytes, boot_entry: int) -> None:
     assert data[0:7] == b"S1API68"
     assert data[7] == 1, "API version mismatch"
     assert data[8] == 6, "API count mismatch"
     assert data[9] == 0, "flags mismatch"
-    assert data[10:16] == bytes(6), "reserved bytes must be zero"
+    actual_boot_entry = (data[10] << 8) | data[11]
+    assert actual_boot_entry == boot_entry, "boot entry mismatch"
+    actual_image_size = (data[12] << 8) | data[13]
+    assert actual_image_size == len(data), "stage1 image size mismatch"
+    assert data[14:16] == bytes(2), "reserved bytes must be zero"
 
 
 def _assert_jump(data: bytes, offset: int, target: int) -> None:
@@ -412,6 +441,85 @@ def _run_stage1_load_harness(
     return int(match.group(1), 16), _parse_dump_bytes(stdout, dest)
 
 
+def _run_stage1_boot_harness(sdfs_factory) -> int:
+    profile = "sbcio_vdg"
+    _run_make(profile)
+    _run_make(profile, target="bin")
+    expected = EXPECTED[profile]
+    suffix = expected["suffix"]
+    stage1_data = (PROJECT_ROOT / "build" / f"stage1{suffix}.bin").read_bytes()
+    symbols = _load_symbols(
+        PROJECT_ROOT / "build" / f"stage1{suffix}.lst",
+        "S1_BASE",
+        "SDFS_LOAD_BASE",
+    )
+    dest = symbols["SDFS_LOAD_BASE"]
+    result_addr = dest + 0x0200
+    boot_entry = (stage1_data[10] << 8) | stage1_data[11]
+    sd_image = _build_sdfs_image(sdfs_factory(dest, result_addr))
+    harness_addr = 0x0100
+    harness = [
+        0xBD, (boot_entry >> 8) & 0xFF, boot_entry & 0xFF,
+        0x25, 0x06,
+        0x86, 0x99,
+        0xB7, (result_addr >> 8) & 0xFF, result_addr & 0xFF,
+        0x3F,
+        0x86, 0xE1,
+        0xB7, (result_addr >> 8) & 0xFF, result_addr & 0xFF,
+        0x3F,
+    ]
+    input_text = (
+        f"M{symbols['S1_BASE']:04X}\r"
+        f"{_hex_bytes(list(stage1_data))}\r.\r"
+        f"M{harness_addr:04X}\r"
+        f"{_hex_bytes(harness)}\r.\r"
+        f"G{harness_addr:04X}\r"
+        f"D{result_addr:04X}-{result_addr:04X}\r"
+        "\r"
+    )
+    stdout, stderr, rc = _run_emu_with_sd(
+        rom_path=PROJECT_ROOT / "build" / "mc6800-monitor-sbcio-vdg.bin",
+        input_text=input_text,
+        sd_image=sd_image,
+        max_cycles=100_000_000,
+    )
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    line = _dump_line(stdout, result_addr)
+    match = re.search(rf"{result_addr:04X}\s+([0-9A-Fa-f]{{2}})", line)
+    if not match:
+        raise AssertionError(f"missing boot result byte: {line!r}\nstdout={stdout!r}")
+    return int(match.group(1), 16)
+
+
+def _make_sdfs_bin(dest: int, result_addr: int, mutate=None) -> bytes:
+    entry = dest + 16
+    entry_code = [
+        0x86, 0x42,
+        0xB7, (result_addr >> 8) & 0xFF, result_addr & 0xFF,
+        0x3F,
+    ]
+    size = 16 + len(entry_code)
+    data = bytearray(size)
+    data[0:6] = b"SDFS68"
+    data[6] = 1
+    data[7] = 16
+    data[8:10] = entry.to_bytes(2, "big")
+    data[10:12] = size.to_bytes(2, "big")
+    data[16:] = bytes(entry_code)
+    if mutate is not None:
+        mutate(data)
+    return bytes(data)
+
+
+def _build_sdfs_image(sdfs_data: bytes) -> bytes:
+    image, _layout = build_fat32_image_from_files(
+        [Fat32File(b"SDFS    BIN", sdfs_data)],
+        with_mbr=True,
+        total_volume_sectors=64,
+    )
+    return image
+
+
 def _run_emu_with_sd(
     *,
     rom_path: Path,
@@ -520,6 +628,8 @@ def main() -> None:
         test_stage1_find_83_service_rejects_missing_name,
         test_stage1_load_file_83_service_loads_one_sector_file,
         test_stage1_load_file_83_service_rejects_unsupported_files,
+        test_stage1_boot_sdfs_jumps_to_valid_entry,
+        test_stage1_boot_sdfs_rejects_invalid_headers,
     ]
     passed = 0
     failed = 0


### PR DESCRIPTION
## Summary
- stage1 headerのreserved領域へboot entryとimage sizeを追加
- `S1_BOOT_SDFS` を追加し、FAT rootの `SDFS.BIN` ロードからSDFS/68 header検査、entry jumpまで接続
- `SDFS68` signature、version、header size、load size、entry範囲の検査を追加
- stage1 boot entry正常系と不正header拒否のエミュレータテストを追加
- #125の計画文書と関連docsを更新

## 対象外
- 512 byte超ロード
- FAT chain対応
- SDFS/68本体の実装
- ROM `BOOT` コマンド実装
- ROM側 `DIR` / `LF` 削減

## 確認内容
- `git diff --check`
- `python3 tests/test_stage1_build.py`
- `MONITOR_PROFILE=sbcio_vdg make stage1`
- `MONITOR_PROFILE=k6802_vdg make stage1`
- stage1 binary size: 2100 bytes / 3072 bytes
- `make bin`
- `REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py`
- `REQUIRE_BUILD_ROM=1 python3 tests/test_sd_fixture.py`
- `python3 tests/test_mk_sdfs_image.py`

Closes #125
Refs #82 #101 #102 #103 #109 #111 #113 #115 #117 #119 #121 #123