### PR TITLE
feat: SDFS/68にDIRコマンドを追加

### DIFF
--- a/docs/plans/issue-138_sdfs68_dir.md
+++ b/docs/plans/issue-138_sdfs68_dir.md
@@ -1,0 +1,102 @@
+# Issue #138 SDFS/68 v2 DIR 実装
+
+## 背景
+
+SDFS/68 v1 では `L filename` で root directory の8.3ファイルを読み、S-Record / Intel HEXをロードできるようになった。
+ただし、system SD に何が入っているかをSDFS/68側から確認する手段がなく、実機確認ではホストPCでSDカードを見てから `L` する必要があった。
+
+Issue #138 では、SDFS/68 v2に向けた最初の通常操作として `DIR` を追加する。
+ただし、まだメジャーバージョンを変えるほどのアーキテクチャ変更ではないため、実機ログでの起動メッセージは `SDFS/68 V1.2 #138` とする。
+`#138` は、この実装の元Issue番号をbuild番号相当として表示する。
+SDFS.BIN headerのversion byteはstage1が検査するバイナリ形式versionなので、互換性のため `1` のまま残す。
+
+## 採用仕様
+
+- `SDFS> DIR` で FAT root の8.3 short filename通常ファイルを一覧表示する。
+- コマンドは `DIR` 完全一致を基本にし、余分な引数はエラーにする。
+- `Dhhhh` の1 byte dumpとは、`DIR` 判定を先に行って分岐する。
+- 表示形式はROM側 `DIR` 相当に寄せる。
+
+```text
+SDFS> DIR
+SDFS.BIN A 0000092F
+HELLO.S A 0000004A
+HELLO.HEX A 00000022
+```
+
+表示対象:
+
+| entry | 扱い |
+| --- | --- |
+| 8.3通常ファイル | 表示する |
+| LFN entry | 表示しない |
+| volume label | 表示しない |
+| directory | 表示しない |
+| deleted entry | 表示しない |
+| empty entry | root directory終端として扱う |
+
+エラーやroot chain終端ではハングせず、SDFS/68プロンプトへ戻る。
+
+## stage1 APIを増やさない判断
+
+`DIR` はstage1/BIOS側APIとして追加しない。
+stage1はSDFS/68を起動するためのboot servicesであり、ユーザー向けのDOS機能を持たせない。
+
+今回の `DIR` は、SDFS/68本体が既存のstage1 jump tableを使って実装する。
+
+- `SDFS_API_MOUNT`
+- `SDFS_API_READ_SECTOR`
+
+ROM側 `CMD_DIR` も呼ばない。
+ROM常駐FATの `DIR` / `LF` は `sbcio` profileの互換機能であり、SDFS/68本線の機能はSDFS/68側へ寄せる。
+
+## 内部レイヤ整理
+
+8kB RAM制約があるため、v2では正式なBIOS/kernel/shell分離や別ABI化までは行わない。
+ただし、今後の肥大化を避けるため、ラベル名と呼び出し方向だけ軽く整理する。
+
+| prefix | 役割 |
+| --- | --- |
+| `SDFS_API_*` | stage1 jump table wrapper |
+| `SDFS_K_*` | root走査、entry判定、entry表示などのkernel相当helper |
+| `SDFS_CMD_*` | shell command本体 |
+| `SDFS_LOOP` / prompt周辺 | shell dispatch |
+
+呼び出し方向は、おおむね `shell -> command -> kernel helper -> stage1 API wrapper` とする。
+v3以降で必要になったら、ここを起点にもう少しきれいに分ける。
+
+## 実機確認手順
+
+1. `MONITOR_PROFILE=sbcio_vdg make stage1 sdfs`
+2. `python3 tools/mk_sdfs_image.py --stage1 build/stage1-sbcio-vdg.bin --sdfs build/SDFS-sbcio-vdg.BIN --output build/sdfs-sbcio-vdg.img HELLO.S HELLO.HEX`
+3. system SDを書き込む。
+4. CPUボード + SBC-IO RAM構成で `RAMTEST C000-DFFF` が `OK` になることを確認する。
+5. `] BOOT` でSDFS/68を起動する。
+6. `SDFS> DIR` で `SDFS.BIN`、`HELLO.S`、`HELLO.HEX` などが見えることを確認する。
+7. `SDFS> L HELLO.S` と `SDFS> D0100` が既存通り動くことを確認する。
+
+## 確認内容
+
+- `make bin`
+- `MONITOR_PROFILE=sbcio_vdg make stage1 sdfs`
+- `MONITOR_PROFILE=k6802_vdg make stage1 sdfs`
+- `python3 tests/test_sdfs68_build.py`
+
+テストでは次を確認する。
+
+- `DIR` がroot上の8.3通常ファイルを表示する。
+- LFN、volume label、directory、deleted entryを表示しない。
+- root chainの後続clusterにあるentryも表示する。
+- 空の後続root clusterでもタイムアウトせずプロンプトへ戻る。
+
+## 対象外
+
+- subdirectory
+- LFN表示
+- wildcard
+- FAT write
+- `TYPE`
+- `RUN`
+- `LOAD` 正式化
+- `EXIT`
+- 低位RAM `$7000-$7FFF` などの新規予約

--- a/docs/usage/sdfs68_system_sd.md
+++ b/docs/usage/sdfs68_system_sd.md
@@ -139,19 +139,39 @@ SDFS/68 v1 のloaderは ROM loader と同じ制限を持つ。S-Recordは `S1` /
 
 SDFS/68 v1 はloaderの書き込み先アドレスを保護しない。`SDFS.BIN` 本体、stage1、SD/FAT work、stack、VDG VRAMなどを壊すファイルも指定できるため、当面は作成者がロード先を管理する。
 
-## SDFS/68 v2 予定コマンド
+## SDFS/68 v2 コマンド
 
 SDFS/68 v2では、DOS風の通常操作を本線にする。
+ただし `DIR` 追加時点ではメジャーバージョンを変えるほどのアーキテクチャ変更ではないため、起動時は `SDFS/68 V1.2 #138` のように表示する。
+`#138` は元Issue番号をbuild番号相当として扱う。
+SDFS.BIN headerのversion byteはstage1が読むバイナリ形式versionであり、起動表示のバージョンとは別に扱う。
 
 | コマンド | 用途 |
 | --- | --- |
-| `DIR` | FAT root の8.3通常ファイルを表示する |
-| `TYPE filename` | テキストファイルをコンソールへ表示する |
-| `RUN filename` | ファイルをロードし、entryが取れれば実行する |
-| `RUN addr` | 指定アドレスへジャンプする |
-| `LOAD filename` | ファイルをロードする。自動実行しない |
-| `L filename` | `LOAD filename` の短縮エイリアス |
-| `EXIT` | ROMモニタへ戻る |
+| `DIR` | 実装済み。FAT root の8.3通常ファイルを表示する |
+| `TYPE filename` | 予定。テキストファイルをコンソールへ表示する |
+| `RUN filename` | 予定。ファイルをロードし、entryが取れれば実行する |
+| `RUN addr` | 予定。指定アドレスへジャンプする |
+| `LOAD filename` | 予定。ファイルをロードする。自動実行しない |
+| `L filename` | 実装済み。現時点では `LOAD filename` の短縮ではなく、S-Record / Intel HEXロード用コマンド |
+| `Dhhhh` | 実装済み。16bit hexadecimal address の1 byteを表示する |
+| `EXIT` | 予定。ROMモニタへ戻る |
+
+`DIR` はSDFS/68本体がstage1の既存低レベルサービスを使ってroot directoryを走査する。
+stage1に `DIR` 専用APIは追加せず、ROM側の `DIR` も呼ばない。
+
+表示例:
+
+```text
+SDFS> DIR
+SDFS.BIN A 0000092F
+HELLO.S A 0000004A
+HELLO.HEX A 00000022
+```
+
+`DIR` が表示するのは、root directory直下の8.3 short filename通常ファイルだけである。
+LFN、volume label、directory、deleted entryは表示しない。
+subdirectory、wildcard、属性詳細表示、FAT writeは対象外である。
 
 通常実行は `RUN` を使う。`LOAD` / `L` はロード確認やデバッグ用の補助コマンドとして扱う。
 

--- a/src/sdfs68.asm
+++ b/src/sdfs68.asm
@@ -2,7 +2,7 @@
 
         include "../include/hardware.inc"
 
-SDFS_VERSION    equ 1
+SDFS_FORMAT_VERSION equ 1
 SDFS_HDR_SIZE   equ 16
 SDFS_S1_VERSION equ 1
 SDFS_S1_COUNT   equ 6
@@ -15,7 +15,7 @@ SDFS_S1_COUNT   equ 6
 
 SDFS_HEADER:
         fcc     "SDFS68"
-        fcb     SDFS_VERSION
+        fcb     SDFS_FORMAT_VERSION
         fcb     SDFS_HDR_SIZE
         fdb     SDFS_ENTRY
         fdb     SDFS_END-SDFS_LOAD_BASE
@@ -53,6 +53,13 @@ SDFS_LOAD_OK:
 SDFS_CHECK_DUMP:
         cmpa    #'D'
         bne     SDFS_COMMAND_ERROR
+        jsr     SDFS_CMD_IS_DIR
+        bcs     SDFS_CHECK_DUMP_BYTE
+        jsr     SDFS_CMD_DIR
+        bcc     SDFS_PROMPT_NEXT
+        jsr     SDFS_SHOW_ERROR
+        bra     SDFS_PROMPT_NEXT
+SDFS_CHECK_DUMP_BYTE:
         jsr     SDFS_CMD_DUMP_BYTE
         bcc     SDFS_PROMPT_NEXT
         jsr     SDFS_SHOW_ERROR
@@ -116,6 +123,164 @@ SDFS_CMD_DUMP_BYTE:
         rts
 SDFS_CMD_DUMP_FAIL:
         sec
+        rts
+
+SDFS_CMD_IS_DIR:
+        ldab    LINE_LEN
+        cmpb    #3
+        bne     SDFS_CMD_IS_DIR_FAIL
+        ldaa    LINE_BUF+1
+        jsr     SDFS_TO_UPPER
+        cmpa    #'I'
+        bne     SDFS_CMD_IS_DIR_FAIL
+        ldaa    LINE_BUF+2
+        jsr     SDFS_TO_UPPER
+        cmpa    #'R'
+        bne     SDFS_CMD_IS_DIR_FAIL
+        clc
+        rts
+SDFS_CMD_IS_DIR_FAIL:
+        sec
+        rts
+
+SDFS_CMD_DIR:
+        jsr     SDFS_K_DIR_ROOT
+        rts
+
+SDFS_K_DIR_ROOT:
+        jsr     SDFS_API_MOUNT
+        bcs     SDFS_K_DIR_FAIL
+        jsr     SDFS_K_COPY_ROOT_TO_CUR
+SDFS_K_DIR_CLUSTER_LOOP:
+        jsr     SDFS_CLUSTER_TO_SD_LBA
+        ldx     #SD_SECTOR_BUF
+        jsr     SDFS_API_READ_SECTOR
+        bcs     SDFS_K_DIR_FAIL
+        ldx     #SD_SECTOR_BUF
+        stx     FAT_ENTRY_PTR
+        ldaa    #16
+        staa    FAT_DIR_COUNT
+SDFS_K_DIR_ENTRY_LOOP:
+        ldx     FAT_ENTRY_PTR
+        ldaa    0,x
+        beq     SDFS_K_DIR_DONE
+        cmpa    #$E5
+        beq     SDFS_K_DIR_NEXT_ENTRY
+        ldaa    11,x
+        anda    #$0F
+        cmpa    #$0F
+        beq     SDFS_K_DIR_NEXT_ENTRY
+        ldaa    11,x
+        anda    #$18
+        bne     SDFS_K_DIR_NEXT_ENTRY
+        jsr     SDFS_K_PRINT_DIR_ENTRY
+SDFS_K_DIR_NEXT_ENTRY:
+        jsr     SDFS_K_ADVANCE_ENTRY_PTR
+        dec     FAT_DIR_COUNT
+        bne     SDFS_K_DIR_ENTRY_LOOP
+        jsr     SDFS_NEXT_CLUSTER
+        bcs     SDFS_K_DIR_DONE
+        jsr     SDFS_COPY_NEXT_TO_CUR
+        bra     SDFS_K_DIR_CLUSTER_LOOP
+SDFS_K_DIR_DONE:
+        clc
+        rts
+SDFS_K_DIR_FAIL:
+        sec
+        rts
+
+SDFS_K_COPY_ROOT_TO_CUR:
+        ldaa    FAT_ROOT_CLUS0
+        staa    FAT_CUR_CLUS0
+        ldaa    FAT_ROOT_CLUS1
+        staa    FAT_CUR_CLUS1
+        ldaa    FAT_ROOT_CLUS2
+        staa    FAT_CUR_CLUS2
+        ldaa    FAT_ROOT_CLUS3
+        staa    FAT_CUR_CLUS3
+        rts
+
+SDFS_K_ADVANCE_ENTRY_PTR:
+        ldx     FAT_ENTRY_PTR
+        ldab    #32
+SDFS_K_ADVANCE_ENTRY_PTR_LOOP:
+        inx
+        decb
+        bne     SDFS_K_ADVANCE_ENTRY_PTR_LOOP
+        stx     FAT_ENTRY_PTR
+        rts
+
+SDFS_K_PRINT_DIR_ENTRY:
+        ldx     FAT_ENTRY_PTR
+        ldab    #8
+SDFS_K_PRINT_DIR_NAME_LOOP:
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        beq     SDFS_K_PRINT_DIR_NAME_DONE
+        jsr     SDFS_PUTC
+        inx
+        decb
+        bne     SDFS_K_PRINT_DIR_NAME_LOOP
+SDFS_K_PRINT_DIR_NAME_DONE:
+        jsr     SDFS_K_DIR_EXT_HAS_CHAR
+        bcs     SDFS_K_PRINT_DIR_NO_EXT
+        ldaa    #'.'
+        jsr     SDFS_PUTC
+        ldx     FAT_ENTRY_PTR
+        ldab    #8
+SDFS_K_PRINT_DIR_EXT_SKIP:
+        inx
+        decb
+        bne     SDFS_K_PRINT_DIR_EXT_SKIP
+        ldab    #3
+SDFS_K_PRINT_DIR_EXT_LOOP:
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        beq     SDFS_K_PRINT_DIR_EXT_DONE
+        jsr     SDFS_PUTC
+        inx
+        decb
+        bne     SDFS_K_PRINT_DIR_EXT_LOOP
+SDFS_K_PRINT_DIR_EXT_DONE:
+SDFS_K_PRINT_DIR_NO_EXT:
+        ldaa    #CHR_SPACE
+        jsr     SDFS_PUTC
+        ldaa    #'A'
+        jsr     SDFS_PUTC
+        ldaa    #CHR_SPACE
+        jsr     SDFS_PUTC
+        ldx     FAT_ENTRY_PTR
+        ldaa    31,x
+        jsr     SDFS_PRINT_HEX8
+        ldaa    30,x
+        jsr     SDFS_PRINT_HEX8
+        ldaa    29,x
+        jsr     SDFS_PRINT_HEX8
+        ldaa    28,x
+        jsr     SDFS_PRINT_HEX8
+        ldaa    #CHR_CR
+        jsr     SDFS_PUTC
+        rts
+
+SDFS_K_DIR_EXT_HAS_CHAR:
+        ldx     FAT_ENTRY_PTR
+        ldab    #8
+SDFS_K_DIR_EXT_SKIP:
+        inx
+        decb
+        bne     SDFS_K_DIR_EXT_SKIP
+        ldab    #3
+SDFS_K_DIR_EXT_CHECK_LOOP:
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        bne     SDFS_K_DIR_EXT_FOUND
+        inx
+        decb
+        bne     SDFS_K_DIR_EXT_CHECK_LOOP
+        sec
+        rts
+SDFS_K_DIR_EXT_FOUND:
+        clc
         rts
 
 SDFS_CHECK_S1:
@@ -1124,7 +1289,7 @@ SDFS_PUTC_DONE:
 
 TXT_BANNER:
         fcb     CHR_CR
-        fcc     "SDFS/68 V1"
+        fcc     "SDFS/68 V1.2 #138"
         fcb     CHR_CR,0
 
 TXT_PROMPT:

--- a/tests/test_sdfs68_build.py
+++ b/tests/test_sdfs68_build.py
@@ -13,7 +13,15 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "tools"))
 
-from fat32_image import Fat32File  # noqa: E402
+from fat32_image import (  # noqa: E402
+    EOC,
+    SECTOR_SIZE,
+    Fat32File,
+    Fat32Layout,
+    root_entry,
+    write_cluster,
+    write_sector,
+)
 from mk_sdfs_image import build_sdfs_image  # noqa: E402
 
 EMU_PATH = PROJECT_ROOT / "emu" / "sbc6800_emu.py"
@@ -62,7 +70,7 @@ def test_sdfs_profiles_build_and_match_header() -> None:
         )
         assert len(data) <= symbols["SDFS_LOAD_LIMIT"] - symbols["SDFS_LOAD_BASE"] + 1
         assert data[0:6] == b"SDFS68"
-        assert data[6] == 1, "SDFS version mismatch"
+        assert data[6] == 1, "SDFS binary format version mismatch"
         assert data[7] == 16, "SDFS header size mismatch"
         entry = (data[8] << 8) | data[9]
         size = (data[10] << 8) | data[11]
@@ -123,7 +131,7 @@ def test_stage1_boot_runs_built_sdfs_binary() -> None:
         assert rc == 0 and "[TIMEOUT]" not in stderr, (
             f"emulator failed for {profile}: rc={rc} stderr={stderr!r}"
         )
-        assert "SDFS/68 V1" in stdout, f"missing SDFS banner for {profile}: {stdout!r}"
+        assert "SDFS/68 V1.2 #138" in stdout, f"missing SDFS banner for {profile}: {stdout!r}"
         assert "SDFS> " in stdout, f"missing SDFS prompt for {profile}: {stdout!r}"
     print("[PASS] test_stage1_boot_runs_built_sdfs_binary")
 
@@ -159,6 +167,141 @@ def test_sdfs_loads_srec_and_ihex_files() -> None:
         assert "0202 4E" in stdout, f"EOF-without-newline HEX did not load for {profile}: {stdout!r}"
         assert stdout.count("OK") >= 3, f"missing load success messages for {profile}: {stdout!r}"
     print("[PASS] test_sdfs_loads_srec_and_ihex_files")
+
+
+def test_sdfs_dir_lists_root_files_and_skips_non_files() -> None:
+    for profile, expected in EXPECTED.items():
+        _run_make(profile, "bin")
+        _run_make(profile, "stage1")
+        _run_make(profile, "sdfs")
+        suffix = expected["suffix"]
+        stage1 = (PROJECT_ROOT / "build" / f"stage1{suffix}.bin").read_bytes()
+        sdfs = (PROJECT_ROOT / "build" / f"SDFS{suffix}.BIN").read_bytes()
+        image = build_sdfs_image(
+            stage1_data=stage1,
+            sdfs_data=sdfs,
+            extra_files=[
+                _file("HELLO.S", _srec_file(0x0200, b"S")),
+                _file("HELLO.HEX", _ihex_file(0x0201, b"I")),
+                _file("README.TXT", b"HELLO\r\n"),
+                _raw_file(b"SKIPVOL    ", b"", attr=0x08),
+                _raw_file(b"SKIPDIR    ", b"", attr=0x10),
+                _raw_file(b"SKIPLFN    ", b"", attr=0x0F),
+                _raw_file(bytes([0xE5]) + b"DEL    TXT", b"", attr=0x20),
+            ],
+        )
+        stdout, stderr, rc = _run_emu_with_sd(
+            rom_path=PROJECT_ROOT / "build" / f"mc6800-monitor{suffix}.bin",
+            input_text="BOOT\rDIR\rX",
+            sd_image=image,
+            max_cycles=160_000_000,
+        )
+        assert rc == 0 and "[TIMEOUT]" not in stderr, (
+            f"emulator failed for {profile}: rc={rc} stderr={stderr!r}"
+        )
+        assert "SDFS.BIN A " in stdout, f"SDFS.BIN missing from DIR for {profile}: {stdout!r}"
+        assert "HELLO.S A " in stdout, f"HELLO.S missing from DIR for {profile}: {stdout!r}"
+        assert "HELLO.HEX A " in stdout, f"HELLO.HEX missing from DIR for {profile}: {stdout!r}"
+        assert "README.TXT A 00000007" in stdout, (
+            f"README.TXT missing or size mismatch for {profile}: {stdout!r}"
+        )
+        assert "SKIPVOL" not in stdout, f"volume label leaked into DIR for {profile}: {stdout!r}"
+        assert "SKIPDIR" not in stdout, f"directory entry leaked into DIR for {profile}: {stdout!r}"
+        assert "SKIPLFN" not in stdout, f"LFN entry leaked into DIR for {profile}: {stdout!r}"
+        assert "DEL.TXT" not in stdout, f"deleted entry leaked into DIR for {profile}: {stdout!r}"
+        assert stdout.count("SDFS> ") >= 2, f"DIR did not return to prompt for {profile}: {stdout!r}"
+    print("[PASS] test_sdfs_dir_lists_root_files_and_skips_non_files")
+
+
+def test_sdfs_dir_scans_root_chain() -> None:
+    profile = "sbcio_vdg"
+    _run_make(profile, "bin")
+    _run_make(profile, "stage1")
+    _run_make(profile, "sdfs")
+    suffix = EXPECTED[profile]["suffix"]
+    stage1 = (PROJECT_ROOT / "build" / f"stage1{suffix}.bin").read_bytes()
+    sdfs = (PROJECT_ROOT / "build" / f"SDFS{suffix}.BIN").read_bytes()
+    image = bytearray(
+        build_sdfs_image(
+            stage1_data=stage1,
+            sdfs_data=sdfs,
+            extra_files=[
+                _file("HELLO.S", _srec_file(0x0200, b"S")),
+                _file("HELLO.HEX", _ihex_file(0x0201, b"I")),
+            ],
+        )
+    )
+    layout = _layout_from_image(image)
+    root_extra_cluster = 64
+    _set_fat_entry(image, layout, layout.root_cluster, root_extra_cluster)
+    _set_fat_entry(image, layout, root_extra_cluster, EOC)
+    _fill_root_tail_with_skipped_entries(image, layout)
+    extra = bytearray(SECTOR_SIZE * layout.sectors_per_cluster)
+    extra[0:32] = root_entry(b"LATE    TXT", 0x20, root_extra_cluster + 1, 4)
+    extra[32] = 0x00
+    write_cluster(image, layout, root_extra_cluster, extra)
+
+    stdout, stderr, rc = _run_emu_with_sd(
+        rom_path=PROJECT_ROOT / "build" / "mc6800-monitor-sbcio-vdg.bin",
+        input_text="BOOT\rDIR\rX",
+        sd_image=bytes(image),
+        max_cycles=160_000_000,
+    )
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    assert "HELLO.S A " in stdout, f"first root cluster entry missing: {stdout!r}"
+    assert "LATE.TXT A 00000004" in stdout, f"root chain entry missing: {stdout!r}"
+    assert stdout.count("SDFS> ") >= 2, f"DIR did not return to prompt: {stdout!r}"
+    print("[PASS] test_sdfs_dir_scans_root_chain")
+
+
+def test_sdfs_dir_returns_prompt_on_empty_followup_root_cluster() -> None:
+    profile = "sbcio_vdg"
+    _run_make(profile, "bin")
+    _run_make(profile, "stage1")
+    _run_make(profile, "sdfs")
+    suffix = EXPECTED[profile]["suffix"]
+    stage1 = (PROJECT_ROOT / "build" / f"stage1{suffix}.bin").read_bytes()
+    sdfs = (PROJECT_ROOT / "build" / f"SDFS{suffix}.BIN").read_bytes()
+    image = bytearray(build_sdfs_image(stage1_data=stage1, sdfs_data=sdfs, extra_files=[]))
+    layout = _layout_from_image(image)
+    empty_cluster = 65
+    _set_fat_entry(image, layout, layout.root_cluster, empty_cluster)
+    _set_fat_entry(image, layout, empty_cluster, EOC)
+    _fill_root_tail_with_skipped_entries(image, layout)
+    write_cluster(image, layout, empty_cluster, bytes(SECTOR_SIZE * layout.sectors_per_cluster))
+
+    stdout, stderr, rc = _run_emu_with_sd(
+        rom_path=PROJECT_ROOT / "build" / "mc6800-monitor-sbcio-vdg.bin",
+        input_text="BOOT\rDIR\rX",
+        sd_image=bytes(image),
+        max_cycles=160_000_000,
+    )
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    assert "SDFS.BIN A " in stdout, f"root entry missing before followup cluster: {stdout!r}"
+    assert stdout.count("SDFS> ") >= 2, f"DIR did not recover to prompt: {stdout!r}"
+    print("[PASS] test_sdfs_dir_returns_prompt_on_empty_followup_root_cluster")
+
+
+def test_sdfs_dir_requires_exact_command_and_dump_still_works() -> None:
+    profile = "sbcio_vdg"
+    _run_make(profile, "bin")
+    _run_make(profile, "stage1")
+    _run_make(profile, "sdfs")
+    suffix = EXPECTED[profile]["suffix"]
+    stage1 = (PROJECT_ROOT / "build" / f"stage1{suffix}.bin").read_bytes()
+    sdfs = (PROJECT_ROOT / "build" / f"SDFS{suffix}.BIN").read_bytes()
+    image = build_sdfs_image(stage1_data=stage1, sdfs_data=sdfs, extra_files=[])
+    stdout, stderr, rc = _run_emu_with_sd(
+        rom_path=PROJECT_ROOT / "build" / "mc6800-monitor-sbcio-vdg.bin",
+        input_text="BOOT\rDIR X\rD0100\rX",
+        sd_image=image,
+        max_cycles=140_000_000,
+    )
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    assert "0100 " in stdout, f"Dhhhh dispatch was broken: {stdout!r}"
+    assert "?" in stdout, f"DIR with extra argument was accepted: {stdout!r}"
+    assert stdout.count("SDFS> ") >= 3, f"prompt did not recover: {stdout!r}"
+    print("[PASS] test_sdfs_dir_requires_exact_command_and_dump_still_works")
 
 
 def test_sdfs_loader_errors_return_to_prompt() -> None:
@@ -342,6 +485,61 @@ def _file(name: str, data: bytes) -> Fat32File:
     return Fat32File(name83, data)
 
 
+def _raw_file(name83: bytes, data: bytes, *, attr: int) -> Fat32File:
+    return Fat32File(name83, data, attr=attr)
+
+
+def _layout_from_image(image: bytes | bytearray) -> Fat32Layout:
+    volume_start = int.from_bytes(image[454:458], "little")
+    vbr = volume_start * SECTOR_SIZE
+    total_volume_sectors = int.from_bytes(image[vbr + 32 : vbr + 36], "little")
+    reserved_sectors = int.from_bytes(image[vbr + 14 : vbr + 16], "little")
+    fat_count = image[vbr + 16]
+    fat_size_sectors = int.from_bytes(image[vbr + 36 : vbr + 40], "little")
+    sectors_per_cluster = image[vbr + 13]
+    root_cluster = int.from_bytes(image[vbr + 44 : vbr + 48], "little")
+    fat_lba = volume_start + reserved_sectors
+    data_start_lba = fat_lba + fat_count * fat_size_sectors
+    return Fat32Layout(
+        volume_start_lba=volume_start,
+        fat_lba=fat_lba,
+        root_dir_lba=data_start_lba + (root_cluster - 2) * sectors_per_cluster,
+        data_start_lba=data_start_lba,
+        total_volume_sectors=total_volume_sectors,
+        reserved_sectors=reserved_sectors,
+        fat_count=fat_count,
+        fat_size_sectors=fat_size_sectors,
+        sectors_per_cluster=sectors_per_cluster,
+        root_cluster=root_cluster,
+    )
+
+
+def _set_fat_entry(image: bytearray, layout: Fat32Layout, cluster: int, value: int) -> None:
+    offset = cluster * 4
+    sector_index = offset // SECTOR_SIZE
+    sector_offset = offset % SECTOR_SIZE
+    for copy_index in range(layout.fat_count):
+        lba = layout.fat_lba + copy_index * layout.fat_size_sectors + sector_index
+        start = lba * SECTOR_SIZE
+        sector = bytearray(image[start : start + SECTOR_SIZE])
+        sector[sector_offset : sector_offset + 4] = value.to_bytes(4, "little")
+        write_sector(image, lba, sector)
+
+
+def _fill_root_tail_with_skipped_entries(image: bytearray, layout: Fat32Layout) -> None:
+    root_lba = layout.root_dir_lba
+    start = root_lba * SECTOR_SIZE
+    root = bytearray(image[start : start + SECTOR_SIZE * layout.sectors_per_cluster])
+    for index in range(SECTOR_SIZE * layout.sectors_per_cluster // 32):
+        entry_start = index * 32
+        if root[entry_start] == 0x00:
+            for fill_index in range(index, SECTOR_SIZE * layout.sectors_per_cluster // 32):
+                fill_start = fill_index * 32
+                root[fill_start : fill_start + 32] = root_entry(b"SKIP    TMP", 0x08, 0, 0)
+            break
+    write_cluster(image, layout, layout.root_cluster, root)
+
+
 def _srec_file(address: int, data: bytes, trailing_newline: bool = True) -> bytes:
     count = len(data) + 3
     values = [count, (address >> 8) & 0xFF, address & 0xFF, *data]
@@ -392,6 +590,10 @@ def main() -> None:
         test_sdfs_api_wrappers_target_stage1_jump_table,
         test_stage1_boot_runs_built_sdfs_binary,
         test_sdfs_loads_srec_and_ihex_files,
+        test_sdfs_dir_lists_root_files_and_skips_non_files,
+        test_sdfs_dir_scans_root_chain,
+        test_sdfs_dir_returns_prompt_on_empty_followup_root_cluster,
+        test_sdfs_dir_requires_exact_command_and_dump_still_works,
         test_sdfs_loader_errors_return_to_prompt,
         test_sdfs_rejects_missing_boot_services,
         test_sdfs_rejects_bad_boot_services_headers,


### PR DESCRIPTION
## 概要
- SDFS/68本体に `DIR` コマンドを追加し、FAT root の8.3通常ファイルを一覧表示できるようにしました
- stage1にDIR専用APIは追加せず、既存の `SDFS_API_MOUNT` / `SDFS_API_READ_SECTOR` を使ってSDFS/68側でroot directoryを走査します
- v2向けの最小レイヤ整理として `SDFS_CMD_*` / `SDFS_K_*` の責務を導入し、仕様メモとusage文書を更新しました

## 確認内容
- `make bin`
- `MONITOR_PROFILE=sbcio_vdg make stage1 sdfs`
- `MONITOR_PROFILE=k6802_vdg make stage1 sdfs`
- `python3 tests/test_sdfs68_build.py`
- `git diff --check`

## 補足
- 最初に `make bin` と別profileのmakeを並列実行したため `build/monitor_config.inc` が競合して失敗しました。これは確認手順の実行方法の問題だったため、単独で `make bin` を再実行して成功しています。

Closes #138
Refs #137 #136