### PR TITLE
docs: ROM FAT profile方針を整理

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@
 - [plans/issue-121_stage1_load_file_1sector.md](plans/issue-121_stage1_load_file_1sector.md): SDFS/68 stage1 1-sector file load boot service
 - [plans/issue-123_stage1_memory_3kb.md](plans/issue-123_stage1_memory_3kb.md): SDFS/68 stage1 3KB配置
 - [plans/issue-125_stage1_sdfs_entry.md](plans/issue-125_stage1_sdfs_entry.md): SDFS/68 stage1 header検査とentry jump
+- [plans/issue-128_rom_fat_cleanup.md](plans/issue-128_rom_fat_cleanup.md): SDFS/68移行後のROM常駐FAT DIR/LF整理
 - [plans/issue-129_sdfs68_migration_roadmap.md](plans/issue-129_sdfs68_migration_roadmap.md): SDFS/68 v1移行とROM FAT整理ロードマップ
 - [plans/issue-130_sdfs68_loader.md](plans/issue-130_sdfs68_loader.md): SDFS/68 v1 HEX/S-recordロード
 - [testing/sbc6800_bringup.md](testing/sbc6800_bringup.md)

--- a/docs/plans/issue-128_rom_fat_cleanup.md
+++ b/docs/plans/issue-128_rom_fat_cleanup.md
@@ -1,0 +1,43 @@
+# Issue #128 ROM常駐FAT DIR/LF整理
+
+## 背景
+
+#111、#102、#130 により、ROM `BOOT` から固定LBA stage1を読み、stage1が `SDFS.BIN` を起動し、SDFS/68側でS-Record / Intel HEXをロードできるようになった。これにより、ROM常駐FAT `DIR` / `LF` は本線機能ではなく互換機能として扱える。
+
+## 採用方針
+
+- `sbcio_vdg` / `k6802_vdg` は `BOOT + SDFS/68` 本線profileとする。
+- `sbcio_vdg` / `k6802_vdg` は `FEATURE_SD=1`、`FEATURE_FAT=0` を維持し、ROMには固定LBA `BOOT` とraw SD sector readを残す。
+- ROM常駐FAT `DIR` / `LF` は `sbcio` profileの互換機能として残す。
+- `base` profileは引き続きSDなしの最小ROMとする。
+- 新しいSDFS/68機能、I2C、RTC、OLED、AUTOEXEC、subdirectory、FAT writeはROMへ戻さず、SDFS/68側の後続Issueで扱う。
+
+## profileの意味
+
+| profile | ROM側の位置づけ | `FEATURE_SD` | `FEATURE_FAT` | `DIR` / `LF` | `BOOT` |
+| --- | --- | --- | --- | --- | --- |
+| `base` | SBC6800互換の最小ROM | 0 | 0 | なし | なし |
+| `sbcio` | ROM常駐FAT互換profile | 1 | 1 | あり | あり |
+| `sbcio_vdg` | SBC-IO + KBD + VDG + SDFS/68本線 | 1 | 0 | なし | あり |
+| `k6802_vdg` | K6802-SBC + KBD + VDG + SDFS/68本線 | 1 | 0 | なし | あり |
+
+## ROMサイズ確認
+
+`make bin` は固定vector領域を含むROMイメージを生成するため、単純な出力サイズは全profileで同じになる。今回の確認では `ROM_CODE_LIMIT=8192` の上限監視を通した。
+
+| profile | 確認コマンド | 出力サイズ |
+| --- | --- | --- |
+| `base` | `MONITOR_PROFILE=base make bin` | 8075 / 8192 bytes |
+| `sbcio` | `MONITOR_PROFILE=sbcio make bin` | 8075 / 8192 bytes |
+| `sbcio_vdg` | `MONITOR_PROFILE=sbcio_vdg make bin` | 8075 / 8192 bytes |
+| `k6802_vdg` | `MONITOR_PROFILE=k6802_vdg make bin` | 8075 / 8192 bytes |
+
+## 検証方針
+
+- `FEATURE_FAT=1` ではhelpに `DIR` / `LF` を表示し、ROM `DIR` / `LF` が動作することを確認する。
+- `FEATURE_FAT=0` かつ `FEATURE_SD=1` ではhelpに `BOOT` を表示し、`DIR` / `LF` は未対応として `?` を返すことを確認する。
+- `FEATURE_SD=0` ではSD行とSD系コマンドを表示しないことを確認する。
+
+## 後続
+
+ROM常駐FAT `DIR` / `LF` を完全削除する判断はしない。`sbcio` profileを互換入口として残し、SDFS/68 v2以降で `DIR`、`TYPE`、AUTOEXEC、subdirectoryなどを育てる。

--- a/docs/usage/monitor_commands.md
+++ b/docs/usage/monitor_commands.md
@@ -256,7 +256,7 @@ OK
 ロード処理はレコードを受信しながら解析する。
 ロード中の進捗表示は速度を優先して行わず、正常終了時は `OK`、異常時は `?S1` から `?S5`、または `?I1` から `?I5` を表示する。
 
-`LF filename` は `FEATURE_SD=1` のROMで、SDカード上のroot directoryから8.3 short filenameのファイルを検索し、S-RecordまたはIntel HEXとしてロードする。
+`LF filename` は `FEATURE_FAT=1` のROMで、SDカード上のroot directoryから8.3 short filenameのファイルを検索し、S-RecordまたはIntel HEXとしてロードする。
 既存の `L` とは別の入口だが、レコード解析とRAM書き込みは同じローダ処理を使う。
 
 ```text
@@ -267,11 +267,11 @@ OK
 
 ファイル名の前後の空白は無視する。subdirectory、LFN、wildcardは対象外である。
 LOAD後の自動実行は行わない。必要に応じて `Gssss` で開始アドレスへジャンプする。
-`FEATURE_SD=0` のROMでは `LF` のコマンド本体をROMに入れず、未対応コマンドとして `?` を返す。
+`FEATURE_FAT=0` のROMでは `LF` のコマンド本体をROMに入れず、未対応コマンドとして `?` を返す。`FEATURE_SD=1` / `FEATURE_FAT=0` のprofileでは、SDからのロードは `BOOT` でSDFS/68を起動し、SDFS/68側の `L filename` を使う。
 
 ## SD directory
 
-`DIR` は `FEATURE_SD=1` のROMで、SDカード上のroot directoryにある8.3通常ファイルを表示する。
+`DIR` は `FEATURE_FAT=1` のROMで、SDカード上のroot directoryにある8.3通常ファイルを表示する。
 LFN、削除entry、volume label、subdirectoryは表示しない。
 
 ```text
@@ -283,7 +283,7 @@ MULTI.BIN A 00000400
 ```
 
 サイズは8桁16進で表示する。`DIR` は `D` dumpとは別コマンドであり、従来の `D0100` や `D0100-011F` はそのまま使える。
-`FEATURE_SD=0` のROMでは `DIR` のコマンド本体をROMに入れず、`D` dump以外の未対応入力として `?` を返す。
+`FEATURE_FAT=0` のROMでは `DIR` のコマンド本体をROMに入れず、`D` dump以外の未対応入力として `?` を返す。
 
 ## ヘルプ
 
@@ -295,27 +295,35 @@ D M MAP RAMTEST G L B C R U H F
 ]
 ```
 
-`FEATURE_SD=1` のROMでは `DIR` と `LF` を含めて表示する。
+`FEATURE_SD=1` かつ `FEATURE_FAT=0` のROMでは、固定LBA stage1起動用の `BOOT` を含めて表示する。
 
 ```text
 ] H
-D DIR M MAP RAMTEST G L LF B C R U H F
+D M MAP RAMTEST G L BOOT B C R U H F
 ]
 ```
 
-`FEATURE_KEYBOARD=1` のROMでは `KEYTEST` を含めて表示する。
+`FEATURE_FAT=1` のROMでは、ROM常駐FAT互換機能として `DIR` と `LF` を含めて表示する。
 
 ```text
 ] H
-D DIR M MAP RAMTEST KEYTEST G L LF B C R U H F
+D DIR M MAP RAMTEST G L LF BOOT B C R U H F
 ]
 ```
 
-`FEATURE_VDG=1` かつ `FEATURE_KEYBOARD=1` のROMでは `VDGTEST` と `KEYTEST` を含めて表示する。
+`FEATURE_KEYBOARD=1` のROMでは `KEYTEST` を含めて表示する。次はSD/FATなしの例である。
 
 ```text
 ] H
-D DIR M MAP RAMTEST VDGTEST KEYTEST G L LF B C R U H F
+D M MAP RAMTEST KEYTEST G L B C R U H F
+]
+```
+
+`FEATURE_VDG=1` かつ `FEATURE_KEYBOARD=1` のROMでは `VDGTEST` と `KEYTEST` を含めて表示する。`FEATURE_SD=1` かつ `FEATURE_FAT=0` のprofileでは、ROM側FAT互換コマンドではなく `BOOT` を含める。
+
+```text
+] H
+D M MAP RAMTEST VDGTEST KEYTEST G L BOOT B C R U H F
 ]
 ```
 

--- a/tests/test_sd_fixture.py
+++ b/tests/test_sd_fixture.py
@@ -908,6 +908,25 @@ def test_rom_fat_commands_disabled_without_feature_fat() -> None:
     print("[PASS] test_rom_fat_commands_disabled_without_feature_fat")
 
 
+def test_rom_fat_feature_help_policy() -> None:
+    if not _is_sd_build():
+        print("[SKIP] test_rom_fat_feature_help_policy")
+        return
+
+    stdout, stderr, rc = _run_emu_with_sd("H\r\r", build_fat32_image(with_mbr=True))
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    if _is_fat_build():
+        expected = "D DIR M MAP RAMTEST KEYTEST G L LF BOOT B C R U H F"
+        assert expected in stdout, f"FEATURE_FAT=1 help should include DIR/LF/BOOT: {stdout!r}"
+    elif _is_vdg_build():
+        expected = "D M MAP RAMTEST VDGTEST KEYTEST G L BOOT B C R U H F"
+        assert expected in stdout, f"FEATURE_FAT=0 VDG help should keep BOOT only: {stdout!r}"
+    else:
+        expected = "D M MAP RAMTEST KEYTEST G L BOOT B C R U H F"
+        assert expected in stdout, f"FEATURE_FAT=0 help should keep BOOT only: {stdout!r}"
+    print("[PASS] test_rom_fat_feature_help_policy")
+
+
 def test_rom_lf_command_opens_83_files_only() -> None:
     image = build_fat32_image(with_mbr=True)
     input_text = (
@@ -1073,6 +1092,7 @@ def main() -> None:
             test_rom_boot_rejects_invalid_stage1_headers,
             test_rom_boot_returns_prompt_on_stage1_read_failure,
             test_rom_fat_commands_disabled_without_feature_fat,
+            test_rom_fat_feature_help_policy,
         ])
     if _is_fat_build():
         tests.extend([


### PR DESCRIPTION
## 対応Issue
- Closes #128
- Refs #82 #102 #111 #129 #130

## 変更内容
- `sbcio_vdg` / `k6802_vdg` を `BOOT + SDFS/68` 本線、`sbcio` をROM常駐FAT互換profileとして整理
- `docs/plans/issue-128_rom_fat_cleanup.md` にprofile別方針、ROMサイズ確認、後続判断を記録
- `monitor_commands.md` の `DIR` / `LF` 説明を `FEATURE_FAT=1` 基準へ修正
- `FEATURE_FAT=0/1` のhelp表示方針をSD fixtureテストへ追加

## テスト結果
- `git diff --check`
- `make bin`
- `REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py`
- `REQUIRE_BUILD_ROM=1 python3 tests/test_sd_fixture.py`
- `MONITOR_PROFILE=sbcio make bin`
- `MONITOR_PROFILE=sbcio REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py`
- `MONITOR_PROFILE=sbcio REQUIRE_BUILD_ROM=1 python3 tests/test_sd_fixture.py`
- `MONITOR_PROFILE=sbcio_vdg make bin`
- `MONITOR_PROFILE=sbcio_vdg REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py`
- `MONITOR_PROFILE=sbcio_vdg REQUIRE_BUILD_ROM=1 python3 tests/test_sd_fixture.py`
- `MONITOR_PROFILE=k6802_vdg make bin`
- `MONITOR_PROFILE=k6802_vdg REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py`
- `MONITOR_PROFILE=k6802_vdg REQUIRE_BUILD_ROM=1 python3 tests/test_sd_fixture.py`
- `python3 tests/test_sdfs68_build.py`
- `python3 tests/test_mk_sdfs_image.py`

## 影響範囲
- ROM本体の実装変更はなし
- `FEATURE_FAT=0` profileではROM常駐FAT `DIR` / `LF` を本線扱いしない方針を明文化
- `sbcio` profileのROM常駐FAT互換機能は残す

## 未対応事項
- ROM常駐FATコードの完全削除はしない
- SDFS/68 v2以降の `DIR`、`TYPE`、AUTOEXEC、subdirectoryは後続Issueで扱う