### PR TITLE
feat: ROMに固定LBA stage1 BOOTを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ PROFILE_TARGET_SUFFIX :=
 PROFILE_MEMORY_CONFIG := base8k
 PROFILE_BOARD_IO := none
 PROFILE_FEATURE_SD := 0
+PROFILE_FEATURE_FAT := 0
 PROFILE_FEATURE_VDG := 0
 PROFILE_FEATURE_KEYBOARD := 0
 PROFILE_FEATURE_I2C := 0
@@ -19,6 +20,7 @@ PROFILE_TARGET_SUFFIX := -sbcio
 PROFILE_MEMORY_CONFIG := ram64_c000_work
 PROFILE_BOARD_IO := sbcio
 PROFILE_FEATURE_SD := 1
+PROFILE_FEATURE_FAT := 1
 PROFILE_FEATURE_VDG := 0
 PROFILE_FEATURE_KEYBOARD := 1
 PROFILE_FEATURE_I2C := 0
@@ -28,6 +30,7 @@ PROFILE_TARGET_SUFFIX := -sbcio-vdg
 PROFILE_MEMORY_CONFIG := ram64_c000_work
 PROFILE_BOARD_IO := sbcio
 PROFILE_FEATURE_SD := 1
+PROFILE_FEATURE_FAT := 0
 PROFILE_FEATURE_VDG := 1
 PROFILE_FEATURE_KEYBOARD := 1
 PROFILE_FEATURE_I2C := 0
@@ -37,6 +40,7 @@ PROFILE_TARGET_SUFFIX := -k6802-vdg
 PROFILE_MEMORY_CONFIG := ram64_a000_work
 PROFILE_BOARD_IO := sbcio
 PROFILE_FEATURE_SD := 1
+PROFILE_FEATURE_FAT := 0
 PROFILE_FEATURE_VDG := 1
 PROFILE_FEATURE_KEYBOARD := 1
 PROFILE_FEATURE_I2C := 0
@@ -55,6 +59,9 @@ endif
 ifneq ($(filter command line environment environment override,$(origin FEATURE_SD)),)
 AXIS_OVERRIDE := 1
 endif
+ifneq ($(filter command line environment environment override,$(origin FEATURE_FAT)),)
+AXIS_OVERRIDE := 1
+endif
 ifneq ($(filter command line environment environment override,$(origin FEATURE_VDG)),)
 AXIS_OVERRIDE := 1
 endif
@@ -71,6 +78,7 @@ endif
 MEMORY_CONFIG ?= $(PROFILE_MEMORY_CONFIG)
 BOARD_IO ?= $(PROFILE_BOARD_IO)
 FEATURE_SD ?= $(PROFILE_FEATURE_SD)
+FEATURE_FAT ?= $(PROFILE_FEATURE_FAT)
 FEATURE_VDG ?= $(PROFILE_FEATURE_VDG)
 FEATURE_KEYBOARD ?= $(PROFILE_FEATURE_KEYBOARD)
 FEATURE_I2C ?= $(PROFILE_FEATURE_I2C)
@@ -90,6 +98,9 @@ endif
 ifeq ($(filter $(FEATURE_SD),$(VALID_FEATURE_VALUES)),)
 $(error Unsupported FEATURE_SD '$(FEATURE_SD)')
 endif
+ifeq ($(filter $(FEATURE_FAT),$(VALID_FEATURE_VALUES)),)
+$(error Unsupported FEATURE_FAT '$(FEATURE_FAT)')
+endif
 ifeq ($(filter $(FEATURE_VDG),$(VALID_FEATURE_VALUES)),)
 $(error Unsupported FEATURE_VDG '$(FEATURE_VDG)')
 endif
@@ -106,6 +117,11 @@ endif
 ifneq ($(FEATURE_SD),0)
 ifneq ($(BOARD_IO),sbcio)
 $(error FEATURE_SD=1 requires BOARD_IO=sbcio)
+endif
+endif
+ifneq ($(FEATURE_FAT),0)
+ifeq ($(FEATURE_SD),0)
+$(error FEATURE_FAT=1 requires FEATURE_SD=1)
 endif
 endif
 ifneq ($(FEATURE_KEYBOARD),0)
@@ -203,7 +219,7 @@ $(OUTDIR):
 	$(MKDIR_P)
 
 $(CONFIG_INC): FORCE tools/generate_monitor_config.py | $(OUTDIR)
-	"$(PYTHON)" tools/generate_monitor_config.py --output "$(CONFIG_INC)" --monitor-profile "$(MONITOR_PROFILE)" --memory-config "$(MEMORY_CONFIG)" --board-io "$(BOARD_IO)" --feature-sd "$(FEATURE_SD)" --feature-vdg "$(FEATURE_VDG)" --feature-keyboard "$(FEATURE_KEYBOARD)" --feature-i2c "$(FEATURE_I2C)" --vdg-vram-config "$(VDG_VRAM_CONFIG)"
+	"$(PYTHON)" tools/generate_monitor_config.py --output "$(CONFIG_INC)" --monitor-profile "$(MONITOR_PROFILE)" --memory-config "$(MEMORY_CONFIG)" --board-io "$(BOARD_IO)" --feature-sd "$(FEATURE_SD)" --feature-fat "$(FEATURE_FAT)" --feature-vdg "$(FEATURE_VDG)" --feature-keyboard "$(FEATURE_KEYBOARD)" --feature-i2c "$(FEATURE_I2C)" --vdg-vram-config "$(VDG_VRAM_CONFIG)"
 
 $(OBJ): FORCE $(TOPSRC) include/hardware.inc include/mikbug.inc $(CONFIG_INC) src/acia6850.asm src/sdcard.asm src/fat32.asm | $(OUTDIR)
 	"$(ASL)" -q -L -olist $(LST) -o $(OBJ) -i $(ASL_INCLUDE_ARG) $(TOPSRC)

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@
 - [design/architecture.md](design/architecture.md)
 - [plans/implementation_plan.md](plans/implementation_plan.md)
 - [plans/issue-103_mk_sdfs_image.md](plans/issue-103_mk_sdfs_image.md): SDFS/68 システムSDイメージ生成ツールの実装計画
+- [plans/issue-101_rom_stage1_boot.md](plans/issue-101_rom_stage1_boot.md): ROM固定LBA stage1 BOOT
 - [plans/issue-107_fixed_sector_boot_eval.md](plans/issue-107_fixed_sector_boot_eval.md): 固定セクタ版SDFS/68 loaderのROM削減評価
 - [plans/issue-109_stage1_boot_services.md](plans/issue-109_stage1_boot_services.md): SDFS/68 stage1 boot services設計
 - [plans/issue-113_stage1_header_build.md](plans/issue-113_stage1_header_build.md): SDFS/68 stage1 header / jump table とビルド基盤

--- a/docs/development/build_configuration_axes.md
+++ b/docs/development/build_configuration_axes.md
@@ -12,7 +12,8 @@
 | --- | --- |
 | `MEMORY_CONFIG` | RAM容量、ユーザーRAM、モニタワークRAM、スタック、SD/FATワークの配置 |
 | `BOARD_IO` | SBC-IOなど、外部I/O基板やI/Oデコードの有無 |
-| `FEATURE_SD` | SD/FAT read-only機能をROMへ入れるか |
+| `FEATURE_SD` | raw SD sector readと固定LBA stage1 `BOOT` をROMへ入れるか |
+| `FEATURE_FAT` | ROM常駐のFAT32 `DIR` / `LF` を入れるか |
 | `FEATURE_VDG` | K68-VDG表示機能をROMへ入れるか |
 | `FEATURE_KEYBOARD` | 2nd ACIAキーボード入力機能をROMへ入れるか |
 | `FEATURE_I2C` | PIA経由I2C機能をROMへ入れるか |
@@ -44,6 +45,7 @@ SBC-IOを装備していてもメモリ配置は別軸で決めるため、`BOAR
 | 機能 | 依存 |
 | --- | --- |
 | `FEATURE_SD=1` | `BOARD_IO=sbcio` が必要 |
+| `FEATURE_FAT=1` | `FEATURE_SD=1` が必要 |
 | `FEATURE_KEYBOARD=1` | `BOARD_IO=sbcio` が必要 |
 | `FEATURE_I2C=1` | `BOARD_IO=sbcio` が必要 |
 | `FEATURE_VDG=1` | SBC-IOとは独立。K68-VDG装備とVRAM配置が必要 |
@@ -51,18 +53,20 @@ SBC-IOを装備していてもメモリ配置は別軸で決めるため、`BOAR
 I2CはSBC-IOのPIAを前提にした将来機能として扱う。
 VDGはSBC-IOとは独立した外部表示装備として扱い、VRAM範囲は `MEMORY_CONFIG` とは別に明示する。
 
-ただし、I2CはRTC、EEPROM、OLED/LCDなど個別デバイス処理を含めるとROM容量を急速に消費する。8KB ROM互換を維持する間は、`FEATURE_I2C=1` を「I2C関連コードを無条件にROMへ押し込む入口」として使わない。ROM側へ入れる場合でも、最小BOOTや診断用の薄い入口に限定し、I2Cバスドライバ本体や個別デバイス機能はシリアル `L`、SD `LF`、または `SDFS.BIN` など第2段のRAMロード機能として検証する。
+ただし、I2CはRTC、EEPROM、OLED/LCDなど個別デバイス処理を含めるとROM容量を急速に消費する。8KB ROM互換を維持する間は、`FEATURE_I2C=1` を「I2C関連コードを無条件にROMへ押し込む入口」として使わない。ROM側へ入れる場合でも、最小BOOTや診断用の薄い入口に限定し、I2Cバスドライバ本体や個別デバイス機能はシリアル `L`、ROM常駐FATがある構成の `LF`、または `SDFS.BIN` など第2段のRAMロード機能として検証する。
+
+`FEATURE_SD=1` はraw SD sector readと固定LBA stage1 `BOOT` の前提を表す。ROM常駐のFAT32 `DIR` / `LF` は `FEATURE_FAT=1` として分ける。VDG + キーボード + BOOTを優先するprofileでは、ROM容量確保のため `FEATURE_SD=1` / `FEATURE_FAT=0` を基本にする。
 
 ## 既存profileの展開
 
 既存の `MONITOR_PROFILE` は、当面は次のプリセットとして扱う。
 
-| `MONITOR_PROFILE` | `MEMORY_CONFIG` | `BOARD_IO` | `FEATURE_SD` | `FEATURE_VDG` | `FEATURE_KEYBOARD` | `FEATURE_I2C` | 補足 |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| `base` | `base8k` | `none` | `0` | `0` | `0` | `0` | SBC6800互換の最小構成 |
-| `sbcio` | `ram64_c000_work` | `sbcio` | `1` | `0` | `1` | `0` | SBC-IO RAM拡張とSD/FAT、2nd ACIAキーボード |
-| `sbcio_vdg` | `ram64_c000_work` | `sbcio` | `1` | `1` | `1` | `0` | SBC-IO構成でVRAM `$A000-$BFFF` |
-| `k6802_vdg` | `ram64_a000_work` | `sbcio` | `1` | `1` | `1` | `0` | K6802-SBC向けにワークRAM `$A000-$BFFF`、VRAM `$C000-$DFFF` |
+| `MONITOR_PROFILE` | `MEMORY_CONFIG` | `BOARD_IO` | `FEATURE_SD` | `FEATURE_FAT` | `FEATURE_VDG` | `FEATURE_KEYBOARD` | `FEATURE_I2C` | 補足 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `base` | `base8k` | `none` | `0` | `0` | `0` | `0` | `0` | SBC6800互換の最小構成 |
+| `sbcio` | `ram64_c000_work` | `sbcio` | `1` | `1` | `0` | `1` | `0` | SBC-IO RAM拡張とSD/FAT、2nd ACIAキーボード |
+| `sbcio_vdg` | `ram64_c000_work` | `sbcio` | `1` | `0` | `1` | `1` | `0` | SBC-IO構成でVRAM `$A000-$BFFF`、ROM FATなし |
+| `k6802_vdg` | `ram64_a000_work` | `sbcio` | `1` | `0` | `1` | `1` | `0` | K6802-SBC向けにワークRAM `$A000-$BFFF`、VRAM `$C000-$DFFF`、ROM FATなし |
 
 `FEATURE_KEYBOARD` は2nd ACIAキーボード入力PoCの構成軸であり、SBC-IOの2nd ACIA `$8094-$8095` を前提にする。
 既存profile名はユーザー向け入口として残し、`MONITOR_PROFILE=base` などのビルド互換を壊さない。
@@ -83,6 +87,7 @@ make bin MEMORY_CONFIG=ram64_a000_work BOARD_IO=sbcio FEATURE_SD=1 FEATURE_VDG=0
 | `MEMORY_CONFIG` | `base8k` / `ram64_c000_work` / `ram64_a000_work` | メモリ配置 |
 | `BOARD_IO` | `none` / `sbcio` | 外部I/O装備 |
 | `FEATURE_SD` | `0` / `1` | SD/FAT機能をROMへ入れるか |
+| `FEATURE_FAT` | `0` / `1` | ROM常駐のFAT32 `DIR` / `LF` を入れるか |
 | `FEATURE_VDG` | `0` / `1` | K68-VDG機能をROMへ入れるか |
 | `FEATURE_KEYBOARD` | `0` / `1` | 2nd ACIAキーボード機能をROMへ入れるか |
 | `FEATURE_I2C` | `0` / `1` | I2C機能をROMへ入れるか。現時点では依存関係だけを検査する |

--- a/docs/plans/issue-101_rom_stage1_boot.md
+++ b/docs/plans/issue-101_rom_stage1_boot.md
@@ -1,0 +1,37 @@
+# Issue #101 ROM固定LBA stage1 BOOT
+
+## 関連リンク
+
+- Issue #101: https://github.com/kuninet/mc6800-rom-monitor/issues/101
+- Issue #111: https://github.com/kuninet/mc6800-rom-monitor/issues/111
+- Issue #125: https://github.com/kuninet/mc6800-rom-monitor/issues/125
+
+## 方針
+
+ROM側 `BOOT` はFATを読まず、固定 physical LBA `16` からstage1 loaderを `S1_BASE` へ読む。FAT rootの `SDFS.BIN` 検索とSDFS/68起動はstage1側の責務にする。
+
+8KB ROM内でVDG + KKBD-USB + BOOTを優先するため、`FEATURE_SD` をraw SD機能、`FEATURE_FAT` をROM常駐FATコマンドとして分離する。`sbcio` profileは従来の `DIR` / `LF` を残し、`sbcio_vdg` / `k6802_vdg` profileはROM FATを外して `BOOT` に寄せる。
+
+## 実装内容
+
+- `BOOT` コマンドを追加する。
+- `BOOT` は `SD_INIT` と `SD_READ_SECTOR` だけを使い、LBA `16` 以降からstage1領域全体を連続ロードする。
+- stage1 headerの `S1API68` signature、API version、boot entry、image sizeを検査する。
+- boot entryが `S1_BASE` からimage size内にあることを確認する。
+- 正常時はstage1 boot entryへ `jmp` する。
+- 失敗時は `?` を出して既存monitorへ戻る。
+
+## 対象外
+
+- ROM側FAT mount、root directory探索、8.3検索。
+- ROM側からの `SDFS.BIN` 直接ロード。
+- SDFS/68本体実装。
+- 512 byte超のSDFS/68ロードやFAT chain対応。これはstage1側の後続Issueで扱う。
+
+## 検証方針
+
+- 固定LBAに正しいstage1 stubがある場合、`BOOT` でentryへジャンプすることをエミュレータで確認する。
+- signature、entry、size不正でハングせずmonitorへ戻ることを確認する。
+- stage1読み込み途中のSD read失敗でmonitorへ戻ることを確認する。
+- `sbcio` のROM常駐FATテストは維持し、`sbcio_vdg` / `k6802_vdg` ではFATコマンドを期待しない。
+

--- a/docs/plans/issue-82_sd_bootstrap_dos.md
+++ b/docs/plans/issue-82_sd_bootstrap_dos.md
@@ -30,6 +30,8 @@
 
 ROM容量は8KB互換を前提にすると既に余裕が小さいため、I2C、RTC、EEPROM、OLED/LCD、AUTOEXEC 処理をROMへ常駐させて肥大化させない。これらの周辺機能は、まずRAMロード可能なPoCとして煮詰め、最終的には `SDFS.BIN` または将来の M6800 DOS 相当の第2段機能へ寄せる。
 
+ROM側のSD機能は `FEATURE_SD` と `FEATURE_FAT` を分ける。`FEATURE_SD` はraw sector readと固定LBA stage1 `BOOT` の前提、`FEATURE_FAT` はROM常駐の `DIR` / `LF` を含める互換構成である。スタンドアロン寄りの `sbcio_vdg` / `k6802_vdg` は `FEATURE_FAT=0` とし、FAT操作はstage1とSDFS/68側へ移す。
+
 ## 方式比較
 
 | 方式 | 位置づけ | 採用条件 |

--- a/docs/usage/build_commands.md
+++ b/docs/usage/build_commands.md
@@ -46,12 +46,12 @@ ROM_CODE_LIMIT=0 make bin
 
 ## profileごとの違い
 
-| `MONITOR_PROFILE` | RAM/WORK | SBC-IO | SD/FAT | VDG | KEYTEST | VRAM |
-| --- | --- | --- | --- | --- | --- | --- |
-| `base` | `RAM 0000-1FFF`, `WORK 1C00-1FFF` | なし | なし | なし | なし | なし |
-| `sbcio` | `RAM 0000-7FFF`, `WORK C000-DFFF` | あり | あり | なし | あり | なし |
-| `sbcio_vdg` | `RAM 0000-7FFF`, `WORK C000-DFFF` | あり | あり | あり | あり | `$A000-$BFFF` |
-| `k6802_vdg` | `RAM 0000-7FFF`, `WORK A000-BFFF` | あり | あり | あり | あり | `$C000-$DFFF` |
+| `MONITOR_PROFILE` | RAM/WORK | SBC-IO | raw SD/BOOT | ROM FAT `DIR`/`LF` | VDG | KEYTEST | VRAM |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `base` | `RAM 0000-1FFF`, `WORK 1C00-1FFF` | なし | なし | なし | なし | なし | なし |
+| `sbcio` | `RAM 0000-7FFF`, `WORK C000-DFFF` | あり | あり | あり | なし | あり | なし |
+| `sbcio_vdg` | `RAM 0000-7FFF`, `WORK C000-DFFF` | あり | あり | なし | あり | あり | `$A000-$BFFF` |
+| `k6802_vdg` | `RAM 0000-7FFF`, `WORK A000-BFFF` | あり | あり | なし | あり | あり | `$C000-$DFFF` |
 
 ## 生成物の種類
 
@@ -83,6 +83,8 @@ MONITOR_PROFILE=k6802_vdg make stage1
 | `k6802_vdg` | `build/stage1-k6802-vdg.bin` |
 
 stage1 v1の配置は、`sbcio_vdg` が `$C400-$CFFF`、`k6802_vdg` が `$A400-$AFFF` である。SDFS/68本体の初期ロード領域はそれぞれ `$D000-$DEFF`、`$B000-$BEFF` とする。
+
+ROM profileでは `FEATURE_SD` と `FEATURE_FAT` を分ける。`FEATURE_SD=1` はraw SD sector readと `BOOT` の前提、`FEATURE_FAT=1` はROM常駐の `DIR` / `LF` を含める設定である。`sbcio` は従来のROM FATコマンドを残し、`sbcio_vdg` / `k6802_vdg` はROM FATを外して固定LBA stage1 `BOOT` に寄せる。
 
 ## ROM_KIND
 

--- a/docs/usage/monitor_commands.md
+++ b/docs/usage/monitor_commands.md
@@ -19,7 +19,8 @@
 | `D` | 継続アドレスから 64 バイト分をダンプする |
 | `Dssss` | `ssss` から 64 バイト分をダンプする |
 | `Dssss-eeee` | `ssss` から `eeee` までをダンプする |
-| `DIR` | SDカード上のroot directoryにある8.3通常ファイルを表示する。`FEATURE_SD=1` のROMだけで有効 |
+| `DIR` | SDカード上のroot directoryにある8.3通常ファイルを表示する。`FEATURE_FAT=1` のROMだけで有効 |
+| `BOOT` | 固定LBAからSDFS/68 stage1 loaderを読み込んで起動する。`FEATURE_SD=1` かつ stage1対応RAM構成のROMで有効 |
 | `Mssss` | `ssss` からメモリを変更する |
 | `MAP` | 現在のビルドが想定する主要メモリ配置を表示する |
 | `RAMTEST ssss-eeee` | 許可された明示範囲のRAMを破壊テストする |
@@ -27,7 +28,7 @@
 | `KEYTEST` | `FEATURE_KEYBOARD=1` のROMで2nd ACIAのキーボード受信文字を表示する |
 | `Gssss` | `ssss` へジャンプして実行する |
 | `L` | S-Record または Intel HEX をロードする |
-| `LF filename` | SDカード上の8.3名ファイルを検索して開く。`FEATURE_SD=1` のROMだけで有効 |
+| `LF filename` | SDカード上の8.3名ファイルを検索して開く。`FEATURE_FAT=1` のROMだけで有効 |
 | `H` | コマンド一覧を表示する |
 | `Fssss-eeee vv` | `ssss` から `eeee` までを `vv` で埋める |
 | `B` | 現在のブレークポイント状態を表示する |
@@ -122,10 +123,10 @@ ROM E000-FFFF
 
 `base` profileは `FEATURE_SD=0`、`FEATURE_VDG=0`、`FEATURE_KEYBOARD=0` のため、SD、VDG、KEYの行を表示しない。
 
-SBC-IO拡張ROMでは `MAP SBCIO` と表示され、`WORK C000-DFFF`、`SD C000`、`MON C200`、`MIK C300`、`STK DFFF` などの拡張RAM前提の配置になる。
+SBC-IO拡張ROMでは `MAP SBCIO` と表示され、`WORK C000-DFFF`、`SD C000`、`MON C200`、`MIK C300`、`STK DFFF` などの拡張RAM前提の配置になる。`sbcio` profileはROM常駐FATを残すため `DIR` / `LF` が有効である。
 `FEATURE_KEYBOARD=1` のROMでは、2nd ACIAキーボード入力候補として `KEY 8094-8095` も表示する。
 
-K68-VDG表示PoC用の `sbcio_vdg` profileでは、SBC-IO拡張ROMの配置に加えて K68-VDG 用の VRAM と設定レジスタを表示する。
+K68-VDG表示PoC用の `sbcio_vdg` profileでは、SBC-IO拡張ROMの配置に加えて K68-VDG 用の VRAM と設定レジスタを表示する。ROM容量をVDG/キーボード/BOOTへ寄せるため、ROM常駐FATの `DIR` / `LF` は無効で、SDからの第2段起動は `BOOT` を使う。
 
 ```text
 ] MAP

--- a/src/main.asm
+++ b/src/main.asm
@@ -78,7 +78,7 @@ MAIN_LOOP:
         ldaa    LINE_BUF
         cmpa    #'D'
         bne     CHK_CMD_MOD
- if MONITOR_FEATURE_SD
+ if MONITOR_FEATURE_FAT
         jsr     IS_CMD_DIR
         bcs     MAIN_DISPATCH_DUMP
         jmp     CMD_DIR
@@ -104,6 +104,14 @@ CHK_CMD_LOAD:
 CHK_CMD_BREAK:
         cmpa    #'B'
         bne     CHK_CMD_RESUME
+ if MONITOR_FEATURE_SD
+ if S1_SUPPORTED
+        jsr     IS_CMD_BOOT
+        bcs     MAIN_DISPATCH_BREAK
+        jmp     CMD_BOOT
+MAIN_DISPATCH_BREAK:
+ endif
+ endif
         jmp     CMD_BREAK_SET
 CHK_CMD_RESUME:
         cmpa    #'R'
@@ -148,7 +156,7 @@ MAIN_LOOP_ERROR:
         jsr     SHOW_ERROR
         bra     MAIN_LOOP
 
- if MONITOR_FEATURE_SD
+ if MONITOR_FEATURE_FAT
 IS_CMD_DIR:
         ldab    LINE_LEN
         cmpb    #3
@@ -216,6 +224,29 @@ IS_CMD_RAMTEST:
 IS_CMD_RAMTEST_FAIL:
         sec
         rts
+
+ if MONITOR_FEATURE_SD
+ if S1_SUPPORTED
+IS_CMD_BOOT:
+        ldab    LINE_LEN
+        cmpb    #4
+        bne     IS_CMD_BOOT_FAIL
+        ldaa    LINE_BUF+1
+        cmpa    #'O'
+        bne     IS_CMD_BOOT_FAIL
+        ldaa    LINE_BUF+2
+        cmpa    #'O'
+        bne     IS_CMD_BOOT_FAIL
+        ldaa    LINE_BUF+3
+        cmpa    #'T'
+        bne     IS_CMD_BOOT_FAIL
+        clc
+        rts
+IS_CMD_BOOT_FAIL:
+        sec
+        rts
+ endif
+ endif
 
 CMD_DUMP:
         ldab    LINE_LEN
@@ -481,7 +512,7 @@ PARSE_FILL_FAIL:
         sec
         rts
 
- if MONITOR_FEATURE_SD
+ if MONITOR_FEATURE_FAT
 PARSE_FILENAME_83:
         stx     ARG_PTR
         stab    ARG_LEN
@@ -1362,7 +1393,7 @@ CMD_LOAD_BADARG:
         jmp     MAIN_LOOP_ERROR
 
 CMD_LOAD_EXTENDED:
- if MONITOR_FEATURE_SD
+ if MONITOR_FEATURE_FAT
         ldaa    LINE_BUF+1
         cmpa    #'F'
         beq     CMD_LF
@@ -1371,7 +1402,7 @@ CMD_LOAD_EXTENDED:
  endif
         jmp     CMD_LOAD_BADARG
 
- if MONITOR_FEATURE_SD
+ if MONITOR_FEATURE_FAT
 CMD_LF:
         ldab    LINE_LEN
         subb    #2
@@ -1392,7 +1423,128 @@ CMD_LF:
         bra     CMD_LOAD_LOOP
 CMD_LF_ERROR:
         jmp     MAIN_LOOP_ERROR
+ endif
 
+ if MONITOR_FEATURE_SD
+ if S1_SUPPORTED
+S1_BOOT_SECTORS equ (S1_LIMIT-S1_BASE+1)/$0200
+S1_BOOT_MAX_HI  equ (S1_LIMIT-S1_BASE+1)/$0100
+S1_BOOT_MAX_LO  equ 0
+
+CMD_BOOT:
+        jsr     SD_INIT
+        bcs     CMD_BOOT_ERROR
+        jsr     BOOT_SET_LBA16
+        ldx     #S1_BASE
+        stx     FAT_READ_PTR
+        ldaa    #S1_BOOT_SECTORS
+        staa    FAT_TMP
+CMD_BOOT_READ_LOOP:
+        ldx     FAT_READ_PTR
+        jsr     SD_READ_SECTOR
+        bcs     CMD_BOOT_ERROR
+        dec     FAT_TMP
+        beq     CMD_BOOT_CHECK
+        ldaa    FAT_READ_PTR
+        adda    #$02
+        staa    FAT_READ_PTR
+        jsr     BOOT_INC_SD_LBA
+        bra     CMD_BOOT_READ_LOOP
+CMD_BOOT_CHECK:
+        jsr     BOOT_CHECK_STAGE1
+        bcs     CMD_BOOT_ERROR
+        ldx     S1_BASE+10
+        jmp     0,x
+CMD_BOOT_ERROR:
+        jmp     MAIN_LOOP_ERROR
+
+BOOT_SET_LBA16:
+        clr     SD_LBA0
+        clr     SD_LBA1
+        clr     SD_LBA2
+        ldaa    #$10
+        staa    SD_LBA3
+        rts
+
+BOOT_INC_SD_LBA:
+        inc     SD_LBA3
+        bne     BOOT_INC_SD_LBA_DONE
+        inc     SD_LBA2
+        bne     BOOT_INC_SD_LBA_DONE
+        inc     SD_LBA1
+        bne     BOOT_INC_SD_LBA_DONE
+        inc     SD_LBA0
+BOOT_INC_SD_LBA_DONE:
+        rts
+
+BOOT_CHECK_STAGE1:
+        ldx     #S1_BASE
+        ldaa    0,x
+        cmpa    #'S'
+        bne     BOOT_STAGE1_SIG_FAIL
+        ldaa    1,x
+        cmpa    #'1'
+        bne     BOOT_STAGE1_SIG_FAIL
+        ldaa    2,x
+        cmpa    #'A'
+        bne     BOOT_STAGE1_SIG_FAIL
+        ldaa    3,x
+        cmpa    #'P'
+        bne     BOOT_STAGE1_SIG_FAIL
+        ldaa    4,x
+        cmpa    #'I'
+        bne     BOOT_STAGE1_SIG_FAIL
+        ldaa    5,x
+        cmpa    #'6'
+        bne     BOOT_STAGE1_SIG_FAIL
+        ldaa    6,x
+        cmpa    #'8'
+        bne     BOOT_STAGE1_SIG_FAIL
+        ldaa    7,x
+        cmpa    #1
+        bne     BOOT_STAGE1_SIG_FAIL
+
+        ldaa    12,x
+        oraa    13,x
+        beq     BOOT_STAGE1_SIZE_FAIL
+        ldaa    12,x
+        cmpa    #S1_BOOT_MAX_HI
+        bhi     BOOT_STAGE1_SIZE_FAIL
+        blo     BOOT_STAGE1_CHECK_ENTRY
+        ldaa    13,x
+        cmpa    #S1_BOOT_MAX_LO
+        bhi     BOOT_STAGE1_SIZE_FAIL
+
+BOOT_STAGE1_CHECK_ENTRY:
+        ldaa    10,x
+        suba    #S1_BASE/$0100
+        bcs     BOOT_STAGE1_SIZE_FAIL
+        staa    FAT_TMP
+        cmpa    #S1_BOOT_MAX_HI
+        bhs     BOOT_STAGE1_SIZE_FAIL
+        ldaa    FAT_TMP
+        cmpa    12,x
+        bhi     BOOT_STAGE1_SIZE_FAIL
+        blo     BOOT_STAGE1_OK
+        ldaa    11,x
+        cmpa    13,x
+        bhs     BOOT_STAGE1_SIZE_FAIL
+BOOT_STAGE1_OK:
+        clc
+        rts
+BOOT_STAGE1_SIG_FAIL:
+        ldaa    #FAT_ERR_SIG
+        jmp     BOOT_FAIL_A
+BOOT_STAGE1_SIZE_FAIL:
+        ldaa    #FAT_ERR_SIZE
+        jmp     BOOT_FAIL_A
+BOOT_FAIL_A:
+        staa    FAT_ERROR
+        sec
+        rts
+ endif
+ endif
+ if MONITOR_FEATURE_FAT
 CMD_DIR:
         ldab    LINE_LEN
         cmpb    #3
@@ -1847,7 +1999,7 @@ ADD_TO_LOADER_SUM:
         rts
 
 LOADER_GETC:
- if MONITOR_FEATURE_SD
+ if MONITOR_FEATURE_FAT
         ldaa    LOADER_INPUT
         cmpa    #LOAD_INPUT_FAT
         beq     LOADER_GETC_FAT
@@ -1855,7 +2007,7 @@ LOADER_GETC:
         jsr     ACIA_GETC
         clc
         rts
- if MONITOR_FEATURE_SD
+ if MONITOR_FEATURE_FAT
 LOADER_GETC_FAT:
         pshb
         jsr     FAT32_STREAM_GETC
@@ -2172,18 +2324,34 @@ TXT_BRK:        fcc     "BRK "
 TXT_WELCOME:    fcc     "MC6800 MONITOR"
                 fcb     $04
 TXT_HELP:
- if MONITOR_FEATURE_SD
+ if MONITOR_FEATURE_FAT
  if MONITOR_FEATURE_VDG
  if MONITOR_FEATURE_KEYBOARD
-                fcc     "D DIR M MAP RAMTEST VDGTEST KEYTEST G L LF B C R U H F"
+                fcc     "D DIR M MAP RAMTEST VDGTEST KEYTEST G L LF BOOT B C R U H F"
  else
-                fcc     "D DIR M MAP RAMTEST VDGTEST G L LF B C R U H F"
+                fcc     "D DIR M MAP RAMTEST VDGTEST G L LF BOOT B C R U H F"
  endif
  else
  if MONITOR_FEATURE_KEYBOARD
-                fcc     "D DIR M MAP RAMTEST KEYTEST G L LF B C R U H F"
+                fcc     "D DIR M MAP RAMTEST KEYTEST G L LF BOOT B C R U H F"
  else
-                fcc     "D DIR M MAP RAMTEST G L LF B C R U H F"
+                fcc     "D DIR M MAP RAMTEST G L LF BOOT B C R U H F"
+ endif
+ endif
+ else
+ if MONITOR_FEATURE_SD
+ if S1_SUPPORTED
+ if MONITOR_FEATURE_VDG
+ if MONITOR_FEATURE_KEYBOARD
+                fcc     "D M MAP RAMTEST VDGTEST KEYTEST G L BOOT B C R U H F"
+ else
+                fcc     "D M MAP RAMTEST VDGTEST G L BOOT B C R U H F"
+ endif
+ else
+ if MONITOR_FEATURE_KEYBOARD
+                fcc     "D M MAP RAMTEST KEYTEST G L BOOT B C R U H F"
+ else
+                fcc     "D M MAP RAMTEST G L BOOT B C R U H F"
  endif
  endif
  else
@@ -2198,6 +2366,22 @@ TXT_HELP:
                 fcc     "D M MAP RAMTEST KEYTEST G L B C R U H F"
  else
                 fcc     "D M MAP RAMTEST G L B C R U H F"
+ endif
+ endif
+ endif
+ else
+ if MONITOR_FEATURE_VDG
+ if MONITOR_FEATURE_KEYBOARD
+                fcc     "D M MAP RAMTEST VDGTEST KEYTEST G L B C R U H F"
+ else
+                fcc     "D M MAP RAMTEST VDGTEST G L B C R U H F"
+ endif
+ else
+ if MONITOR_FEATURE_KEYBOARD
+                fcc     "D M MAP RAMTEST KEYTEST G L B C R U H F"
+ else
+                fcc     "D M MAP RAMTEST G L B C R U H F"
+ endif
  endif
  endif
  endif
@@ -2363,9 +2547,11 @@ SPURIOUS_IRQ:
 
         include "acia6850.asm"
  if MONITOR_FEATURE_SD
+        include "sdcard.asm"
+ endif
+ if MONITOR_FEATURE_FAT
 FAT32_INCLUDE_FIND_API equ 1
 FAT32_INCLUDE_FILE_API equ 1
-        include "sdcard.asm"
         include "fat32.asm"
  endif
 

--- a/tests/test_sd_fixture.py
+++ b/tests/test_sd_fixture.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import re
 import sys
 import subprocess
 import tempfile
@@ -12,6 +13,7 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "tests"))
+sys.path.insert(0, str(PROJECT_ROOT / "tools"))
 sys.path.insert(0, str(PROJECT_ROOT / "emu"))
 EMU_PATH = PROJECT_ROOT / "emu" / "sbc6800_emu.py"
 
@@ -72,6 +74,7 @@ from sd_fixtures import (
     layout_for_image,
     sector,
 )
+from mk_sdfs_image import build_sdfs_image
 
 
 def u16(data: bytes, offset: int) -> int:
@@ -236,8 +239,6 @@ def _poll_until(read_byte, expected: int) -> int:
 
 
 def _load_symbol_addresses(*names: str) -> dict[str, int]:
-    import re
-
     text = BUILD_LST_PATH.read_text(encoding="utf-8", errors="replace")
     result: dict[str, int] = {}
     wanted = set(names)
@@ -292,6 +293,16 @@ def _is_sd_build() -> bool:
     if os.environ.get("FEATURE_SD") in ("0", "1"):
         return os.environ["FEATURE_SD"] == "1"
     return _is_sbcio_build()
+
+
+def _is_fat_build() -> bool:
+    if os.environ.get("FEATURE_FAT") in ("0", "1"):
+        return os.environ["FEATURE_FAT"] == "1"
+    return BUILD_ROM_PATH.stem.endswith("-sbcio")
+
+
+def _is_s1_boot_build() -> bool:
+    return _is_sd_build() and (_is_vdg_build() or BUILD_ROM_PATH.stem.endswith("-sbcio"))
 
 
 def _run_emu_with_sd(input_text: str, sd_image: bytes, max_cycles: int = 30_000_000) -> tuple[str, str, int]:
@@ -495,6 +506,7 @@ def test_rom_sd_read_sector_reads_known_fixture_sector() -> None:
 def test_rom_profile_memory_layout() -> None:
     names = [
         "MONITOR_FEATURE_SD",
+        "MONITOR_FEATURE_FAT",
         "MONITOR_RAM_BASE",
         "USER_RAM_END",
         "WORK_RAM_START",
@@ -526,6 +538,7 @@ def test_rom_profile_memory_layout() -> None:
         expected_work_end = 0x1FFF
 
     assert symbols["MONITOR_FEATURE_SD"] == (1 if _is_sd_build() else 0), "SD feature flag mismatch"
+    assert symbols["MONITOR_FEATURE_FAT"] == (1 if _is_fat_build() else 0), "FAT feature flag mismatch"
     if _is_sd_build():
         assert symbols["SD_SECTOR_BUF"] == expected_sector_buf, (
             f"SD_SECTOR_BUF mismatch: got={symbols['SD_SECTOR_BUF']:04X} "
@@ -814,6 +827,87 @@ def test_rom_dir_keeps_dump_command() -> None:
     print("[PASS] test_rom_dir_keeps_dump_command")
 
 
+def test_rom_boot_loads_fixed_lba_stage1_and_jumps() -> None:
+    if not _is_s1_boot_build():
+        print("[SKIP] test_rom_boot_loads_fixed_lba_stage1_and_jumps")
+        return
+
+    symbols = _load_symbol_addresses("S1_BASE")
+    result_addr = symbols["S1_BASE"] + 0x0300
+    image = _build_boot_stage1_image(_make_boot_stage1_stub(symbols["S1_BASE"], result_addr))
+    stdout, stderr, rc = _run_emu_with_sd(
+        f"BOOT\rD{result_addr:04X}-{result_addr:04X}\r\r",
+        image,
+        max_cycles=120_000_000,
+    )
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    line = _dump_line(stdout, result_addr)
+    assert re.search(rf"{result_addr:04X}\s+42\b", line), f"BOOT did not jump to stage1: {stdout!r}"
+    print("[PASS] test_rom_boot_loads_fixed_lba_stage1_and_jumps")
+
+
+def test_rom_boot_rejects_invalid_stage1_headers() -> None:
+    if not _is_s1_boot_build():
+        print("[SKIP] test_rom_boot_rejects_invalid_stage1_headers")
+        return
+
+    symbols = _load_symbol_addresses("S1_BASE")
+    result_addr = symbols["S1_BASE"] + 0x0300
+    cases = [
+        lambda data: data.__setitem__(0, ord("X")),
+        lambda data: data.__setitem__(slice(10, 12), b"\x00\x00"),
+        lambda data: data.__setitem__(slice(12, 14), b"\x00\x00"),
+        lambda data: data.__setitem__(slice(12, 14), b"\x20\x00"),
+    ]
+    for mutate in cases:
+        stage1 = bytearray(_make_boot_stage1_stub(symbols["S1_BASE"], result_addr))
+        mutate(stage1)
+        image = _build_boot_stage1_image(bytes(stage1))
+        stdout, stderr, rc = _run_emu_with_sd(
+            f"BOOT\rD{result_addr:04X}-{result_addr:04X}\r\r",
+            image,
+            max_cycles=120_000_000,
+        )
+        assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+        assert "?" in stdout, f"BOOT should reject invalid stage1: {stdout!r}"
+        line = _dump_line(stdout, result_addr)
+        assert not re.search(rf"{result_addr:04X}\s+42\b", line), (
+            f"BOOT jumped despite invalid stage1: {stdout!r}"
+        )
+    print("[PASS] test_rom_boot_rejects_invalid_stage1_headers")
+
+
+def test_rom_boot_returns_prompt_on_stage1_read_failure() -> None:
+    if not _is_s1_boot_build():
+        print("[SKIP] test_rom_boot_returns_prompt_on_stage1_read_failure")
+        return
+
+    symbols = _load_symbol_addresses("S1_BASE")
+    result_addr = symbols["S1_BASE"] + 0x0300
+    stdout, stderr, rc = _run_emu_with_sd(
+        f"BOOT\rD{result_addr:04X}-{result_addr:04X}\r\r",
+        bytes(SECTOR_SIZE * 17),
+        max_cycles=120_000_000,
+    )
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    assert "?" in stdout, f"BOOT read failure should return an error prompt: {stdout!r}"
+    assert f"{result_addr:04X}" in stdout, f"monitor did not continue after BOOT failure: {stdout!r}"
+    print("[PASS] test_rom_boot_returns_prompt_on_stage1_read_failure")
+
+
+def test_rom_fat_commands_disabled_without_feature_fat() -> None:
+    if not _is_sd_build() or _is_fat_build():
+        print("[SKIP] test_rom_fat_commands_disabled_without_feature_fat")
+        return
+
+    stdout, stderr, rc = _run_emu_with_sd("DIR\rLF TEST.S\r\r", build_fat32_image(with_mbr=True))
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    assert stdout.count("?") >= 2, f"DIR/LF should be disabled when FEATURE_FAT=0: {stdout!r}"
+    assert "TEST.S A" not in stdout, f"DIR should not list FAT root when FEATURE_FAT=0: {stdout!r}"
+    assert "OK" not in stdout, f"LF should not load when FEATURE_FAT=0: {stdout!r}"
+    print("[PASS] test_rom_fat_commands_disabled_without_feature_fat")
+
+
 def test_rom_lf_command_opens_83_files_only() -> None:
     image = build_fat32_image(with_mbr=True)
     input_text = (
@@ -891,7 +985,7 @@ def test_rom_lf_reads_file_across_cluster_boundary_multisector_cluster() -> None
 
 
 def test_sbcio_sd_fat_ignores_old_low_ram_work_area() -> None:
-    if not _is_sbcio_build():
+    if not _is_fat_build():
         print("[SKIP] test_sbcio_sd_fat_ignores_old_low_ram_work_area")
         return
 
@@ -909,7 +1003,7 @@ def test_sbcio_sd_fat_ignores_old_low_ram_work_area() -> None:
 
 
 def test_sbcio_ramtest_preserves_sd_fat_work_area() -> None:
-    if not _is_sbcio_build():
+    if not _is_fat_build():
         print("[SKIP] test_sbcio_ramtest_preserves_sd_fat_work_area")
         return
 
@@ -927,6 +1021,33 @@ def test_sbcio_ramtest_preserves_sd_fat_work_area() -> None:
     assert "TEST.S A 0000001E" in stdout, f"DIR should work after RAMTEST: {stdout!r}"
     assert "0200 01 02 03" in stdout, f"LF should work after RAMTEST: {stdout!r}"
     print("[PASS] test_sbcio_ramtest_preserves_sd_fat_work_area")
+
+
+def _make_boot_stage1_stub(s1_base: int, result_addr: int) -> bytes:
+    entry = s1_base + 16
+    code = bytes([
+        0x86, 0x42,
+        0xB7, (result_addr >> 8) & 0xFF, result_addr & 0xFF,
+        0x3F,
+    ])
+    data = bytearray(512)
+    data[0:7] = b"S1API68"
+    data[7] = 1
+    data[8] = 6
+    data[9] = 0
+    data[10:12] = entry.to_bytes(2, "big")
+    data[12:14] = (16 + len(code)).to_bytes(2, "big")
+    data[16:16 + len(code)] = code
+    return bytes(data)
+
+
+def _build_boot_stage1_image(stage1: bytes) -> bytes:
+    return build_sdfs_image(
+        stage1_data=stage1,
+        sdfs_data=b"SDFS68\x01\x10\x00\x00\x00\x10" + bytes(4),
+        extra_files=[],
+        total_volume_sectors=64,
+    )
 
 
 def main() -> None:
@@ -948,6 +1069,13 @@ def main() -> None:
     if _is_sd_build():
         tests.extend([
             test_rom_sd_read_sector_reads_known_fixture_sector,
+            test_rom_boot_loads_fixed_lba_stage1_and_jumps,
+            test_rom_boot_rejects_invalid_stage1_headers,
+            test_rom_boot_returns_prompt_on_stage1_read_failure,
+            test_rom_fat_commands_disabled_without_feature_fat,
+        ])
+    if _is_fat_build():
+        tests.extend([
             test_rom_fat32_mount_reads_mbr_bpb_layout,
             test_rom_fat32_mount_reads_superfloppy_bpb_layout,
             test_rom_fat32_find_and_read_multicluster_file,
@@ -965,7 +1093,7 @@ def main() -> None:
             test_sbcio_sd_fat_ignores_old_low_ram_work_area,
             test_sbcio_ramtest_preserves_sd_fat_work_area,
         ])
-    else:
+    if not _is_sd_build():
         tests.append(test_rom_sd_commands_disabled_without_feature)
 
     passed = 0

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -160,14 +160,22 @@ def test_error_display():
 
 def test_help_command():
     stdout, stderr, rc = run_emu("H\r\r")
-    if is_sd_build() and is_vdg_build() and is_keyboard_build():
-        expected = "D DIR M MAP RAMTEST VDGTEST KEYTEST G L LF B C R U H F"
+    if is_fat_build() and is_vdg_build() and is_keyboard_build():
+        expected = "D DIR M MAP RAMTEST VDGTEST KEYTEST G L LF BOOT B C R U H F"
+    elif is_fat_build() and is_vdg_build():
+        expected = "D DIR M MAP RAMTEST VDGTEST G L LF BOOT B C R U H F"
+    elif is_fat_build() and is_keyboard_build():
+        expected = "D DIR M MAP RAMTEST KEYTEST G L LF BOOT B C R U H F"
+    elif is_fat_build():
+        expected = "D DIR M MAP RAMTEST G L LF BOOT B C R U H F"
+    elif is_sd_build() and is_vdg_build() and is_keyboard_build():
+        expected = "D M MAP RAMTEST VDGTEST KEYTEST G L BOOT B C R U H F"
     elif is_sd_build() and is_vdg_build():
-        expected = "D DIR M MAP RAMTEST VDGTEST G L LF B C R U H F"
+        expected = "D M MAP RAMTEST VDGTEST G L BOOT B C R U H F"
     elif is_sd_build() and is_keyboard_build():
-        expected = "D DIR M MAP RAMTEST KEYTEST G L LF B C R U H F"
+        expected = "D M MAP RAMTEST KEYTEST G L BOOT B C R U H F"
     elif is_sd_build():
-        expected = "D DIR M MAP RAMTEST G L LF B C R U H F"
+        expected = "D M MAP RAMTEST G L BOOT B C R U H F"
     elif is_vdg_build() and is_keyboard_build():
         expected = "D M MAP RAMTEST VDGTEST KEYTEST G L B C R U H F"
     elif is_vdg_build():
@@ -210,6 +218,12 @@ def is_sd_build() -> bool:
     if os.environ.get("FEATURE_SD") in ("0", "1"):
         return os.environ["FEATURE_SD"] == "1"
     return is_sbcio_build()
+
+
+def is_fat_build() -> bool:
+    if os.environ.get("FEATURE_FAT") in ("0", "1"):
+        return os.environ["FEATURE_FAT"] == "1"
+    return BUILD_ROM_PATH.stem.endswith("-sbcio")
 
 
 def is_keyboard_build() -> bool:

--- a/tools/generate_monitor_config.py
+++ b/tools/generate_monitor_config.py
@@ -92,11 +92,15 @@ def main() -> None:
     parser.add_argument("--memory-config", choices=MEMORY_CONFIGS, required=True)
     parser.add_argument("--board-io", choices=("none", "sbcio"), required=True)
     parser.add_argument("--feature-sd", type=feature, required=True)
+    parser.add_argument("--feature-fat", type=feature, default=None)
     parser.add_argument("--feature-vdg", type=feature, required=True)
     parser.add_argument("--feature-keyboard", type=feature, required=True)
     parser.add_argument("--feature-i2c", type=feature, required=True)
     parser.add_argument("--vdg-vram-config", choices=VDG_VRAM, required=True)
     args = parser.parse_args()
+    feature_fat = args.feature_sd if args.feature_fat is None else args.feature_fat
+    if feature_fat and not args.feature_sd:
+        raise SystemExit("FEATURE_FAT=1 requires FEATURE_SD=1")
 
     memory = MEMORY_CONFIGS[args.memory_config]
     is_base = args.memory_config == "base8k" and args.board_io == "none"
@@ -120,6 +124,7 @@ def main() -> None:
         f"MONITOR_PROFILE_SBCIO equ {1 if is_sbcio else 0}",
         f"MONITOR_PROFILE_K6802_VDG equ {1 if is_k6802_vdg else 0}",
         f"MONITOR_FEATURE_SD equ {args.feature_sd}",
+        f"MONITOR_FEATURE_FAT equ {feature_fat}",
         f"MONITOR_FEATURE_VDG equ {args.feature_vdg}",
         f"MONITOR_FEATURE_KEYBOARD equ {args.feature_keyboard}",
         f"MONITOR_FEATURE_I2C equ {args.feature_i2c}",


### PR DESCRIPTION
## Summary
- ROMに固定LBA 16からstage1を読む `BOOT` コマンドを追加
- stage1 headerのsignature/version/entry/sizeを検査してboot entryへjump
- `FEATURE_SD` と `FEATURE_FAT` を分離し、`sbcio_vdg` / `k6802_vdg` ではROM常駐FATを外してBOOTへ寄せる
- BOOT正常系、header異常、read失敗、FEATURE_FAT無効時のDIR/LF無効化テストを追加
- #101計画文書と関連docsを更新

## 対象外
- stage1 FAT reader本体の変更
- SDFS/68本体の実装
- 512 byte超SDFS/68ロードやFAT chain対応
- ROM側 `DIR` / `LF` の完全削除（`sbcio` profileでは互換のため維持）

## 確認内容
- `git diff --check`
- `make bin`
- `REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py`
- `REQUIRE_BUILD_ROM=1 python3 tests/test_sd_fixture.py`
- `MONITOR_PROFILE=sbcio make bin`
- `MONITOR_PROFILE=sbcio REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py`
- `MONITOR_PROFILE=sbcio REQUIRE_BUILD_ROM=1 python3 tests/test_sd_fixture.py`
- `MONITOR_PROFILE=sbcio_vdg make bin`
- `MONITOR_PROFILE=sbcio_vdg REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py`
- `MONITOR_PROFILE=sbcio_vdg REQUIRE_BUILD_ROM=1 python3 tests/test_sd_fixture.py`
- `MONITOR_PROFILE=k6802_vdg make bin`
- `MONITOR_PROFILE=k6802_vdg REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py`
- `MONITOR_PROFILE=k6802_vdg REQUIRE_BUILD_ROM=1 python3 tests/test_sd_fixture.py`
- `python3 tests/test_stage1_build.py`
- `python3 tests/test_mk_sdfs_image.py`

Closes #101
Refs #82 #103 #107 #109 #111 #125