### PR TITLE
docs: SDFS/68移行ロードマップを追加

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@
 - [plans/issue-121_stage1_load_file_1sector.md](plans/issue-121_stage1_load_file_1sector.md): SDFS/68 stage1 1-sector file load boot service
 - [plans/issue-123_stage1_memory_3kb.md](plans/issue-123_stage1_memory_3kb.md): SDFS/68 stage1 3KB配置
 - [plans/issue-125_stage1_sdfs_entry.md](plans/issue-125_stage1_sdfs_entry.md): SDFS/68 stage1 header検査とentry jump
+- [plans/issue-129_sdfs68_migration_roadmap.md](plans/issue-129_sdfs68_migration_roadmap.md): SDFS/68 v1移行とROM FAT整理ロードマップ
 - [testing/sbc6800_bringup.md](testing/sbc6800_bringup.md)
 - [testing/sbc_io_sd_bringup.md](testing/sbc_io_sd_bringup.md): SBC-IO と microSD SPI モジュールで SD/FAT を実機確認する手順
 - [testing/sbc6800_datapack.md](testing/sbc6800_datapack.md): SBC6800 データパックの扱いと互換確認

--- a/docs/plans/issue-129_sdfs68_migration_roadmap.md
+++ b/docs/plans/issue-129_sdfs68_migration_roadmap.md
@@ -1,0 +1,61 @@
+# Issue #129 SDFS/68 v1移行とROM FAT整理ロードマップ
+
+## 背景
+
+PR #127 で #101 のROM固定LBA stage1 `BOOT` は完了した。ROMはFATを読まず、固定 physical LBA `16` からstage1 loaderをRAMへ読み込む方針になった。
+
+この後の作業は、stage1、SDFS/68本体、ROM FAT整理の責務が混ざりやすい。中断後も迷わないよう、#129 を親ロードマップIssueとして扱い、実装順序をこの文書に固定する。
+
+## 実装順序
+
+| 順番 | Issue | 役割 | 完了条件 |
+| --- | --- | --- | --- |
+| 完了済み | #101 / PR #127 | ROM固定LBA stage1 `BOOT` | ROMが固定LBAからstage1を読み、`S1API68` header確認後にjumpする |
+| 1 | #111 | stage1 loader完成 | stage1がFAT rootの `SDFS.BIN` を512 byte超も含めて読み、SDFS/68 entryへjumpする |
+| 2 | #102 | SDFS/68最小本体 | `SDFS.BIN` として起動し、stage1 boot servicesを呼べる |
+| 3 | #130 | SDFS/68 HEX/S-record loader | SDFS/68からroot上の `.S` / `.HEX` をRAMへロードできる |
+| 4 | #128 | ROM FAT整理 | SDFS/68移行後のROM常駐FAT `DIR` / `LF` の扱いをprofile、docs、testsで整理する |
+
+## Issue単位の責務
+
+### #111 stage1 loader
+
+#111 はstage1側で閉じる。FAT32 read-only最小mount、root 8.3検索、`SDFS.BIN` のFAT chain読み込み、SDFS/68 header検査、entry jump、boot servicesエラーコードを扱う。
+
+SDFS/68本体のシェルやHEX/S-record loaderは含めない。
+
+### #102 SDFS/68最小本体
+
+#102 は `SDFS.BIN` として起動する最小本体に絞る。`SDFS68` header、entry、最小プロンプト、stage1 boot servicesの検出と呼び出し口を実装する。
+
+旧 #102 の本文に含まれていたHEX/S-record loaderは #130 に分離した。
+
+### #130 HEX/S-record loader
+
+#130 はSDFS/68上のロード機能を扱う。stage1 boot services経由でroot上の8.3ファイルを読み、S-RecordまたはIntel HEXとしてRAMへ展開する。
+
+このIssueが完了すると、ROM側 `LF` 相当の主用途をSDFS/68側へ移せる。
+
+### #128 ROM FAT整理
+
+#128 は #130 完了後に実施する。`sbcio_vdg` / `k6802_vdg` は `BOOT + SDFS/68` 本線として固め、`sbcio` のROM FAT `DIR` / `LF` は互換扱いとして残すか、別profile化するかを判断する。
+
+## profile方針
+
+- `sbcio_vdg` / `k6802_vdg` は `FEATURE_SD=1` / `FEATURE_FAT=0` の `BOOT + SDFS/68` 本線に寄せる。
+- `sbcio` は当面ROM常駐FAT互換profileとして扱う。
+- `sbcio` のROM FATを維持するか分離するかは、SDFS/68のHEX/S-record loaderが動いた後に #128 で判断する。
+
+## 対象外
+
+- I2C / RTC / OLED / VDG高機能。
+- SDFS/68 v2の `DIR`、`TYPE`、AUTOEXEC、subdirectory、direct read API。
+- FAT write、LFN、複数open、seek。
+
+## テスト方針
+
+- #111 では stage1 build、`mk-sdfs` 生成イメージ、SD fixtureで `SDFS.BIN` 起動まで確認する。
+- #102 では `SDFS.BIN` 単体ビルドと、stage1から最小SDFS/68へ制御が渡ることを確認する。
+- #130 では `.S` / `.HEX` 正常ロードと、壊れたHEX、終端なし、存在しないファイルの異常系を確認する。
+- #128 では `FEATURE_FAT=0/1` の `DIR` / `LF` / `BOOT` / help表示とprofile別ROMサイズを確認する。
+


### PR DESCRIPTION
## Summary
- SDFS/68 v1移行とROM FAT整理の親Issue #129 を作成
- #102 をSDFS/68最小本体に再定義し、HEX/S-record loaderを #130 として分離
- ROM FAT整理Issue #128 とstage1 Issue #111 の本文を最新順序へ更新
- `docs/plans/issue-129_sdfs68_migration_roadmap.md` に `#111 → #102 → #130 → #128` の実装順序を記録
- docs目次からロードマップ文書へリンク

## Issue整理
- 新規: #128 ROM削減: SDFS/68移行後にROM常駐FAT DIR/LFを整理する
- 新規: #129 SDFS/68 v1移行とROM FAT整理
- 新規: #130 SDFS/68 v1: HEX/S-recordロードを実装する
- 更新: #102, #111, #128, #129

## 確認内容
- `git diff --check`
- レビュー役によるロードマップ整合性確認

Closes #129
Refs #82 #102 #111 #128 #130