### PR TITLE
feat: SDFS/68にHEXロードを追加

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@
 - [plans/issue-123_stage1_memory_3kb.md](plans/issue-123_stage1_memory_3kb.md): SDFS/68 stage1 3KB配置
 - [plans/issue-125_stage1_sdfs_entry.md](plans/issue-125_stage1_sdfs_entry.md): SDFS/68 stage1 header検査とentry jump
 - [plans/issue-129_sdfs68_migration_roadmap.md](plans/issue-129_sdfs68_migration_roadmap.md): SDFS/68 v1移行とROM FAT整理ロードマップ
+- [plans/issue-130_sdfs68_loader.md](plans/issue-130_sdfs68_loader.md): SDFS/68 v1 HEX/S-recordロード
 - [testing/sbc6800_bringup.md](testing/sbc6800_bringup.md)
 - [testing/sbc_io_sd_bringup.md](testing/sbc_io_sd_bringup.md): SBC-IO と microSD SPI モジュールで SD/FAT を実機確認する手順
 - [testing/sbc6800_datapack.md](testing/sbc6800_datapack.md): SBC6800 データパックの扱いと互換確認

--- a/docs/plans/issue-130_sdfs68_loader.md
+++ b/docs/plans/issue-130_sdfs68_loader.md
@@ -1,0 +1,46 @@
+# Issue #130 SDFS/68 v1 HEX/S-recordロード
+
+## 背景
+
+#102 で SDFS/68 最小本体が起動し、stage1 boot services の header と jump table を確認できるようになった。#130 では、ROM常駐 `LF` の主用途である S-Record / Intel HEX ロードを SDFS/68 側へ移す。
+
+## 方針
+
+- SDFS/68 の最小シェルに `L filename` コマンドを追加する。
+- ロード確認用に `Dhhhh` で1 byteを表示する最小dumpコマンドを追加する。
+- filename は v1 では root directory の 8.3 short filename のみ扱う。
+- `S1_LOAD_FILE_83` は使わない。これはロード先が `SDFS_LOAD_BASE` 固定で、起動後の SDFS/68 本体を自己上書きするため。
+- ファイル検索は `S1_MOUNT` と `S1_FIND_83` を使う。
+- ファイル内容の読み取りは、stage1 が設定した FAT work 変数を参照し、SDFS/68 側の最小 stream reader が `S1_READ_SECTOR` で sector を読みながら 1 byte ずつ loader parser へ渡す。
+- S-Record / Intel HEX parser は ROM loader と同等の制限を引き継ぐ。
+
+## 対応形式
+
+- S-Record は `S0` / `S1` / `S2` / `S5` / `S8` / `S9` を扱う。
+- S-Record の実データ書き込みは `S1` / `S2` のみ行う。
+- `S2` は上位 1 byte が `0` の 24bit address のみ許容する。
+- Intel HEX は record type `00` と `01` のみ扱う。
+- Intel HEX の拡張リニアアドレス、拡張セグメントアドレスは v1 では扱わない。
+- SDFS/68 v1 はロード先アドレスの保護を行わない。SDFS/68本体、stage1、SD/FAT work、stack、VDG VRAMなどを壊す入力は利用者責任で避ける。
+- SDFS/68側のFAT streamは既存stage1/FAT work変数を参照する暫定実装であり、v1では `mk-sdfs` 生成イメージのrootファイルを対象にする。クラスタ番号が大きい汎用FAT32カードでの堅牢性は、将来のstage1 stream APIまたはFAT処理整理で扱う。
+
+## 対象外
+
+- stage1 boot services のAPI追加。
+- `DIR`、`TYPE`、AUTOEXEC。
+- 汎用FAT32カード上の任意クラスタ配置への完全対応。
+- ロード先メモリ範囲の保護。
+- FAT write、subdirectory、LFN。
+- ROM側 `DIR` / `LF` 整理。これは #128 で扱う。
+
+## 検証方針
+
+- `mk-sdfs` 生成相当のSDイメージに `.S` / `.HEX` を置き、SDFS/68 の `L filename` でロードできることを確認する。
+- ロード結果はテスト内で SDFS/68 のプロンプト文字列を書き換え、出力変化として確認する。
+- 存在しないファイル、壊れたHEX、終端なしS-recordでハングせずプロンプトへ戻ることを確認する。
+- `S1_LOAD_FILE_83` を起動後に使わないことを実装コメントと計画文書に残す。
+
+## 後続
+
+- #128 で SDFS/68 移行後のROM常駐FAT `DIR` / `LF` を整理する。
+- 将来、stage1 APIに file stream service を追加する場合は、SDFS/68側のFAT stream重複を減らす。

--- a/docs/usage/sdfs68_system_sd.md
+++ b/docs/usage/sdfs68_system_sd.md
@@ -76,6 +76,32 @@ v1 の root directory は次を想定する。
 
 `AUTOEXEC.S` は v1 の必須ファイルではない。ROM 側 `BOOT` は `AUTOEXEC.S` を直接読まない。
 
+## SDFS/68 v1 コマンド
+
+SDFS/68 v1 は最小シェルとして `SDFS> ` プロンプトを表示する。
+
+| コマンド | 用途 |
+| --- | --- |
+| `L filename` | FAT root の8.3 short filenameファイルをS-RecordまたはIntel HEXとしてロードする |
+| `Dhhhh` | 16bit hexadecimal address の1 byteを表示する。ロード確認用の最小コマンド |
+
+例:
+
+```text
+SDFS> L HELLO.S
+OK
+SDFS> L HELLO.HEX
+OK
+SDFS> D0200
+0200 86
+```
+
+存在しないファイル、壊れたHEX、終端recordなしのファイルでは `?` または `?S5` / `?I5` のようなloader stage付きエラーを表示し、プロンプトへ戻る。
+
+SDFS/68 v1 のloaderは ROM loader と同じ制限を持つ。S-Recordは `S1` / `S2` のデータrecordを扱い、`S2` は上位 1 byte が `0` の場合だけ有効である。Intel HEX は record type `00` と `01` のみ対応し、拡張アドレスrecordは扱わない。
+
+SDFS/68 v1 はloaderの書き込み先アドレスを保護しない。`SDFS.BIN` 本体、stage1、SD/FAT work、stack、VDG VRAMなどを壊すファイルも指定できるため、当面は作成者がロード先を管理する。
+
 ## 将来拡張
 
 SDFS/68 v2 以降では、既存 FAT32 カードへ必要ファイルをコピーする補助ツールを追加できる。

--- a/src/sdfs68.asm
+++ b/src/sdfs68.asm
@@ -35,13 +35,88 @@ SDFS_START:
         jsr     SDFS_PRINT_PROMPT
 
 SDFS_LOOP:
-        jsr     MIKBUG_INCH
-        cmpa    #CHR_LF
-        beq     SDFS_LOOP
-        cmpa    #CHR_CR
-        bne     SDFS_LOOP
+        jsr     SDFS_READ_LINE
+        ldab    LINE_LEN
+        beq     SDFS_PROMPT_NEXT
+        ldaa    LINE_BUF
+        jsr     SDFS_TO_UPPER
+        cmpa    #'L'
+        bne     SDFS_CHECK_DUMP
+        jsr     SDFS_CMD_LOAD
+        bcc     SDFS_LOAD_OK
+        jsr     SDFS_SHOW_LOADER_ERROR
+        bra     SDFS_PROMPT_NEXT
+SDFS_LOAD_OK:
+        ldx     #TXT_OK
+        jsr     SDFS_PRINT
+        bra     SDFS_PROMPT_NEXT
+SDFS_CHECK_DUMP:
+        cmpa    #'D'
+        bne     SDFS_COMMAND_ERROR
+        jsr     SDFS_CMD_DUMP_BYTE
+        bcc     SDFS_PROMPT_NEXT
+        jsr     SDFS_SHOW_ERROR
+SDFS_PROMPT_NEXT:
         jsr     SDFS_PRINT_PROMPT
         bra     SDFS_LOOP
+SDFS_COMMAND_ERROR:
+        jsr     SDFS_SHOW_ERROR
+        bra     SDFS_PROMPT_NEXT
+
+SDFS_CMD_LOAD:
+        clr     LOADER_MODE
+        clr     LOADER_STAGE
+        ldab    LINE_LEN
+        cmpb    #2
+        blo     SDFS_CMD_LOAD_FAIL
+        subb    #1
+        ldx     #LINE_BUF+1
+        jsr     SDFS_PARSE_FILENAME_83
+        bcs     SDFS_CMD_LOAD_FAIL
+        jsr     SDFS_API_MOUNT
+        bcs     SDFS_CMD_LOAD_FAIL
+        ldx     #FAT_FIND_NAME0
+        jsr     SDFS_API_FIND_83
+        bcs     SDFS_CMD_LOAD_FAIL
+        jsr     SDFS_STREAM_OPEN
+        bcs     SDFS_CMD_LOAD_FAIL
+SDFS_LOAD_LOOP:
+        jsr     SDFS_READ_LOADER_RECORD
+        bcs     SDFS_CMD_LOAD_FAIL
+        cmpa    #1
+        beq     SDFS_CMD_LOAD_DONE
+        bra     SDFS_LOAD_LOOP
+SDFS_CMD_LOAD_DONE:
+        clc
+        rts
+SDFS_CMD_LOAD_FAIL:
+        sec
+        rts
+
+SDFS_CMD_DUMP_BYTE:
+        ldab    LINE_LEN
+        cmpb    #2
+        blo     SDFS_CMD_DUMP_FAIL
+        subb    #1
+        ldx     #LINE_BUF+1
+        jsr     SDFS_PARSE_HEX16
+        bcs     SDFS_CMD_DUMP_FAIL
+        ldaa    HEX_VALUE_HI
+        jsr     SDFS_PRINT_HEX8
+        ldaa    HEX_VALUE_LO
+        jsr     SDFS_PRINT_HEX8
+        ldaa    #CHR_SPACE
+        jsr     SDFS_PUTC
+        ldx     HEX_VALUE_HI
+        ldaa    0,x
+        jsr     SDFS_PRINT_HEX8
+        ldaa    #CHR_CR
+        jsr     SDFS_PUTC
+        clc
+        rts
+SDFS_CMD_DUMP_FAIL:
+        sec
+        rts
 
 SDFS_CHECK_S1:
         ldx     #S1_BASE
@@ -104,6 +179,925 @@ SDFS_API_GET_ERROR:
         jsr     S1_BASE+31
         rts
 
+SDFS_READ_LINE:
+        ldx     #LINE_BUF
+        stx     LINE_PTR
+        clr     LINE_LEN
+SDFS_READ_LINE_LOOP:
+        jsr     MIKBUG_INCH
+        cmpa    #CHR_LF
+        beq     SDFS_READ_LINE_LOOP
+        cmpa    #CHR_CR
+        beq     SDFS_READ_LINE_DONE
+        cmpa    #CHR_BS
+        beq     SDFS_READ_LINE_BACKSPACE
+        cmpa    #CHR_DEL
+        beq     SDFS_READ_LINE_BACKSPACE
+        cmpa    #CHR_SPACE
+        blo     SDFS_READ_LINE_LOOP
+        ldab    LINE_LEN
+        cmpb    #LINE_BUF_SIZE
+        bhs     SDFS_READ_LINE_LOOP
+        ldx     LINE_PTR
+        staa    0,x
+        inx
+        stx     LINE_PTR
+        inc     LINE_LEN
+        bra     SDFS_READ_LINE_LOOP
+SDFS_READ_LINE_BACKSPACE:
+        tst     LINE_LEN
+        beq     SDFS_READ_LINE_LOOP
+        ldx     LINE_PTR
+        dex
+        stx     LINE_PTR
+        dec     LINE_LEN
+        bra     SDFS_READ_LINE_LOOP
+SDFS_READ_LINE_DONE:
+        ldaa    #CHR_CR
+        jsr     SDFS_PUTC
+        rts
+
+SDFS_PARSE_FILENAME_83:
+        stx     ARG_PTR
+        stab    ARG_LEN
+        jsr     SDFS_CLEAR_FIND_NAME
+SDFS_PARSE_FILENAME_SKIP_HEAD:
+        tst     ARG_LEN
+        bne     SDFS_PARSE_FILENAME_SKIP_HAS
+        jmp     SDFS_PARSE_FILENAME_FAIL
+SDFS_PARSE_FILENAME_SKIP_HAS:
+        ldx     ARG_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        bne     SDFS_PARSE_FILENAME_NAME_START
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        bra     SDFS_PARSE_FILENAME_SKIP_HEAD
+
+SDFS_PARSE_FILENAME_NAME_START:
+        ldx     #FAT_FIND_NAME0
+        stx     FAT_ENTRY_PTR
+        clr     ARG2_LEN
+SDFS_PARSE_FILENAME_NAME_LOOP:
+        tst     ARG_LEN
+        beq     SDFS_PARSE_FILENAME_NAME_DONE
+        ldx     ARG_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        bne     SDFS_PARSE_FILENAME_NAME_NOT_SPACE
+        jmp     SDFS_PARSE_FILENAME_TRAILING
+SDFS_PARSE_FILENAME_NAME_NOT_SPACE:
+        cmpa    #'.'
+        bne     SDFS_PARSE_FILENAME_NAME_NOT_DOT
+        jmp     SDFS_PARSE_FILENAME_EXT_START
+SDFS_PARSE_FILENAME_NAME_NOT_DOT:
+        ldab    ARG2_LEN
+        cmpb    #8
+        blo     SDFS_PARSE_FILENAME_NAME_ROOM
+        jmp     SDFS_PARSE_FILENAME_FAIL
+SDFS_PARSE_FILENAME_NAME_ROOM:
+        jsr     SDFS_TO_UPPER
+        ldx     FAT_ENTRY_PTR
+        staa    0,x
+        inx
+        stx     FAT_ENTRY_PTR
+        inc     ARG2_LEN
+        ldx     ARG_PTR
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        bra     SDFS_PARSE_FILENAME_NAME_LOOP
+
+SDFS_PARSE_FILENAME_NAME_DONE:
+        tst     ARG2_LEN
+        bne     SDFS_PARSE_FILENAME_NAME_OK
+        jmp     SDFS_PARSE_FILENAME_FAIL
+SDFS_PARSE_FILENAME_NAME_OK:
+        jmp     SDFS_PARSE_FILENAME_OK
+
+SDFS_PARSE_FILENAME_EXT_START:
+        tst     ARG2_LEN
+        bne     SDFS_PARSE_FILENAME_EXT_NAME_OK
+        jmp     SDFS_PARSE_FILENAME_FAIL
+SDFS_PARSE_FILENAME_EXT_NAME_OK:
+        ldx     ARG_PTR
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        ldx     #FAT_FIND_NAME8
+        stx     FAT_ENTRY_PTR
+        clr     ARG2_LEN
+SDFS_PARSE_FILENAME_EXT_LOOP:
+        tst     ARG_LEN
+        bne     SDFS_PARSE_FILENAME_EXT_HAS_LEN
+        jmp     SDFS_PARSE_FILENAME_OK
+SDFS_PARSE_FILENAME_EXT_HAS_LEN:
+        ldx     ARG_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        bne     SDFS_PARSE_FILENAME_EXT_NOT_SPACE
+        jmp     SDFS_PARSE_FILENAME_TRAILING
+SDFS_PARSE_FILENAME_EXT_NOT_SPACE:
+        cmpa    #'.'
+        bne     SDFS_PARSE_FILENAME_EXT_CHAR_OK
+        jmp     SDFS_PARSE_FILENAME_FAIL
+SDFS_PARSE_FILENAME_EXT_CHAR_OK:
+        ldab    ARG2_LEN
+        cmpb    #3
+        blo     SDFS_PARSE_FILENAME_EXT_ROOM
+        jmp     SDFS_PARSE_FILENAME_FAIL
+SDFS_PARSE_FILENAME_EXT_ROOM:
+        jsr     SDFS_TO_UPPER
+        ldx     FAT_ENTRY_PTR
+        staa    0,x
+        inx
+        stx     FAT_ENTRY_PTR
+        inc     ARG2_LEN
+        ldx     ARG_PTR
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        bra     SDFS_PARSE_FILENAME_EXT_LOOP
+
+SDFS_PARSE_FILENAME_TRAILING:
+        ldx     ARG_PTR
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+SDFS_PARSE_FILENAME_TRAILING_LOOP:
+        tst     ARG_LEN
+        beq     SDFS_PARSE_FILENAME_OK
+        ldx     ARG_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        beq     SDFS_PARSE_FILENAME_TRAILING_SPACE_OK
+        jmp     SDFS_PARSE_FILENAME_FAIL
+SDFS_PARSE_FILENAME_TRAILING_SPACE_OK:
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        bra     SDFS_PARSE_FILENAME_TRAILING_LOOP
+
+SDFS_PARSE_FILENAME_OK:
+        clc
+        rts
+SDFS_PARSE_FILENAME_FAIL:
+        sec
+        rts
+
+SDFS_CLEAR_FIND_NAME:
+        ldx     #FAT_FIND_NAME0
+        ldab    #11
+SDFS_CLEAR_FIND_NAME_LOOP:
+        ldaa    #CHR_SPACE
+        staa    0,x
+        inx
+        decb
+        bne     SDFS_CLEAR_FIND_NAME_LOOP
+        rts
+
+SDFS_TO_UPPER:
+        cmpa    #'a'
+        blo     SDFS_TO_UPPER_DONE
+        cmpa    #'z'
+        bhi     SDFS_TO_UPPER_DONE
+        suba    #$20
+SDFS_TO_UPPER_DONE:
+        rts
+
+SDFS_PARSE_HEX16:
+        stx     ARG_PTR
+        stab    ARG_LEN
+        clr     HEX_VALUE_HI
+        clr     HEX_VALUE_LO
+        clr     ARG2_LEN
+SDFS_PARSE_HEX16_SKIP:
+        tst     ARG_LEN
+        bne     SDFS_PARSE_HEX16_SKIP_HAS
+        jmp     SDFS_PARSE_HEX16_FAIL
+SDFS_PARSE_HEX16_SKIP_HAS:
+        ldx     ARG_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        bne     SDFS_PARSE_HEX16_LOOP
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        bra     SDFS_PARSE_HEX16_SKIP
+SDFS_PARSE_HEX16_LOOP:
+        tst     ARG_LEN
+        beq     SDFS_PARSE_HEX16_DONE
+        ldx     ARG_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        beq     SDFS_PARSE_HEX16_TRAILING
+        jsr     SDFS_HEX_TO_NIBBLE
+        bcs     SDFS_PARSE_HEX16_FAIL
+        ldab    ARG2_LEN
+        cmpb    #4
+        bhs     SDFS_PARSE_HEX16_FAIL
+        tstb
+        beq     SDFS_PARSE_HEX16_HI_H
+        cmpb    #1
+        beq     SDFS_PARSE_HEX16_HI_L
+        cmpb    #2
+        beq     SDFS_PARSE_HEX16_LO_H
+        oraa    HEX_VALUE_LO
+        staa    HEX_VALUE_LO
+        bra     SDFS_PARSE_HEX16_ADVANCE
+SDFS_PARSE_HEX16_HI_H:
+        lsla
+        lsla
+        lsla
+        lsla
+        staa    HEX_VALUE_HI
+        bra     SDFS_PARSE_HEX16_ADVANCE
+SDFS_PARSE_HEX16_HI_L:
+        oraa    HEX_VALUE_HI
+        staa    HEX_VALUE_HI
+        bra     SDFS_PARSE_HEX16_ADVANCE
+SDFS_PARSE_HEX16_LO_H:
+        lsla
+        lsla
+        lsla
+        lsla
+        staa    HEX_VALUE_LO
+SDFS_PARSE_HEX16_ADVANCE:
+        ldx     ARG_PTR
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        inc     ARG2_LEN
+        bra     SDFS_PARSE_HEX16_LOOP
+SDFS_PARSE_HEX16_TRAILING:
+        ldx     ARG_PTR
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+SDFS_PARSE_HEX16_TRAILING_LOOP:
+        tst     ARG_LEN
+        beq     SDFS_PARSE_HEX16_DONE
+        ldx     ARG_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        bne     SDFS_PARSE_HEX16_FAIL
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        bra     SDFS_PARSE_HEX16_TRAILING_LOOP
+SDFS_PARSE_HEX16_DONE:
+        ldaa    ARG2_LEN
+        cmpa    #4
+        bne     SDFS_PARSE_HEX16_FAIL
+        clc
+        rts
+SDFS_PARSE_HEX16_FAIL:
+        sec
+        rts
+
+SDFS_STREAM_OPEN:
+        ldaa    FAT_FILE_CLUS0
+        staa    FAT_CUR_CLUS0
+        ldaa    FAT_FILE_CLUS1
+        staa    FAT_CUR_CLUS1
+        ldaa    FAT_FILE_CLUS2
+        staa    FAT_CUR_CLUS2
+        ldaa    FAT_FILE_CLUS3
+        staa    FAT_CUR_CLUS3
+        ldaa    FAT_FILE_SIZE0
+        staa    FAT_BYTES_REM0
+        ldaa    FAT_FILE_SIZE1
+        staa    FAT_BYTES_REM1
+        ldaa    FAT_FILE_SIZE2
+        staa    FAT_BYTES_REM2
+        ldaa    FAT_FILE_SIZE3
+        staa    FAT_BYTES_REM3
+        clr     FAT_COPY_COUNT
+        clr     FAT_COPY_COUNT+1
+        clr     FAT_SECTOR_IN_CLUS
+        ldx     #SD_SECTOR_BUF
+        stx     FAT_ENTRY_PTR
+        clc
+        rts
+
+SDFS_STREAM_GETC:
+        jsr     SDFS_BYTES_REMAIN
+        bcs     SDFS_STREAM_HAS_REMAIN
+        sec
+        rts
+SDFS_STREAM_HAS_REMAIN:
+        ldaa    FAT_COPY_COUNT
+        oraa    FAT_COPY_COUNT+1
+        bne     SDFS_STREAM_HAVE_SECTOR
+        jsr     SDFS_STREAM_LOAD_SECTOR
+        bcc     SDFS_STREAM_HAVE_SECTOR
+        sec
+        rts
+SDFS_STREAM_HAVE_SECTOR:
+        ldx     FAT_ENTRY_PTR
+        ldaa    0,x
+        inx
+        stx     FAT_ENTRY_PTR
+        psha
+        ldx     FAT_COPY_COUNT
+        dex
+        stx     FAT_COPY_COUNT
+        jsr     SDFS_DEC_BYTES_REM_ONE
+        ldaa    FAT_COPY_COUNT
+        oraa    FAT_COPY_COUNT+1
+        bne     SDFS_STREAM_RETURN_BYTE
+        jsr     SDFS_BYTES_REMAIN
+        bcc     SDFS_STREAM_RETURN_BYTE
+        jsr     SDFS_ADVANCE_FILE_SECTOR
+        bcc     SDFS_STREAM_RETURN_BYTE
+        pula
+        sec
+        rts
+SDFS_STREAM_RETURN_BYTE:
+        pula
+        clc
+        rts
+
+SDFS_STREAM_LOAD_SECTOR:
+        jsr     SDFS_SECTOR_TO_SD_LBA
+        ldx     #SD_SECTOR_BUF
+        jsr     SDFS_API_READ_SECTOR
+        bcc     SDFS_STREAM_LOAD_OK
+        sec
+        rts
+SDFS_STREAM_LOAD_OK:
+        jsr     SDFS_PREP_COPY_COUNT
+        ldx     #SD_SECTOR_BUF
+        stx     FAT_ENTRY_PTR
+        clc
+        rts
+
+SDFS_SECTOR_TO_SD_LBA:
+        jsr     SDFS_CLUSTER_TO_SD_LBA
+        ldab    FAT_SECTOR_IN_CLUS
+        beq     SDFS_SECTOR_TO_SD_LBA_DONE
+SDFS_SECTOR_TO_SD_LBA_LOOP:
+        jsr     SDFS_INC_SD_LBA
+        decb
+        bne     SDFS_SECTOR_TO_SD_LBA_LOOP
+SDFS_SECTOR_TO_SD_LBA_DONE:
+        rts
+
+SDFS_CLUSTER_TO_SD_LBA:
+        ldaa    FAT_DATA_LBA0
+        staa    SD_LBA0
+        ldaa    FAT_DATA_LBA1
+        staa    SD_LBA1
+        ldaa    FAT_DATA_LBA2
+        staa    SD_LBA2
+        ldaa    FAT_DATA_LBA3
+        staa    SD_LBA3
+        ldaa    FAT_CUR_CLUS3
+        suba    #$02
+        staa    FAT_TMP
+SDFS_CLUSTER_ADD_LOOP:
+        ldaa    FAT_TMP
+        beq     SDFS_CLUSTER_ADD_DONE
+        ldab    FAT_SEC_PER_CLUS
+SDFS_CLUSTER_ADD_SECTOR_LOOP:
+        jsr     SDFS_INC_SD_LBA
+        decb
+        bne     SDFS_CLUSTER_ADD_SECTOR_LOOP
+        dec     FAT_TMP
+        bra     SDFS_CLUSTER_ADD_LOOP
+SDFS_CLUSTER_ADD_DONE:
+        rts
+
+SDFS_INC_SD_LBA:
+        inc     SD_LBA3
+        bne     SDFS_INC_SD_LBA_DONE
+        inc     SD_LBA2
+        bne     SDFS_INC_SD_LBA_DONE
+        inc     SD_LBA1
+        bne     SDFS_INC_SD_LBA_DONE
+        inc     SD_LBA0
+SDFS_INC_SD_LBA_DONE:
+        rts
+
+SDFS_ADVANCE_FILE_SECTOR:
+        inc     FAT_SECTOR_IN_CLUS
+        ldaa    FAT_SECTOR_IN_CLUS
+        cmpa    FAT_SEC_PER_CLUS
+        blo     SDFS_ADVANCE_SAME_CLUSTER
+        clr     FAT_SECTOR_IN_CLUS
+        jsr     SDFS_NEXT_CLUSTER
+        bcc     SDFS_ADVANCE_NEXT_CLUSTER
+        sec
+        rts
+SDFS_ADVANCE_NEXT_CLUSTER:
+        jsr     SDFS_COPY_NEXT_TO_CUR
+SDFS_ADVANCE_SAME_CLUSTER:
+        clc
+        rts
+
+SDFS_NEXT_CLUSTER:
+        ldaa    FAT_FAT_LBA0
+        staa    SD_LBA0
+        ldaa    FAT_FAT_LBA1
+        staa    SD_LBA1
+        ldaa    FAT_FAT_LBA2
+        staa    SD_LBA2
+        ldaa    FAT_FAT_LBA3
+        staa    SD_LBA3
+        ldx     #SD_SECTOR_BUF
+        jsr     SDFS_API_READ_SECTOR
+        bcc     SDFS_NEXT_OFFSET_PREP
+        sec
+        rts
+SDFS_NEXT_OFFSET_PREP:
+        ldaa    FAT_CUR_CLUS3
+        asla
+        asla
+        tab
+        ldx     #SD_SECTOR_BUF
+SDFS_NEXT_OFFSET_LOOP:
+        tstb
+        beq     SDFS_NEXT_READ
+        inx
+        decb
+        bra     SDFS_NEXT_OFFSET_LOOP
+SDFS_NEXT_READ:
+        ldaa    3,x
+        anda    #$0F
+        staa    FAT_NEXT_CLUS0
+        ldaa    2,x
+        staa    FAT_NEXT_CLUS1
+        ldaa    1,x
+        staa    FAT_NEXT_CLUS2
+        ldaa    0,x
+        staa    FAT_NEXT_CLUS3
+        ldaa    FAT_NEXT_CLUS0
+        cmpa    #$0F
+        bne     SDFS_NEXT_NOT_EOC
+        ldaa    FAT_NEXT_CLUS1
+        cmpa    #$FF
+        bne     SDFS_NEXT_NOT_EOC
+        ldaa    FAT_NEXT_CLUS2
+        cmpa    #$FF
+        bne     SDFS_NEXT_NOT_EOC
+        ldaa    FAT_NEXT_CLUS3
+        cmpa    #$F8
+        blo     SDFS_NEXT_NOT_EOC
+        sec
+        rts
+SDFS_NEXT_NOT_EOC:
+        clc
+        rts
+
+SDFS_COPY_NEXT_TO_CUR:
+        ldaa    FAT_NEXT_CLUS0
+        staa    FAT_CUR_CLUS0
+        ldaa    FAT_NEXT_CLUS1
+        staa    FAT_CUR_CLUS1
+        ldaa    FAT_NEXT_CLUS2
+        staa    FAT_CUR_CLUS2
+        ldaa    FAT_NEXT_CLUS3
+        staa    FAT_CUR_CLUS3
+        rts
+
+SDFS_BYTES_REMAIN:
+        ldaa    FAT_BYTES_REM0
+        oraa    FAT_BYTES_REM1
+        oraa    FAT_BYTES_REM2
+        oraa    FAT_BYTES_REM3
+        bne     SDFS_BYTES_REMAIN_YES
+        clc
+        rts
+SDFS_BYTES_REMAIN_YES:
+        sec
+        rts
+
+SDFS_PREP_COPY_COUNT:
+        ldaa    FAT_BYTES_REM0
+        oraa    FAT_BYTES_REM1
+        bne     SDFS_PREP_COPY_512
+        ldaa    FAT_BYTES_REM2
+        cmpa    #$02
+        bhs     SDFS_PREP_COPY_512
+        staa    FAT_COPY_COUNT
+        ldaa    FAT_BYTES_REM3
+        staa    FAT_COPY_COUNT+1
+        rts
+SDFS_PREP_COPY_512:
+        ldaa    #$02
+        staa    FAT_COPY_COUNT
+        clr     FAT_COPY_COUNT+1
+        rts
+
+SDFS_DEC_BYTES_REM_ONE:
+        ldaa    FAT_BYTES_REM3
+        bne     SDFS_DEC_REM_LO
+        ldaa    #$FF
+        staa    FAT_BYTES_REM3
+        ldaa    FAT_BYTES_REM2
+        bne     SDFS_DEC_REM_B2
+        ldaa    #$FF
+        staa    FAT_BYTES_REM2
+        ldaa    FAT_BYTES_REM1
+        bne     SDFS_DEC_REM_B1
+        ldaa    #$FF
+        staa    FAT_BYTES_REM1
+        dec     FAT_BYTES_REM0
+        rts
+SDFS_DEC_REM_B1:
+        dec     FAT_BYTES_REM1
+        rts
+SDFS_DEC_REM_B2:
+        dec     FAT_BYTES_REM2
+        rts
+SDFS_DEC_REM_LO:
+        dec     FAT_BYTES_REM3
+        rts
+
+SDFS_READ_LOADER_RECORD:
+        jsr     SDFS_READ_RECORD_HEAD
+        bcs     SDFS_READ_LOADER_RECORD_FAIL
+        ldaa    LOADER_MODE
+        bne     SDFS_READ_LOADER_RECORD_MODE_SET
+        ldaa    HEX_NIBBLE
+        cmpa    #'S'
+        beq     SDFS_READ_LOADER_RECORD_SET_SREC
+        cmpa    #':'
+        beq     SDFS_READ_LOADER_RECORD_SET_IHEX
+        sec
+        rts
+SDFS_READ_LOADER_RECORD_SET_SREC:
+        ldaa    #LOAD_MODE_SREC
+        staa    LOADER_MODE
+        bra     SDFS_READ_LOADER_RECORD_MODE_SET
+SDFS_READ_LOADER_RECORD_SET_IHEX:
+        ldaa    #LOAD_MODE_IHEX
+        staa    LOADER_MODE
+SDFS_READ_LOADER_RECORD_MODE_SET:
+        ldaa    LOADER_MODE
+        cmpa    #LOAD_MODE_SREC
+        beq     SDFS_READ_SREC_RECORD
+        cmpa    #LOAD_MODE_IHEX
+        bne     SDFS_READ_LOADER_RECORD_FAIL
+        jmp     SDFS_READ_IHEX_RECORD
+SDFS_READ_LOADER_RECORD_FAIL:
+        sec
+        rts
+
+SDFS_READ_RECORD_HEAD:
+        jsr     SDFS_STREAM_GETC
+        bcs     SDFS_READ_RECORD_HEAD_FAIL
+        cmpa    #CHR_LF
+        beq     SDFS_READ_RECORD_HEAD
+        cmpa    #CHR_CR
+        beq     SDFS_READ_RECORD_HEAD
+        cmpa    #CHR_SPACE
+        blo     SDFS_READ_RECORD_HEAD
+        staa    HEX_NIBBLE
+        clc
+        rts
+SDFS_READ_RECORD_HEAD_FAIL:
+        sec
+        rts
+
+SDFS_READ_RECORD_TRAILER:
+        jsr     SDFS_STREAM_GETC
+        bcs     SDFS_READ_RECORD_TRAILER_OK
+        cmpa    #CHR_LF
+        beq     SDFS_READ_RECORD_TRAILER_OK
+        cmpa    #CHR_CR
+        beq     SDFS_READ_RECORD_TRAILER_OK
+SDFS_READ_RECORD_TRAILER_FAIL:
+        sec
+        rts
+SDFS_READ_RECORD_TRAILER_OK:
+        clc
+        rts
+
+SDFS_READ_HEXBYTE_INPUT:
+        pshb
+        jsr     SDFS_STREAM_GETC
+        bcs     SDFS_READ_HEXBYTE_INPUT_FAIL
+        jsr     SDFS_HEX_TO_NIBBLE
+        bcs     SDFS_READ_HEXBYTE_INPUT_FAIL
+        lsla
+        lsla
+        lsla
+        lsla
+        tab
+        jsr     SDFS_STREAM_GETC
+        bcs     SDFS_READ_HEXBYTE_INPUT_FAIL
+        jsr     SDFS_HEX_TO_NIBBLE
+        bcs     SDFS_READ_HEXBYTE_INPUT_FAIL
+        aba
+        pulb
+        clc
+        rts
+SDFS_READ_HEXBYTE_INPUT_FAIL:
+        pulb
+        sec
+        rts
+
+SDFS_READ_SREC_RECORD:
+        ldaa    HEX_NIBBLE
+        cmpa    #'S'
+        beq     SDFS_READ_SREC_HEAD_OK
+        jmp     SDFS_READ_SREC_FAIL
+SDFS_READ_SREC_HEAD_OK:
+        ldaa    #1
+        staa    LOADER_STAGE
+        jsr     SDFS_STREAM_GETC
+        bcs     SDFS_READ_SREC_FAIL_NEAR0
+        staa    LOADER_TYPE
+        cmpa    #'0'
+        beq     SDFS_READ_SREC_TYPE_OK
+        cmpa    #'1'
+        beq     SDFS_READ_SREC_TYPE_OK
+        cmpa    #'2'
+        beq     SDFS_READ_SREC_TYPE_OK
+        cmpa    #'5'
+        beq     SDFS_READ_SREC_TYPE_OK
+        cmpa    #'8'
+        beq     SDFS_READ_SREC_TYPE_OK
+        cmpa    #'9'
+        beq     SDFS_READ_SREC_TYPE_OK
+        jmp     SDFS_READ_SREC_FAIL
+SDFS_READ_SREC_FAIL_NEAR0:
+        jmp     SDFS_READ_SREC_FAIL
+SDFS_READ_SREC_TYPE_OK:
+        ldaa    #2
+        staa    LOADER_STAGE
+        jsr     SDFS_READ_HEXBYTE_INPUT
+        bcs     SDFS_READ_SREC_FAIL_NEAR1
+        staa    LOADER_COUNT
+        staa    LOADER_SUM
+        ldaa    LOADER_TYPE
+        cmpa    #'2'
+        beq     SDFS_READ_SREC_ADDR24
+        cmpa    #'8'
+        beq     SDFS_READ_SREC_ADDR24
+        ldaa    LOADER_COUNT
+        cmpa    #3
+        blo     SDFS_READ_SREC_FAIL_NEAR1
+        ldaa    #3
+        staa    LOADER_STAGE
+        jsr     SDFS_READ_HEXBYTE_INPUT
+        bcs     SDFS_READ_SREC_FAIL_NEAR1
+        staa    LOADER_ADDR
+        jsr     SDFS_ADD_TO_LOADER_SUM
+        jsr     SDFS_READ_HEXBYTE_INPUT
+        bcs     SDFS_READ_SREC_FAIL_NEAR1
+        staa    LOADER_ADDR+1
+        jsr     SDFS_ADD_TO_LOADER_SUM
+        ldab    LOADER_COUNT
+        subb    #3
+        bra     SDFS_READ_SREC_DATA_LOOP
+SDFS_READ_SREC_FAIL_NEAR1:
+        jmp     SDFS_READ_SREC_FAIL
+SDFS_READ_SREC_ADDR24:
+        ldaa    LOADER_COUNT
+        cmpa    #4
+        blo     SDFS_READ_SREC_FAIL_NEAR2
+        ldaa    #3
+        staa    LOADER_STAGE
+        jsr     SDFS_READ_HEXBYTE_INPUT
+        bcs     SDFS_READ_SREC_FAIL_NEAR2
+        staa    HEX_NIBBLE
+        jsr     SDFS_ADD_TO_LOADER_SUM
+        ldaa    HEX_NIBBLE
+        bne     SDFS_READ_SREC_FAIL_NEAR2
+        jsr     SDFS_READ_HEXBYTE_INPUT
+        bcs     SDFS_READ_SREC_FAIL_NEAR2
+        staa    LOADER_ADDR
+        jsr     SDFS_ADD_TO_LOADER_SUM
+        jsr     SDFS_READ_HEXBYTE_INPUT
+        bcs     SDFS_READ_SREC_FAIL_NEAR2
+        staa    LOADER_ADDR+1
+        jsr     SDFS_ADD_TO_LOADER_SUM
+        ldab    LOADER_COUNT
+        subb    #4
+        bra     SDFS_READ_SREC_DATA_LOOP
+SDFS_READ_SREC_FAIL_NEAR2:
+        jmp     SDFS_READ_SREC_FAIL
+SDFS_READ_SREC_DATA_LOOP:
+        ldaa    #4
+        staa    LOADER_STAGE
+        tstb
+        beq     SDFS_READ_SREC_CHECKSUM
+        jsr     SDFS_READ_HEXBYTE_INPUT
+        bcs     SDFS_READ_SREC_FAIL
+        staa    HEX_NIBBLE
+        jsr     SDFS_ADD_TO_LOADER_SUM
+        ldaa    LOADER_TYPE
+        cmpa    #'1'
+        beq     SDFS_READ_SREC_STORE
+        cmpa    #'2'
+        bne     SDFS_READ_SREC_SKIP_STORE
+SDFS_READ_SREC_STORE:
+        ldaa    HEX_NIBBLE
+        pshb
+        ldx     LOADER_ADDR
+        staa    0,x
+        inx
+        stx     LOADER_ADDR
+        pulb
+SDFS_READ_SREC_SKIP_STORE:
+        decb
+        bra     SDFS_READ_SREC_DATA_LOOP
+SDFS_READ_SREC_CHECKSUM:
+        ldaa    #5
+        staa    LOADER_STAGE
+        jsr     SDFS_READ_HEXBYTE_INPUT
+        bcs     SDFS_READ_SREC_FAIL
+        jsr     SDFS_ADD_TO_LOADER_SUM
+        cmpa    #$FF
+        bne     SDFS_READ_SREC_FAIL
+        jsr     SDFS_READ_RECORD_TRAILER
+        bcs     SDFS_READ_SREC_FAIL
+        ldaa    LOADER_TYPE
+        cmpa    #'8'
+        beq     SDFS_READ_SREC_EOF
+        cmpa    #'9'
+        beq     SDFS_READ_SREC_EOF
+        ldaa    #0
+        clc
+        rts
+SDFS_READ_SREC_EOF:
+        ldaa    #1
+        clc
+        rts
+SDFS_READ_SREC_FAIL:
+        sec
+        rts
+
+SDFS_READ_IHEX_RECORD:
+        ldaa    HEX_NIBBLE
+        cmpa    #':'
+        beq     SDFS_READ_IHEX_HEAD_OK
+        jmp     SDFS_READ_IHEX_FAIL
+SDFS_READ_IHEX_HEAD_OK:
+        ldaa    #1
+        staa    LOADER_STAGE
+        ldaa    #2
+        staa    LOADER_STAGE
+        jsr     SDFS_READ_HEXBYTE_INPUT
+        bcs     SDFS_READ_IHEX_FAIL_NEAR1
+        staa    LOADER_COUNT
+        staa    LOADER_SUM
+        ldaa    #3
+        staa    LOADER_STAGE
+        jsr     SDFS_READ_HEXBYTE_INPUT
+        bcs     SDFS_READ_IHEX_FAIL_NEAR1
+        staa    LOADER_ADDR
+        jsr     SDFS_ADD_TO_LOADER_SUM
+        jsr     SDFS_READ_HEXBYTE_INPUT
+        bcs     SDFS_READ_IHEX_FAIL_NEAR1
+        staa    LOADER_ADDR+1
+        jsr     SDFS_ADD_TO_LOADER_SUM
+        jsr     SDFS_READ_HEXBYTE_INPUT
+        bcs     SDFS_READ_IHEX_FAIL_NEAR1
+        staa    LOADER_TYPE
+        jsr     SDFS_ADD_TO_LOADER_SUM
+        ldaa    LOADER_TYPE
+        cmpa    #$00
+        beq     SDFS_READ_IHEX_DATA
+        cmpa    #$01
+        bne     SDFS_READ_IHEX_FAIL
+        ldaa    LOADER_COUNT
+        bne     SDFS_READ_IHEX_FAIL
+        bra     SDFS_READ_IHEX_DATA
+SDFS_READ_IHEX_FAIL_NEAR1:
+        jmp     SDFS_READ_IHEX_FAIL
+SDFS_READ_IHEX_DATA:
+        ldaa    #4
+        staa    LOADER_STAGE
+        ldab    LOADER_COUNT
+SDFS_READ_IHEX_DATA_LOOP:
+        tstb
+        beq     SDFS_READ_IHEX_CHECKSUM
+        jsr     SDFS_READ_HEXBYTE_INPUT
+        bcs     SDFS_READ_IHEX_FAIL
+        staa    HEX_NIBBLE
+        jsr     SDFS_ADD_TO_LOADER_SUM
+        ldaa    LOADER_TYPE
+        cmpa    #$00
+        bne     SDFS_READ_IHEX_SKIP_STORE
+        ldaa    HEX_NIBBLE
+        pshb
+        ldx     LOADER_ADDR
+        staa    0,x
+        inx
+        stx     LOADER_ADDR
+        pulb
+SDFS_READ_IHEX_SKIP_STORE:
+        decb
+        bra     SDFS_READ_IHEX_DATA_LOOP
+SDFS_READ_IHEX_CHECKSUM:
+        ldaa    #5
+        staa    LOADER_STAGE
+        jsr     SDFS_READ_HEXBYTE_INPUT
+        bcs     SDFS_READ_IHEX_FAIL
+        jsr     SDFS_ADD_TO_LOADER_SUM
+        cmpa    #$00
+        bne     SDFS_READ_IHEX_FAIL
+        jsr     SDFS_READ_RECORD_TRAILER
+        bcs     SDFS_READ_IHEX_FAIL
+        ldaa    LOADER_TYPE
+        cmpa    #$01
+        beq     SDFS_READ_IHEX_EOF
+        ldaa    #0
+        clc
+        rts
+SDFS_READ_IHEX_EOF:
+        ldaa    #1
+        clc
+        rts
+SDFS_READ_IHEX_FAIL:
+        sec
+        rts
+
+SDFS_HEX_TO_NIBBLE:
+        cmpa    #'0'
+        blo     SDFS_HEX_TO_NIBBLE_FAIL
+        cmpa    #'9'
+        bhi     SDFS_HEX_ALPHA
+        suba    #'0'
+        clc
+        rts
+SDFS_HEX_ALPHA:
+        cmpa    #'A'
+        blo     SDFS_HEX_LOWER
+        cmpa    #'F'
+        bhi     SDFS_HEX_LOWER
+        suba    #'A'
+        adda    #10
+        clc
+        rts
+SDFS_HEX_LOWER:
+        cmpa    #'a'
+        blo     SDFS_HEX_TO_NIBBLE_FAIL
+        cmpa    #'f'
+        bhi     SDFS_HEX_TO_NIBBLE_FAIL
+        suba    #'a'
+        adda    #10
+        clc
+        rts
+SDFS_HEX_TO_NIBBLE_FAIL:
+        sec
+        rts
+
+SDFS_ADD_TO_LOADER_SUM:
+        adda    LOADER_SUM
+        staa    LOADER_SUM
+        rts
+
+SDFS_PRINT_HEX8:
+        psha
+        lsra
+        lsra
+        lsra
+        lsra
+        bsr     SDFS_PRINT_NIBBLE
+        pula
+        bsr     SDFS_PRINT_NIBBLE
+        rts
+
+SDFS_PRINT_NIBBLE:
+        anda    #$0F
+        adda    #'0'
+        cmpa    #'9'+1
+        blo     SDFS_PRINT_NIBBLE_OUT
+        adda    #7
+SDFS_PRINT_NIBBLE_OUT:
+        jmp     SDFS_PUTC
+
+SDFS_SHOW_ERROR:
+        ldx     #TXT_ERROR
+        jmp     SDFS_PRINT
+
+SDFS_SHOW_LOADER_ERROR:
+        ldx     #TXT_ERROR_PREFIX
+        jsr     SDFS_PRINT
+        ldaa    LOADER_MODE
+        beq     SDFS_SHOW_LOADER_ERROR_CR
+        cmpa    #LOAD_MODE_SREC
+        bne     SDFS_SHOW_LOADER_ERROR_IHEX
+        ldaa    #'S'
+        jsr     SDFS_PUTC
+        bra     SDFS_SHOW_LOADER_ERROR_STAGE
+SDFS_SHOW_LOADER_ERROR_IHEX:
+        ldaa    #'I'
+        jsr     SDFS_PUTC
+SDFS_SHOW_LOADER_ERROR_STAGE:
+        ldaa    LOADER_STAGE
+        adda    #'0'
+        jsr     SDFS_PUTC
+SDFS_SHOW_LOADER_ERROR_CR:
+        ldaa    #CHR_CR
+        jsr     SDFS_PUTC
+        rts
+
 SDFS_PRINT_PROMPT:
         ldx     #TXT_PROMPT
         jmp     SDFS_PRINT
@@ -135,6 +1129,18 @@ TXT_BANNER:
 
 TXT_PROMPT:
         fcc     "SDFS> "
+        fcb     0
+
+TXT_OK:
+        fcc     "OK"
+        fcb     CHR_CR,0
+
+TXT_ERROR:
+        fcc     "?"
+        fcb     CHR_CR,0
+
+TXT_ERROR_PREFIX:
+        fcc     "?"
         fcb     0
 
 TXT_S1_ERROR:

--- a/tests/test_sdfs68_build.py
+++ b/tests/test_sdfs68_build.py
@@ -13,6 +13,7 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "tools"))
 
+from fat32_image import Fat32File  # noqa: E402
 from mk_sdfs_image import build_sdfs_image  # noqa: E402
 
 EMU_PATH = PROJECT_ROOT / "emu" / "sbc6800_emu.py"
@@ -125,6 +126,68 @@ def test_stage1_boot_runs_built_sdfs_binary() -> None:
         assert "SDFS/68 V1" in stdout, f"missing SDFS banner for {profile}: {stdout!r}"
         assert "SDFS> " in stdout, f"missing SDFS prompt for {profile}: {stdout!r}"
     print("[PASS] test_stage1_boot_runs_built_sdfs_binary")
+
+
+def test_sdfs_loads_srec_and_ihex_files() -> None:
+    for profile, expected in EXPECTED.items():
+        _run_make(profile, "bin")
+        _run_make(profile, "stage1")
+        _run_make(profile, "sdfs")
+        suffix = expected["suffix"]
+        stage1 = (PROJECT_ROOT / "build" / f"stage1{suffix}.bin").read_bytes()
+        sdfs = (PROJECT_ROOT / "build" / f"SDFS{suffix}.BIN").read_bytes()
+        image = build_sdfs_image(
+            stage1_data=stage1,
+            sdfs_data=sdfs,
+            extra_files=[
+                _file("HELLO.S", _srec_file(0x0200, b"S")),
+                _file("HELLO.HEX", _ihex_file(0x0201, b"I")),
+                _file("EOF.HEX", _ihex_file(0x0202, b"N", trailing_newline=False)),
+            ],
+        )
+        stdout, stderr, rc = _run_emu_with_sd(
+            rom_path=PROJECT_ROOT / "build" / f"mc6800-monitor{suffix}.bin",
+            input_text="BOOT\rL HELLO.S\rD0200\rL HELLO.HEX\rD0201\rL EOF.HEX\rD0202\rX",
+            sd_image=image,
+            max_cycles=160_000_000,
+        )
+        assert rc == 0 and "[TIMEOUT]" not in stderr, (
+            f"emulator failed for {profile}: rc={rc} stderr={stderr!r}"
+        )
+        assert "0200 53" in stdout, f"S-record load did not write data for {profile}: {stdout!r}"
+        assert "0201 49" in stdout, f"Intel HEX load did not write data for {profile}: {stdout!r}"
+        assert "0202 4E" in stdout, f"EOF-without-newline HEX did not load for {profile}: {stdout!r}"
+        assert stdout.count("OK") >= 3, f"missing load success messages for {profile}: {stdout!r}"
+    print("[PASS] test_sdfs_loads_srec_and_ihex_files")
+
+
+def test_sdfs_loader_errors_return_to_prompt() -> None:
+    profile = "sbcio_vdg"
+    _run_make(profile, "bin")
+    _run_make(profile, "stage1")
+    _run_make(profile, "sdfs")
+    suffix = EXPECTED[profile]["suffix"]
+    stage1 = (PROJECT_ROOT / "build" / f"stage1{suffix}.bin").read_bytes()
+    sdfs = (PROJECT_ROOT / "build" / f"SDFS{suffix}.BIN").read_bytes()
+    image = build_sdfs_image(
+        stage1_data=stage1,
+        sdfs_data=sdfs,
+        extra_files=[
+            _file("BAD.HEX", b":00000000FF\r\n"),
+            _file("NOEND.S", b"S1060200010203F1\r\n"),
+        ],
+    )
+    stdout, stderr, rc = _run_emu_with_sd(
+        rom_path=PROJECT_ROOT / "build" / "mc6800-monitor-sbcio-vdg.bin",
+        input_text="BOOT\rL MISSING.S\rL BAD.HEX\rL NOEND.S\rX",
+        sd_image=image,
+        max_cycles=140_000_000,
+    )
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    assert "MISSING.S" in stdout and "BAD.HEX" in stdout and "NOEND.S" in stdout
+    assert stdout.count("SDFS> ") >= 4, f"SDFS prompt did not recover after errors: {stdout!r}"
+    assert "?" in stdout, f"missing loader error output: {stdout!r}"
+    print("[PASS] test_sdfs_loader_errors_return_to_prompt")
 
 
 def test_sdfs_rejects_missing_boot_services() -> None:
@@ -272,6 +335,34 @@ def _hex_bytes(values: list[int]) -> str:
     return "\r".join(f"{value:02X}" for value in values)
 
 
+def _file(name: str, data: bytes) -> Fat32File:
+    stem, _dot, ext = name.partition(".")
+    name83 = stem.upper().encode("ascii").ljust(8, b" ")
+    name83 += ext.upper().encode("ascii").ljust(3, b" ")
+    return Fat32File(name83, data)
+
+
+def _srec_file(address: int, data: bytes, trailing_newline: bool = True) -> bytes:
+    count = len(data) + 3
+    values = [count, (address >> 8) & 0xFF, address & 0xFF, *data]
+    checksum = (~sum(values)) & 0xFF
+    record = "S1" + "".join(f"{value:02X}" for value in [*values, checksum])
+    text = record + "\r\nS9030000FC"
+    if trailing_newline:
+        text += "\r\n"
+    return text.encode("ascii")
+
+
+def _ihex_file(address: int, data: bytes, trailing_newline: bool = True) -> bytes:
+    values = [len(data), (address >> 8) & 0xFF, address & 0xFF, 0x00, *data]
+    checksum = (-sum(values)) & 0xFF
+    record = ":" + "".join(f"{value:02X}" for value in [*values, checksum])
+    text = record + "\r\n:00000001FF"
+    if trailing_newline:
+        text += "\r\n"
+    return text.encode("ascii")
+
+
 def _load_symbols(path: Path, *names: str) -> dict[str, int]:
     text = path.read_text(encoding="utf-8", errors="replace")
     result: dict[str, int] = {}
@@ -300,6 +391,8 @@ def main() -> None:
         test_sdfs_profiles_build_and_match_header,
         test_sdfs_api_wrappers_target_stage1_jump_table,
         test_stage1_boot_runs_built_sdfs_binary,
+        test_sdfs_loads_srec_and_ihex_files,
+        test_sdfs_loader_errors_return_to_prompt,
         test_sdfs_rejects_missing_boot_services,
         test_sdfs_rejects_bad_boot_services_headers,
     ]


### PR DESCRIPTION
## 対応Issue
- Closes #130
- Refs #82 #102 #111 #128 #129

## 変更内容
- SDFS/68最小シェルに L filename を追加し、FAT rootの8.3ファイルをS-RecordまたはIntel HEXとしてロードできるようにしました。
- ロード確認用に Dhhhh の1 byte dumpコマンドを追加しました。
- S1_LOAD_FILE_83 は自己上書きになるため使わず、SDFS/68側で S1_MOUNT / S1_FIND_83 / S1_READ_SECTOR を使う最小FAT stream readerを持たせました。
- S-Record / Intel HEX parserはROM loader相当の制限を引き継ぎます。
- #130計画文書とSDFS/68使用手順を更新しました。

## 制限・未対応
- ロード先メモリ範囲は保護しません。SDFS/68本体、stage1、SD/FAT work、stack、VDG VRAMなどを壊すファイルは利用者側で避ける前提です。
- SDFS/68側FAT streamはv1暫定実装です。クラスタ番号が大きい汎用FAT32カードへの堅牢性は、将来のstage1 stream APIまたはFAT処理整理で扱います。
- Intel HEXの拡張アドレスrecord、subdirectory、LFN、FAT write、DIR/TYPE/AUTOEXECは対象外です。

## テスト結果
- python3 tests/test_sdfs68_build.py
- python3 tests/test_stage1_build.py
- python3 tests/test_mk_sdfs_image.py
- MONITOR_PROFILE=sbcio_vdg make sdfs
- MONITOR_PROFILE=k6802_vdg make sdfs
- make bin
- REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py
- REQUIRE_BUILD_ROM=1 python3 tests/test_sd_fixture.py
- git diff --check