### PR TITLE
feat: SDFS/68最小本体を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,7 @@ TARGET := mc6800-monitor$(TARGET_SUFFIX)
 OUTDIR := build
 TOPSRC := src/main.asm
 STAGE1_TOPSRC := src/stage1.asm
+SDFS_TOPSRC := src/sdfs68.asm
 OBJ := $(OUTDIR)/$(TARGET).p
 LST := $(OUTDIR)/$(TARGET).lst
 BIN := $(OUTDIR)/$(TARGET).bin
@@ -156,6 +157,10 @@ STAGE1_TARGET := stage1$(TARGET_SUFFIX)
 STAGE1_OBJ := $(OUTDIR)/$(STAGE1_TARGET).p
 STAGE1_LST := $(OUTDIR)/$(STAGE1_TARGET).lst
 STAGE1_BIN := $(OUTDIR)/$(STAGE1_TARGET).bin
+SDFS_TARGET := SDFS$(TARGET_SUFFIX)
+SDFS_OBJ := $(OUTDIR)/$(SDFS_TARGET).p
+SDFS_LST := $(OUTDIR)/$(SDFS_TARGET).lst
+SDFS_BIN := $(OUTDIR)/$(SDFS_TARGET).BIN
 CONFIG_INC := $(OUTDIR)/monitor_config.inc
 ROM_KIND ?= 27C64
 ROM_FILL ?= 0xFF
@@ -211,7 +216,7 @@ endif
 
 ASL_INCLUDE := $(CURDIR)/$(OUTDIR)$(ASL_PATHSEP)$(CURDIR)/include$(ASL_PATHSEP)$(CURDIR)/src
 
-.PHONY: all clean bin check-rom-size srec ihex stage1 check-stage1-profile rombin rombin-27c64 rombin-27c128 rombin-27c256 rombin-28c256 rombin-w27c512 program verify readback program-27c64 program-27c128 program-27c256 program-28c256 program-w27c512 program-upd28c256 FORCE
+.PHONY: all clean bin check-rom-size srec ihex stage1 sdfs check-stage1-profile rombin rombin-27c64 rombin-27c128 rombin-27c256 rombin-28c256 rombin-w27c512 program verify readback program-27c64 program-27c128 program-27c256 program-28c256 program-w27c512 program-upd28c256 FORCE
 
 all: check-rom-size srec ihex
 
@@ -234,6 +239,8 @@ check-rom-size: $(BIN)
 
 stage1: check-stage1-profile $(STAGE1_BIN)
 
+sdfs: check-stage1-profile $(SDFS_BIN)
+
 check-stage1-profile:
 	"$(PYTHON)" -c "import sys; profile='$(MONITOR_PROFILE)'; sys.exit(0 if profile in ('sbcio_vdg', 'k6802_vdg') else 1)" || (echo "stage1 target requires MONITOR_PROFILE=sbcio_vdg or MONITOR_PROFILE=k6802_vdg" && exit 1)
 
@@ -242,6 +249,12 @@ $(STAGE1_OBJ): FORCE $(STAGE1_TOPSRC) include/hardware.inc $(CONFIG_INC) src/sdc
 
 $(STAGE1_BIN): $(STAGE1_OBJ)
 	"$(P2BIN)" $(STAGE1_OBJ) $(STAGE1_BIN) -q
+
+$(SDFS_OBJ): FORCE $(SDFS_TOPSRC) include/hardware.inc $(CONFIG_INC) | $(OUTDIR)
+	"$(ASL)" -q -L -olist $(SDFS_LST) -o $(SDFS_OBJ) -i $(ASL_INCLUDE_ARG) $(SDFS_TOPSRC)
+
+$(SDFS_BIN): $(SDFS_OBJ)
+	"$(P2BIN)" $(SDFS_OBJ) $(SDFS_BIN) -q
 
 srec: $(SREC)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@
 - [plans/implementation_plan.md](plans/implementation_plan.md)
 - [plans/issue-103_mk_sdfs_image.md](plans/issue-103_mk_sdfs_image.md): SDFS/68 システムSDイメージ生成ツールの実装計画
 - [plans/issue-101_rom_stage1_boot.md](plans/issue-101_rom_stage1_boot.md): ROM固定LBA stage1 BOOT
+- [plans/issue-102_sdfs68_minimal.md](plans/issue-102_sdfs68_minimal.md): SDFS/68最小本体とboot services接続
 - [plans/issue-107_fixed_sector_boot_eval.md](plans/issue-107_fixed_sector_boot_eval.md): 固定セクタ版SDFS/68 loaderのROM削減評価
 - [plans/issue-109_stage1_boot_services.md](plans/issue-109_stage1_boot_services.md): SDFS/68 stage1 boot services設計
 - [plans/issue-113_stage1_header_build.md](plans/issue-113_stage1_header_build.md): SDFS/68 stage1 header / jump table とビルド基盤

--- a/docs/plans/issue-102_sdfs68_minimal.md
+++ b/docs/plans/issue-102_sdfs68_minimal.md
@@ -1,0 +1,36 @@
+# Issue #102 SDFS/68最小本体とboot services接続
+
+## 背景
+
+#111 でstage1 loaderがFAT rootの `SDFS.BIN` を読み、SDFS/68 header確認後にentryへ制御を渡せるようになった。#102では、後続 #130 のHEX/S-record loaderを載せるための最小SDFS/68本体を追加する。
+
+## 方針
+
+- SDFS/68本体は `SDFS_LOAD_BASE` を `org` とするRAMロード用バイナリとして生成する。
+- 先頭16 bytesは `SDFS68` header、version、header size、entry address、image size、reservedとする。
+- 起動時に固定 `S1_BASE` の `S1API68` header、API version、API countを確認する。
+- SDFS/68側にはstage1 boot services jump tableを呼ぶ薄いラッパを置く。
+- v1最小本体では起動メッセージと `SDFS> ` プロンプトまでに留め、HEX/S-record loaderは #130 に分離する。
+- `S1_LOAD_FILE_83` はロード先が `SDFS_LOAD_BASE` 固定であり、起動後のSDFS/68本体から呼ぶと自己上書きになる。そのため #102 ではラッパの接続確認までに留め、#130 では `.S` / `.HEX` 読み込み用に別バッファへ読む手段、または `S1_READ_SECTOR` / `S1_FIND_83` を使ったストリーム処理を設計する。
+
+## 対象外
+
+- HEX/S-record loader本体。
+- `DIR`、`TYPE`、AUTOEXEC。
+- FAT write、subdirectory、LFN、direct read API。
+- stage1 loader本体の追加変更。
+- 起動後のSDFS/68から安全に使える汎用ファイルロードAPIの確定。
+
+## 検証方針
+
+- `make sdfs` で `sbcio_vdg` / `k6802_vdg` のSDFS/68バイナリを生成できることを確認する。
+- 生成バイナリの `SDFS68` header、entry、image size、`SDFS_LOAD_LIMIT` 内サイズを検査する。
+- `mk-sdfs` 生成相当のSDイメージで、ROM `BOOT` → stage1 → SDFS/68 起動メッセージまでをエミュレータで確認する。
+- stage1 boot services headerが存在しない場合に `S1?` を表示して停止することを確認する。
+- stage1 boot services headerのversion不一致、API count不足を拒否することを確認する。
+- SDFS/68側のboot servicesラッパが固定offsetのstage1 jump tableを呼ぶ形で生成されることを確認する。
+
+## 後続
+
+- #130 でSDFS/68のHEX/S-record loaderを実装する。
+- #128 でSDFS/68移行後のROM常駐FAT `DIR` / `LF` を整理する。

--- a/docs/usage/build_commands.md
+++ b/docs/usage/build_commands.md
@@ -65,6 +65,7 @@ ROM_CODE_LIMIT=0 make bin
 | S-record と Intel HEX | `MONITOR_PROFILE=sbcio make` | `.srec` と `.hex` |
 | ROMライタ用の容量合わせ済みバイナリ | `MONITOR_PROFILE=sbcio make rombin ROM_KIND=W27C512` | `build/mc6800-monitor-sbcio-W27C512.bin` |
 | SDFS/68 stage1 | `MONITOR_PROFILE=sbcio_vdg make stage1` | `build/stage1-sbcio-vdg.bin` |
+| SDFS/68本体 | `MONITOR_PROFILE=sbcio_vdg make sdfs` | `build/SDFS-sbcio-vdg.BIN` |
 
 ## SDFS/68 stage1
 
@@ -73,6 +74,8 @@ ROM_CODE_LIMIT=0 make bin
 ```sh
 MONITOR_PROFILE=sbcio_vdg make stage1
 MONITOR_PROFILE=k6802_vdg make stage1
+MONITOR_PROFILE=sbcio_vdg make sdfs
+MONITOR_PROFILE=k6802_vdg make sdfs
 ```
 
 主な出力:
@@ -83,6 +86,8 @@ MONITOR_PROFILE=k6802_vdg make stage1
 | `k6802_vdg` | `build/stage1-k6802-vdg.bin` |
 
 stage1 v1の配置は、`sbcio_vdg` が `$C400-$CFFF`、`k6802_vdg` が `$A400-$AFFF` である。SDFS/68本体の初期ロード領域はそれぞれ `$D000-$DEFF`、`$B000-$BEFF` とする。
+
+`sdfs` ターゲットは FAT root の `SDFS.BIN` として配置するSDFS/68本体を生成する。出力はprofile suffix付きの `build/SDFS-sbcio-vdg.BIN` / `build/SDFS-k6802-vdg.BIN` で、SDイメージ作成時に root の8.3名 `SDFS.BIN` として格納する。
 
 ROM profileでは `FEATURE_SD` と `FEATURE_FAT` を分ける。`FEATURE_SD=1` はraw SD sector readと `BOOT` の前提、`FEATURE_FAT=1` はROM常駐の `DIR` / `LF` を含める設定である。`sbcio` は従来のROM FATコマンドを残し、`sbcio_vdg` / `k6802_vdg` はROM FATを外して固定LBA stage1 `BOOT` に寄せる。
 

--- a/src/sdfs68.asm
+++ b/src/sdfs68.asm
@@ -1,0 +1,148 @@
+        cpu     6800
+
+        include "../include/hardware.inc"
+
+SDFS_VERSION    equ 1
+SDFS_HDR_SIZE   equ 16
+SDFS_S1_VERSION equ 1
+SDFS_S1_COUNT   equ 6
+
+        if S1_SUPPORTED = 0
+        error   "SDFS/68 is not supported for this memory configuration"
+        endif
+
+        org     SDFS_LOAD_BASE
+
+SDFS_HEADER:
+        fcc     "SDFS68"
+        fcb     SDFS_VERSION
+        fcb     SDFS_HDR_SIZE
+        fdb     SDFS_ENTRY
+        fdb     SDFS_END-SDFS_LOAD_BASE
+        fcb     0,0,0,0
+
+SDFS_ENTRY:
+        jsr     SDFS_CHECK_S1
+        bcc     SDFS_START
+        ldx     #TXT_S1_ERROR
+        jsr     SDFS_PRINT
+        swi
+
+SDFS_START:
+        ldx     #TXT_BANNER
+        jsr     SDFS_PRINT
+        jsr     SDFS_API_GET_ERROR
+        jsr     SDFS_PRINT_PROMPT
+
+SDFS_LOOP:
+        jsr     MIKBUG_INCH
+        cmpa    #CHR_LF
+        beq     SDFS_LOOP
+        cmpa    #CHR_CR
+        bne     SDFS_LOOP
+        jsr     SDFS_PRINT_PROMPT
+        bra     SDFS_LOOP
+
+SDFS_CHECK_S1:
+        ldx     #S1_BASE
+        ldaa    0,x
+        cmpa    #'S'
+        bne     SDFS_CHECK_S1_FAIL
+        ldaa    1,x
+        cmpa    #'1'
+        bne     SDFS_CHECK_S1_FAIL
+        ldaa    2,x
+        cmpa    #'A'
+        bne     SDFS_CHECK_S1_FAIL
+        ldaa    3,x
+        cmpa    #'P'
+        bne     SDFS_CHECK_S1_FAIL
+        ldaa    4,x
+        cmpa    #'I'
+        bne     SDFS_CHECK_S1_FAIL
+        ldaa    5,x
+        cmpa    #'6'
+        bne     SDFS_CHECK_S1_FAIL
+        ldaa    6,x
+        cmpa    #'8'
+        bne     SDFS_CHECK_S1_FAIL
+        ldaa    7,x
+        cmpa    #SDFS_S1_VERSION
+        bne     SDFS_CHECK_S1_FAIL
+        ldaa    8,x
+        cmpa    #SDFS_S1_COUNT
+        blo     SDFS_CHECK_S1_FAIL
+        clc
+        rts
+SDFS_CHECK_S1_FAIL:
+        sec
+        rts
+
+SDFS_API_INIT:
+        jsr     S1_BASE+16
+        rts
+
+SDFS_API_READ_SECTOR:
+        jsr     S1_BASE+19
+        rts
+
+SDFS_API_MOUNT:
+        jsr     S1_BASE+22
+        rts
+
+SDFS_API_FIND_83:
+        jsr     S1_BASE+25
+        rts
+
+; S1_LOAD_FILE_83 loads to SDFS_LOAD_BASE. Resident SDFS/68 must not call it
+; after boot because it would overwrite the running image.
+SDFS_API_LOAD_FILE_83:
+        jsr     S1_BASE+28
+        rts
+
+SDFS_API_GET_ERROR:
+        jsr     S1_BASE+31
+        rts
+
+SDFS_PRINT_PROMPT:
+        ldx     #TXT_PROMPT
+        jmp     SDFS_PRINT
+
+SDFS_PRINT:
+        ldaa    0,x
+        beq     SDFS_PRINT_DONE
+        jsr     SDFS_PUTC
+        inx
+        bra     SDFS_PRINT
+SDFS_PRINT_DONE:
+        rts
+
+SDFS_PUTC:
+        psha
+        jsr     MIKBUG_OUTCH
+        pula
+        cmpa    #CHR_CR
+        bne     SDFS_PUTC_DONE
+        ldaa    #CHR_LF
+        jsr     MIKBUG_OUTCH
+SDFS_PUTC_DONE:
+        rts
+
+TXT_BANNER:
+        fcb     CHR_CR
+        fcc     "SDFS/68 V1"
+        fcb     CHR_CR,0
+
+TXT_PROMPT:
+        fcc     "SDFS> "
+        fcb     0
+
+TXT_S1_ERROR:
+        fcb     CHR_CR
+        fcc     "S1?"
+        fcb     CHR_CR,0
+
+SDFS_END:
+        if SDFS_END-1 > SDFS_LOAD_LIMIT
+        error   "SDFS/68 exceeds SDFS_LOAD_LIMIT"
+        endif

--- a/tests/test_sdfs68_build.py
+++ b/tests/test_sdfs68_build.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""SDFS/68 minimal binary tests."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "tools"))
+
+from mk_sdfs_image import build_sdfs_image  # noqa: E402
+
+EMU_PATH = PROJECT_ROOT / "emu" / "sbc6800_emu.py"
+
+
+EXPECTED = {
+    "sbcio_vdg": {
+        "suffix": "-sbcio-vdg",
+        "SDFS_LOAD_BASE": 0xD000,
+        "SDFS_LOAD_LIMIT": 0xDEFF,
+    },
+    "k6802_vdg": {
+        "suffix": "-k6802-vdg",
+        "SDFS_LOAD_BASE": 0xB000,
+        "SDFS_LOAD_LIMIT": 0xBEFF,
+    },
+}
+
+
+def test_sdfs_rejects_base_profile() -> None:
+    result = _run_make("base", "sdfs", expect_success=False)
+    assert result.returncode != 0
+    assert "stage1 target requires" in result.stdout or "stage1 target requires" in result.stderr
+    print("[PASS] test_sdfs_rejects_base_profile")
+
+
+def test_sdfs_profiles_build_and_match_header() -> None:
+    for profile, expected in EXPECTED.items():
+        _run_make(profile, "sdfs")
+        suffix = expected["suffix"]
+        bin_path = PROJECT_ROOT / "build" / f"SDFS{suffix}.BIN"
+        lst_path = PROJECT_ROOT / "build" / f"SDFS{suffix}.lst"
+        data = bin_path.read_bytes()
+        symbols = _load_symbols(
+            lst_path,
+            "SDFS_LOAD_BASE",
+            "SDFS_LOAD_LIMIT",
+            "SDFS_ENTRY",
+            "SDFS_END",
+        )
+        assert symbols["SDFS_LOAD_BASE"] == expected["SDFS_LOAD_BASE"], (
+            f"{profile} SDFS_LOAD_BASE mismatch"
+        )
+        assert symbols["SDFS_LOAD_LIMIT"] == expected["SDFS_LOAD_LIMIT"], (
+            f"{profile} SDFS_LOAD_LIMIT mismatch"
+        )
+        assert len(data) <= symbols["SDFS_LOAD_LIMIT"] - symbols["SDFS_LOAD_BASE"] + 1
+        assert data[0:6] == b"SDFS68"
+        assert data[6] == 1, "SDFS version mismatch"
+        assert data[7] == 16, "SDFS header size mismatch"
+        entry = (data[8] << 8) | data[9]
+        size = (data[10] << 8) | data[11]
+        assert entry == symbols["SDFS_ENTRY"], "SDFS entry mismatch"
+        assert size == len(data), "SDFS image size mismatch"
+        assert data[12:16] == bytes(4), "SDFS reserved bytes must be zero"
+    print("[PASS] test_sdfs_profiles_build_and_match_header")
+
+
+def test_sdfs_api_wrappers_target_stage1_jump_table() -> None:
+    profile = "sbcio_vdg"
+    _run_make(profile, "sdfs")
+    suffix = EXPECTED[profile]["suffix"]
+    data = (PROJECT_ROOT / "build" / f"SDFS{suffix}.BIN").read_bytes()
+    symbols = _load_symbols(
+        PROJECT_ROOT / "build" / f"SDFS{suffix}.lst",
+        "SDFS_LOAD_BASE",
+        "S1_BASE",
+        "SDFS_API_INIT",
+        "SDFS_API_READ_SECTOR",
+        "SDFS_API_MOUNT",
+        "SDFS_API_FIND_83",
+        "SDFS_API_LOAD_FILE_83",
+        "SDFS_API_GET_ERROR",
+    )
+    wrappers = {
+        "SDFS_API_INIT": 16,
+        "SDFS_API_READ_SECTOR": 19,
+        "SDFS_API_MOUNT": 22,
+        "SDFS_API_FIND_83": 25,
+        "SDFS_API_LOAD_FILE_83": 28,
+        "SDFS_API_GET_ERROR": 31,
+    }
+    for name, offset in wrappers.items():
+        index = symbols[name] - symbols["SDFS_LOAD_BASE"]
+        target = symbols["S1_BASE"] + offset
+        assert data[index : index + 4] == bytes(
+            [0xBD, (target >> 8) & 0xFF, target & 0xFF, 0x39]
+        ), f"{name} wrapper mismatch"
+    print("[PASS] test_sdfs_api_wrappers_target_stage1_jump_table")
+
+
+def test_stage1_boot_runs_built_sdfs_binary() -> None:
+    for profile, expected in EXPECTED.items():
+        _run_make(profile, "bin")
+        _run_make(profile, "stage1")
+        _run_make(profile, "sdfs")
+        suffix = expected["suffix"]
+        stage1 = (PROJECT_ROOT / "build" / f"stage1{suffix}.bin").read_bytes()
+        sdfs = (PROJECT_ROOT / "build" / f"SDFS{suffix}.BIN").read_bytes()
+        image = build_sdfs_image(stage1_data=stage1, sdfs_data=sdfs, extra_files=[])
+        stdout, stderr, rc = _run_emu_with_sd(
+            rom_path=PROJECT_ROOT / "build" / f"mc6800-monitor{suffix}.bin",
+            input_text="BOOT\rX",
+            sd_image=image,
+            max_cycles=120_000_000,
+        )
+        assert rc == 0 and "[TIMEOUT]" not in stderr, (
+            f"emulator failed for {profile}: rc={rc} stderr={stderr!r}"
+        )
+        assert "SDFS/68 V1" in stdout, f"missing SDFS banner for {profile}: {stdout!r}"
+        assert "SDFS> " in stdout, f"missing SDFS prompt for {profile}: {stdout!r}"
+    print("[PASS] test_stage1_boot_runs_built_sdfs_binary")
+
+
+def test_sdfs_rejects_missing_boot_services() -> None:
+    profile = "sbcio_vdg"
+    _run_make(profile, "bin")
+    _run_make(profile, "sdfs")
+    suffix = EXPECTED[profile]["suffix"]
+    sdfs_path = PROJECT_ROOT / "build" / f"SDFS{suffix}.BIN"
+    sdfs = sdfs_path.read_bytes()
+    symbols = _load_symbols(
+        PROJECT_ROOT / "build" / f"SDFS{suffix}.lst",
+        "SDFS_LOAD_BASE",
+        "SDFS_ENTRY",
+    )
+    input_text = (
+        f"M{symbols['SDFS_LOAD_BASE']:04X}\r"
+        f"{_hex_bytes(list(sdfs))}\r.\r"
+        f"G{symbols['SDFS_ENTRY']:04X}\rX"
+    )
+    stdout, stderr, rc = _run_emu(
+        rom_path=PROJECT_ROOT / "build" / "mc6800-monitor-sbcio-vdg.bin",
+        input_text=input_text,
+        max_cycles=40_000_000,
+    )
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    assert "S1?" in stdout, f"missing S1 error: {stdout!r}"
+    print("[PASS] test_sdfs_rejects_missing_boot_services")
+
+
+def test_sdfs_rejects_bad_boot_services_headers() -> None:
+    profile = "sbcio_vdg"
+    _run_make(profile, "bin")
+    _run_make(profile, "sdfs")
+    suffix = EXPECTED[profile]["suffix"]
+    sdfs = (PROJECT_ROOT / "build" / f"SDFS{suffix}.BIN").read_bytes()
+    symbols = _load_symbols(
+        PROJECT_ROOT / "build" / f"SDFS{suffix}.lst",
+        "S1_BASE",
+        "SDFS_LOAD_BASE",
+        "SDFS_ENTRY",
+    )
+    cases = [
+        ("bad version", b"S1API68\x02\x06"),
+        ("low api count", b"S1API68\x01\x05"),
+    ]
+    for label, header in cases:
+        input_text = (
+            f"M{symbols['S1_BASE']:04X}\r"
+            f"{_hex_bytes(list(header))}\r.\r"
+            f"M{symbols['SDFS_LOAD_BASE']:04X}\r"
+            f"{_hex_bytes(list(sdfs))}\r.\r"
+            f"G{symbols['SDFS_ENTRY']:04X}\rX"
+        )
+        stdout, stderr, rc = _run_emu(
+            rom_path=PROJECT_ROOT / "build" / "mc6800-monitor-sbcio-vdg.bin",
+            input_text=input_text,
+            max_cycles=40_000_000,
+        )
+        assert rc == 0 and "[TIMEOUT]" not in stderr, (
+            f"emulator failed for {label}: rc={rc} stderr={stderr!r}"
+        )
+        assert "S1?" in stdout, f"SDFS accepted {label}: {stdout!r}"
+    print("[PASS] test_sdfs_rejects_bad_boot_services_headers")
+
+
+def _run_make(
+    profile: str,
+    target: str,
+    expect_success: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["make", target, f"MONITOR_PROFILE={profile}"],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=15,
+    )
+    if expect_success and result.returncode != 0:
+        raise AssertionError(
+            f"make {target} failed for {profile}: stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+    return result
+
+
+def _run_emu_with_sd(
+    *,
+    rom_path: Path,
+    input_text: str,
+    sd_image: bytes,
+    max_cycles: int,
+) -> tuple[str, str, int]:
+    with tempfile.NamedTemporaryFile(suffix=".img", delete=False) as sd_file:
+        sd_file.write(sd_image)
+        sd_path = Path(sd_file.name)
+    try:
+        return _run_emu(
+            rom_path=rom_path,
+            input_text=input_text,
+            max_cycles=max_cycles,
+            extra_args=["--sd", str(sd_path)],
+        )
+    finally:
+        sd_path.unlink(missing_ok=True)
+
+
+def _run_emu(
+    *,
+    rom_path: Path,
+    input_text: str,
+    max_cycles: int,
+    extra_args: list[str] | None = None,
+) -> tuple[str, str, int]:
+    with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as input_file:
+        input_file.write(input_text.encode("ascii"))
+        input_path = Path(input_file.name)
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(EMU_PATH),
+                str(rom_path),
+                "--input",
+                str(input_path),
+                "--max-cycles",
+                str(max_cycles),
+                *(extra_args or []),
+            ],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=20,
+        )
+        return result.stdout, result.stderr, result.returncode
+    except subprocess.TimeoutExpired as exc:
+        return exc.stdout or "", (exc.stderr or "") + "[TIMEOUT]", -1
+    finally:
+        input_path.unlink(missing_ok=True)
+
+
+def _hex_bytes(values: list[int]) -> str:
+    return "\r".join(f"{value:02X}" for value in values)
+
+
+def _load_symbols(path: Path, *names: str) -> dict[str, int]:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    result: dict[str, int] = {}
+    for name in names:
+        patterns = [
+            re.compile(rf":\s*=\$([0-9A-Fa-f]{{1,4}})\s+{re.escape(name)}\s+equ\b"),
+            re.compile(rf"/([0-9A-Fa-f]{{1,4}})\s+:\s+.*\b{re.escape(name)}:\s*$"),
+            re.compile(rf"\b{re.escape(name)}\s+:\s+([0-9A-Fa-f]{{1,4}})\b"),
+        ]
+        for pattern in patterns:
+            match = pattern.search(text)
+            if match:
+                result[name] = int(match.group(1), 16)
+                break
+        if name not in result:
+            raise AssertionError(f"missing symbol in listing: {name}")
+    return result
+
+
+def main() -> None:
+    print("=" * 50)
+    print("SDFS/68 build tests")
+    print("=" * 50)
+    tests = [
+        test_sdfs_rejects_base_profile,
+        test_sdfs_profiles_build_and_match_header,
+        test_sdfs_api_wrappers_target_stage1_jump_table,
+        test_stage1_boot_runs_built_sdfs_binary,
+        test_sdfs_rejects_missing_boot_services,
+        test_sdfs_rejects_bad_boot_services_headers,
+    ]
+    passed = 0
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            passed += 1
+        except AssertionError as exc:
+            print(f"[FAIL] {test.__name__}: {exc}")
+            failed += 1
+        except Exception as exc:
+            print(f"[ERROR] {test.__name__}: {exc}")
+            failed += 1
+    print()
+    print(f"Result: {passed} passed, {failed} failed")
+    sys.exit(0 if failed == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 対応Issue
- Closes #102
- Refs #82 #111 #128 #129 #130

## 変更内容
- `src/sdfs68.asm` を追加し、`SDFS68` header付きのSDFS/68最小本体を生成できるようにしました。
- `make sdfs` ターゲットを追加し、`sbcio_vdg` / `k6802_vdg` のprofile別SDFS/68バイナリを生成します。
- 起動時に `S1API68` boot services header、version、API countを検査し、正常時は `SDFS/68 V1` と `SDFS> ` を表示します。
- SDFS/68側のstage1 boot services wrapperを固定offsetのjump tableへ接続しました。
- #102計画文書とビルド手順を更新しました。

## 注意事項
- `S1_LOAD_FILE_83` はロード先が `SDFS_LOAD_BASE` 固定のため、起動後のSDFS/68本体から直接呼ぶと自己上書きします。#130では別バッファ読み込みまたはsector/stream処理を設計します。
- HEX/S-record loader、DIR/TYPE/AUTOEXEC、ROM FAT整理はこのPRの対象外です。

## テスト結果
- `python3 tests/test_sdfs68_build.py`
- `python3 tests/test_stage1_build.py`
- `python3 tests/test_mk_sdfs_image.py`
- `MONITOR_PROFILE=sbcio_vdg make sdfs`
- `MONITOR_PROFILE=k6802_vdg make sdfs`
- `make bin`
- `REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py`
- `REQUIRE_BUILD_ROM=1 python3 tests/test_sd_fixture.py`
- `git diff --check`