### PR TITLE
docs: SDFS/68 v2の責務境界を整理

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,8 @@
 - [plans/issue-128_rom_fat_cleanup.md](plans/issue-128_rom_fat_cleanup.md): SDFS/68移行後のROM常駐FAT DIR/LF整理
 - [plans/issue-129_sdfs68_migration_roadmap.md](plans/issue-129_sdfs68_migration_roadmap.md): SDFS/68 v1移行とROM FAT整理ロードマップ
 - [plans/issue-130_sdfs68_loader.md](plans/issue-130_sdfs68_loader.md): SDFS/68 v1 HEX/S-recordロード
+- [plans/issue-sdfs68_responsibility_boundary.md](plans/issue-sdfs68_responsibility_boundary.md): SDFS/68とROMモニタの責務境界
+- [plans/issue-sdfs68_v2_roadmap.md](plans/issue-sdfs68_v2_roadmap.md): SDFS/68 v2 第2段DOS基本操作ロードマップ
 - [testing/sbc6800_bringup.md](testing/sbc6800_bringup.md)
 - [testing/sbc_io_sd_bringup.md](testing/sbc_io_sd_bringup.md): SBC-IO と microSD SPI モジュールで SD/FAT を実機確認する手順
 - [testing/sbc6800_datapack.md](testing/sbc6800_datapack.md): SBC6800 データパックの扱いと互換確認

--- a/docs/plans/issue-sdfs68_responsibility_boundary.md
+++ b/docs/plans/issue-sdfs68_responsibility_boundary.md
@@ -1,0 +1,53 @@
+# Issue #136 SDFS/68 責務境界整理
+
+## 背景
+
+SDFS/68 v1 では、ROM `BOOT` から固定LBA stage1を読み、stage1がFAT rootの `SDFS.BIN` を起動し、SDFS/68側で `L filename` によるS-Record / Intel HEXロードまでできるようになった。
+
+一方で、SDFS/68に機能を足していくと、ROMモニタの延長なのか、第2段DOSなのかが曖昧になりやすい。v2へ進む前に、操作性と責務の境界を固定する。
+
+## 採用方針
+
+- ROMモニタは、電源投入直後の救命具、デバッガ、復旧口として扱う。
+- stage1は、SD/FATを読むboot servicesであり、ユーザー操作面には出さない。
+- SDFS/68は、通常運用のための小さい第2段DOSとして扱う。
+- SDFS/68内で `M`、`B`、`C`、`R`、`U` などのROMモニタ機能を再実装しない。
+- SDFS/68でのプログラム起動は `RUN` を本線にする。
+- 低レベルデバッグ、メモリ変更、逆アセンブルは `EXIT` でROMモニタへ戻って行う。
+
+## 操作モデル
+
+通常運用は次の流れを本線にする。
+
+```text
+] BOOT
+SDFS/68
+SDFS> DIR
+SDFS> RUN HELLO.S
+```
+
+デバッグ時はSDFS/68からROMモニタへ戻る。
+
+```text
+SDFS> LOAD TEST.S
+SDFS> EXIT
+] U0200
+] M0200
+] BOOT
+SDFS>
+```
+
+`EXIT` はSDFS/68からROMモニタへ戻る明示的な出口であり、SDFS/68をモニタ機能で肥大化させる代わりに使う。
+
+## 対象外
+
+- SDFS/68内へのROMモニタ機能の移植。
+- 本格的な実行ファイル形式。
+- `FOO` 入力で `FOO.COM` を探すトランジェントコマンド。
+- ユーザープログラムからSDFS/68へ戻るABI。
+- FAT write、subdirectory、LFN、direct read API。
+
+## 後続
+
+- #137 でSDFS/68 v2全体の基本操作ロードマップを管理する。
+- #138 以降で `DIR`、`TYPE`、`RUN`、`LOAD`、`EXIT` を子Issueとして実装する。

--- a/docs/plans/issue-sdfs68_v2_roadmap.md
+++ b/docs/plans/issue-sdfs68_v2_roadmap.md
@@ -1,0 +1,54 @@
+# Issue #137 SDFS/68 v2 第2段DOS基本操作ロードマップ
+
+## 背景
+
+SDFS/68 v1は、`BOOT -> stage1 -> SDFS.BIN -> L filename` まで完了した。v2では、SDFS/68をROMモニタの延長ではなく、小さい第2段DOSとして通常運用できる基本操作へ進める。
+
+責務境界は #136 の方針に従う。
+
+## v2の本線
+
+- `DIR`: root directoryを表示する。
+- `TYPE filename`: root上のテキストファイルを表示する。
+- `RUN filename`: ファイルをロードし、entryが取れれば実行する。
+- `RUN addr`: 指定アドレスへジャンプする。
+- `LOAD filename`: ロードのみを行う開発補助コマンド。
+- `L filename`: `LOAD filename` の短縮エイリアス。
+- `EXIT`: ROMモニタへ戻る。
+
+`RUN` を通常実行の本線にし、`LOAD` / `L` はロード確認やデバッグ用の補助として扱う。
+
+## 実装順序
+
+| 順番 | Issue | 内容 |
+| --- | --- | --- |
+| 1 | #138 | `DIR` でroot directoryを表示する |
+| 2 | #139 | `TYPE` でテキストファイルを表示する |
+| 3 | #140 | `RUN` でファイルまたはアドレスを実行する |
+| 4 | #141 | `LOAD` を開発補助コマンドとして整理する |
+| 5 | #142 | `EXIT` でROMモニタへ戻る |
+
+## 対象外
+
+- subdirectory、LFN、wildcard。
+- FAT write、SAVE。
+- direct read API。
+- I2C、RTC、OLED、VDG高機能。
+- `FOO` 入力で `FOO.COM` を探す本格トランジェントコマンド。
+- ユーザープログラム終了後にSDFS/68へ戻るABI。
+
+## 検証方針
+
+- `DIR` はroot上の8.3通常ファイルを表示する。
+- `TYPE` は短いテキストファイルを表示し、存在しないファイルでプロンプトへ戻る。
+- `RUN addr` は指定アドレスへジャンプする。
+- `RUN filename` はentryありファイルをロードして実行する。
+- `LOAD` / `L` は同じロード結果になる。
+- `EXIT` 後にROMモニタの `] ` プロンプトへ戻り、再度 `BOOT` できる。
+- 既存の `make bin`、`make stage1`、`make sdfs`、`test_sdfs68_build.py`、`test_mk_sdfs_image.py`、`test_sd_fixture.py` を維持する。
+
+## 既存Issueの位置づけ
+
+- #104 はv4以降のdirect read API設計として残す。
+- #105 はv3以降のsubdirectory設計として残す。
+- #128 の方針どおり、`sbcio` はROM常駐FAT互換profile、`sbcio_vdg` / `k6802_vdg` は `BOOT + SDFS/68` 本線profileとして扱う。

--- a/docs/usage/monitor_commands.md
+++ b/docs/usage/monitor_commands.md
@@ -20,7 +20,7 @@
 | `Dssss` | `ssss` から 64 バイト分をダンプする |
 | `Dssss-eeee` | `ssss` から `eeee` までをダンプする |
 | `DIR` | SDカード上のroot directoryにある8.3通常ファイルを表示する。`FEATURE_FAT=1` のROMだけで有効 |
-| `BOOT` | 固定LBAからSDFS/68 stage1 loaderを読み込んで起動する。`FEATURE_SD=1` かつ stage1対応RAM構成のROMで有効 |
+| `BOOT` | 固定LBAからSDFS/68 stage1 loaderを読み込んで、第2段システムへ移行する。`FEATURE_SD=1` かつ stage1対応RAM構成のROMで有効 |
 | `Mssss` | `ssss` からメモリを変更する |
 | `MAP` | 現在のビルドが想定する主要メモリ配置を表示する |
 | `RAMTEST ssss-eeee` | 許可された明示範囲のRAMを破壊テストする |
@@ -268,6 +268,8 @@ OK
 ファイル名の前後の空白は無視する。subdirectory、LFN、wildcardは対象外である。
 LOAD後の自動実行は行わない。必要に応じて `Gssss` で開始アドレスへジャンプする。
 `FEATURE_FAT=0` のROMでは `LF` のコマンド本体をROMに入れず、未対応コマンドとして `?` を返す。`FEATURE_SD=1` / `FEATURE_FAT=0` のprofileでは、SDからのロードは `BOOT` でSDFS/68を起動し、SDFS/68側の `L filename` を使う。
+
+SDFS/68はROMモニタとは別の第2段システムとして扱う。SDFS/68側の `DIR`、`TYPE`、`RUN`、`LOAD`、`EXIT` は [SDFS/68 システムSDカード方針](sdfs68_system_sd.md) に記載する。
 
 ## SD directory
 

--- a/docs/usage/sdfs68_system_sd.md
+++ b/docs/usage/sdfs68_system_sd.md
@@ -11,6 +11,8 @@ SDFS/68 は、ROM モニタの `BOOT` から起動する第2段システムで�
 - ROMはFATを読まず、stage1がFAT32 read-only最小実装で `SDFS.BIN` を読む。
 - 初期 SDFS/68 は read-only とし、FAT write や SAVE は別Issueで扱う。
 - 8.3 short filename を前提にする。LFN とサブディレクトリは後続段階で扱う。
+- SDFS/68はROMモニタの拡張コマンドではなく、小さい第2段DOSとして扱う。
+- ROMモニタは救命具、デバッガ、復旧口として残し、SDFS/68内にモニタ機能を再実装しない。
 
 ## システムSDイメージ生成
 
@@ -101,6 +103,24 @@ SDFS> D0200
 SDFS/68 v1 のloaderは ROM loader と同じ制限を持つ。S-Recordは `S1` / `S2` のデータrecordを扱い、`S2` は上位 1 byte が `0` の場合だけ有効である。Intel HEX は record type `00` と `01` のみ対応し、拡張アドレスrecordは扱わない。
 
 SDFS/68 v1 はloaderの書き込み先アドレスを保護しない。`SDFS.BIN` 本体、stage1、SD/FAT work、stack、VDG VRAMなどを壊すファイルも指定できるため、当面は作成者がロード先を管理する。
+
+## SDFS/68 v2 予定コマンド
+
+SDFS/68 v2では、DOS風の通常操作を本線にする。
+
+| コマンド | 用途 |
+| --- | --- |
+| `DIR` | FAT root の8.3通常ファイルを表示する |
+| `TYPE filename` | テキストファイルをコンソールへ表示する |
+| `RUN filename` | ファイルをロードし、entryが取れれば実行する |
+| `RUN addr` | 指定アドレスへジャンプする |
+| `LOAD filename` | ファイルをロードする。自動実行しない |
+| `L filename` | `LOAD filename` の短縮エイリアス |
+| `EXIT` | ROMモニタへ戻る |
+
+通常実行は `RUN` を使う。`LOAD` / `L` はロード確認やデバッグ用の補助コマンドとして扱う。
+
+メモリ変更、ブレークポイント、逆アセンブルなどの低レベルデバッグはSDFS/68に取り込まず、`EXIT` でROMモニタへ戻って行う。
 
 ## 将来拡張
 


### PR DESCRIPTION
## 対応Issue
- Closes #136
- Refs #137 #138 #139 #140 #141 #142
- Refs #82 #102 #111 #128 #130

## 変更内容
- SDFS/68をROMモニタの拡張ではなく第2段DOSとして扱う責務境界を文書化
- v2基本操作のロードマップを `DIR` / `TYPE` / `RUN` / `LOAD` / `EXIT` の子Issue順に整理
- `docs/usage/sdfs68_system_sd.md` にv2予定コマンドとROMモニタとの棲み分けを追記
- `docs/usage/monitor_commands.md` では `BOOT` が第2段システムへ移行する入口であることを明記

## 作成Issue
- #136 SDFS/68: モニタと第2段DOSの責務境界を整理する
- #137 SDFS/68 v2: 第2段DOS基本操作を整備する
- #138 SDFS/68 v2: DIRでroot directoryを表示する
- #139 SDFS/68 v2: TYPEでテキストファイルを表示する
- #140 SDFS/68 v2: RUNでファイルまたはアドレスを実行する
- #141 SDFS/68 v2: LOADを開発補助コマンドとして整理する
- #142 SDFS/68 v2: EXITでROMモニタへ戻る

## テスト結果
- `git diff --check`
- docs差分確認

## 影響範囲
- ドキュメントのみ
- ROM、stage1、SDFS/68本体の実装変更はなし

## 未対応事項
- v2各コマンドの実装は #138 以降で扱う
- subdirectory、LFN、write、direct read API、本格トランジェントコマンドは対象外