### PR TITLE
feat: SDFS/68にEXITコマンドを追加

### DIFF
--- a/docs/plans/issue-142_sdfs68_exit.md
+++ b/docs/plans/issue-142_sdfs68_exit.md
@@ -1,0 +1,46 @@
+# Issue #142 SDFS/68 EXIT 実装
+
+## 背景
+
+SDFS/68は通常運用の第2段DOSとして扱い、メモリ変更、ブレークポイント、逆アセンブルなどの低レベルデバッグはROMモニタへ残す。
+そのため、SDFS/68からROMモニタの `] ` プロンプトへ戻る明示的な出口が必要である。
+起動メッセージは `SDFS/68 V1.2 #142` とする。
+メジャー/マイナー番号はSDFS/68の機能世代、`#142` は元Issue番号をbuild番号相当として扱う。
+
+## 採用仕様
+
+- `SDFS> EXIT` でROMモニタへ戻る。
+- `EXIT` は完全一致を基本とし、余分な引数は `?` にする。
+- 小文字入力は既存コマンドと同じく大文字扱いで受け付ける。
+- `EXIT` 後にROM側で再度 `BOOT` すれば、SDFS/68へ戻れる。
+
+## 実装判断
+
+ROM側 `CMD_BOOT` は stage1 entry へ `jmp` し、stage1もSDFS/68 entryへ `jmp` する。
+そのため、SDFS/68には戻り番地がなく、`EXIT` を `rts` で実装することはできない。
+
+`EXIT` は `MONITOR_REENTRY` へ `jmp` する。
+`MONITOR_REENTRY` は現行ROMの `MONITOR_ENTRY_NO_KEYBOARD` に相当する `MONITOR_BASE+$000D` で、ACIA再初期化を避けて `MAIN_LOOP` へ戻る入口として扱う。
+SDFS/68側で `STACK_TOP` を設定してから飛ぶため、SDFS/68内部の呼び出しstackは持ち越さない。
+ROMモニタ状態の完全初期化は対象外で、必要ならリセット操作で行う。
+
+## 確認内容
+
+- `python3 tests/test_sdfs68_build.py`
+- `MONITOR_PROFILE=sbcio_vdg make stage1 sdfs`
+- `MONITOR_PROFILE=k6802_vdg make stage1 sdfs`
+
+テストでは `BOOT -> EXIT -> BOOT` がタイムアウトせず、SDFS/68 bannerが2回表示されることを確認する。
+
+## 実機確認手順
+
+1. 新しい `SDFS.BIN` をsystem SDのrootへコピーする。
+2. `] BOOT` でSDFS/68を起動する。
+3. `SDFS> EXIT` でROMモニタの `] ` プロンプトへ戻ることを確認する。
+4. `] BOOT` でもう一度SDFS/68を起動できることを確認する。
+
+## 対象外
+
+- ROMモニタ状態の完全初期化。
+- ユーザープログラムからSDFS/68へ戻るABI。
+- SDFS/68の常駐復帰機構。

--- a/docs/usage/sdfs68_system_sd.md
+++ b/docs/usage/sdfs68_system_sd.md
@@ -142,8 +142,8 @@ SDFS/68 v1 はloaderの書き込み先アドレスを保護しない。`SDFS.BIN
 ## SDFS/68 v2 コマンド
 
 SDFS/68 v2では、DOS風の通常操作を本線にする。
-ただし `DIR` 追加時点ではメジャーバージョンを変えるほどのアーキテクチャ変更ではないため、起動時は `SDFS/68 V1.2 #138` のように表示する。
-`#138` は元Issue番号をbuild番号相当として扱う。
+ただし現時点ではメジャーバージョンを変えるほどのアーキテクチャ変更ではないため、起動時は `SDFS/68 V1.2 #142` のように表示する。
+`#142` は元Issue番号をbuild番号相当として扱う。
 SDFS.BIN headerのversion byteはstage1が読むバイナリ形式versionであり、起動表示のバージョンとは別に扱う。
 
 | コマンド | 用途 |
@@ -155,7 +155,7 @@ SDFS.BIN headerのversion byteはstage1が読むバイナリ形式versionであ�
 | `LOAD filename` | 予定。ファイルをロードする。自動実行しない |
 | `L filename` | 実装済み。現時点では `LOAD filename` の短縮ではなく、S-Record / Intel HEXロード用コマンド |
 | `Dhhhh` | 実装済み。16bit hexadecimal address の1 byteを表示する |
-| `EXIT` | 予定。ROMモニタへ戻る |
+| `EXIT` | 実装済み。ROMモニタへ戻る |
 
 `DIR` はSDFS/68本体がstage1の既存低レベルサービスを使ってroot directoryを走査する。
 stage1に `DIR` 専用APIは追加せず、ROM側の `DIR` も呼ばない。
@@ -177,6 +177,8 @@ subdirectory、wildcard、属性詳細表示、FAT writeは対象外である。
 
 メモリ変更、ブレークポイント、逆アセンブルなどの低レベルデバッグはSDFS/68に取り込まず、`EXIT` でROMモニタへ戻って行う。
 ROMへ戻った後は `] ` プロンプトで `M`、`D`、`U`、`B`、`R` などを使い、必要に応じて再度 `BOOT` する。
+`EXIT` はROMモニタの再入口へ戻る通常終了口であり、SDFS/68へ戻る常駐復帰機構ではない。
+ACIAは再初期化せず、ROMモニタの `] ` プロンプトへ戻る。
 
 ## 将来拡張
 

--- a/include/hardware.inc
+++ b/include/hardware.inc
@@ -3,6 +3,7 @@
 ROM_BASE         equ $E000
 ROM_END          equ $FFFF
 MONITOR_BASE     equ $E200
+MONITOR_REENTRY  equ MONITOR_BASE+$000D
 
         include "../build/monitor_config.inc"
 

--- a/src/sdfs68.asm
+++ b/src/sdfs68.asm
@@ -52,7 +52,7 @@ SDFS_LOAD_OK:
         bra     SDFS_PROMPT_NEXT
 SDFS_CHECK_DUMP:
         cmpa    #'D'
-        bne     SDFS_COMMAND_ERROR
+        bne     SDFS_CHECK_EXIT
         jsr     SDFS_CMD_IS_DIR
         bcs     SDFS_CHECK_DUMP_BYTE
         jsr     SDFS_CMD_DIR
@@ -63,6 +63,13 @@ SDFS_CHECK_DUMP_BYTE:
         jsr     SDFS_CMD_DUMP_BYTE
         bcc     SDFS_PROMPT_NEXT
         jsr     SDFS_SHOW_ERROR
+        bra     SDFS_PROMPT_NEXT
+SDFS_CHECK_EXIT:
+        cmpa    #'E'
+        bne     SDFS_COMMAND_ERROR
+        jsr     SDFS_CMD_IS_EXIT
+        bcs     SDFS_COMMAND_ERROR
+        jmp     SDFS_CMD_EXIT
 SDFS_PROMPT_NEXT:
         jsr     SDFS_PRINT_PROMPT
         bra     SDFS_LOOP
@@ -142,6 +149,32 @@ SDFS_CMD_IS_DIR:
 SDFS_CMD_IS_DIR_FAIL:
         sec
         rts
+
+SDFS_CMD_IS_EXIT:
+        ldab    LINE_LEN
+        cmpb    #4
+        bne     SDFS_CMD_IS_EXIT_FAIL
+        ldaa    LINE_BUF+1
+        jsr     SDFS_TO_UPPER
+        cmpa    #'X'
+        bne     SDFS_CMD_IS_EXIT_FAIL
+        ldaa    LINE_BUF+2
+        jsr     SDFS_TO_UPPER
+        cmpa    #'I'
+        bne     SDFS_CMD_IS_EXIT_FAIL
+        ldaa    LINE_BUF+3
+        jsr     SDFS_TO_UPPER
+        cmpa    #'T'
+        bne     SDFS_CMD_IS_EXIT_FAIL
+        clc
+        rts
+SDFS_CMD_IS_EXIT_FAIL:
+        sec
+        rts
+
+SDFS_CMD_EXIT:
+        lds     #STACK_TOP
+        jmp     MONITOR_REENTRY
 
 SDFS_CMD_DIR:
         jsr     SDFS_K_DIR_ROOT
@@ -1289,7 +1322,7 @@ SDFS_PUTC_DONE:
 
 TXT_BANNER:
         fcb     CHR_CR
-        fcc     "SDFS/68 V1.2 #138"
+        fcc     "SDFS/68 V1.2 #142"
         fcb     CHR_CR,0
 
 TXT_PROMPT:

--- a/tests/test_sdfs68_build.py
+++ b/tests/test_sdfs68_build.py
@@ -131,7 +131,7 @@ def test_stage1_boot_runs_built_sdfs_binary() -> None:
         assert rc == 0 and "[TIMEOUT]" not in stderr, (
             f"emulator failed for {profile}: rc={rc} stderr={stderr!r}"
         )
-        assert "SDFS/68 V1.2 #138" in stdout, f"missing SDFS banner for {profile}: {stdout!r}"
+        assert "SDFS/68 V1.2 #142" in stdout, f"missing SDFS banner for {profile}: {stdout!r}"
         assert "SDFS> " in stdout, f"missing SDFS prompt for {profile}: {stdout!r}"
     print("[PASS] test_stage1_boot_runs_built_sdfs_binary")
 
@@ -302,6 +302,27 @@ def test_sdfs_dir_requires_exact_command_and_dump_still_works() -> None:
     assert "?" in stdout, f"DIR with extra argument was accepted: {stdout!r}"
     assert stdout.count("SDFS> ") >= 3, f"prompt did not recover: {stdout!r}"
     print("[PASS] test_sdfs_dir_requires_exact_command_and_dump_still_works")
+
+
+def test_sdfs_exit_returns_to_monitor_and_boots_again() -> None:
+    profile = "sbcio_vdg"
+    _run_make(profile, "bin")
+    _run_make(profile, "stage1")
+    _run_make(profile, "sdfs")
+    suffix = EXPECTED[profile]["suffix"]
+    stage1 = (PROJECT_ROOT / "build" / f"stage1{suffix}.bin").read_bytes()
+    sdfs = (PROJECT_ROOT / "build" / f"SDFS{suffix}.BIN").read_bytes()
+    image = build_sdfs_image(stage1_data=stage1, sdfs_data=sdfs, extra_files=[])
+    stdout, stderr, rc = _run_emu_with_sd(
+        rom_path=PROJECT_ROOT / "build" / "mc6800-monitor-sbcio-vdg.bin",
+        input_text="BOOT\rEXIT\rBOOT\rX",
+        sd_image=image,
+        max_cycles=180_000_000,
+    )
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    assert stdout.count("SDFS/68 V1.2 #142") >= 2, f"EXIT did not allow BOOT again: {stdout!r}"
+    assert stdout.count("] ") >= 2, f"monitor prompt did not return after EXIT: {stdout!r}"
+    print("[PASS] test_sdfs_exit_returns_to_monitor_and_boots_again")
 
 
 def test_sdfs_loader_errors_return_to_prompt() -> None:
@@ -594,6 +615,7 @@ def main() -> None:
         test_sdfs_dir_scans_root_chain,
         test_sdfs_dir_returns_prompt_on_empty_followup_root_cluster,
         test_sdfs_dir_requires_exact_command_and_dump_still_works,
+        test_sdfs_exit_returns_to_monitor_and_boots_again,
         test_sdfs_loader_errors_return_to_prompt,
         test_sdfs_rejects_missing_boot_services,
         test_sdfs_rejects_bad_boot_services_headers,


### PR DESCRIPTION
## 対応Issue
- Closes #142
- Refs #137 #136 #82

## 変更内容
- SDFS/68に `EXIT` コマンドを追加しました
- `EXIT` はROM側 `MONITOR_ENTRY` 相当の `MONITOR_BASE` へ `jmp` し、ROMモニタの `] ` プロンプトへ戻ります
- `BOOT -> EXIT -> BOOT` の回帰テストを追加しました
- usage文書と `docs/plans/issue-142_sdfs68_exit.md` に実装判断と実機確認手順を追記しました

## テスト結果
- `make bin`
- `MONITOR_PROFILE=sbcio_vdg make stage1 sdfs`
- `MONITOR_PROFILE=k6802_vdg make stage1 sdfs`
- `python3 tests/test_sdfs68_build.py`
- `git diff --check`

## 影響範囲
- SDFS/68本体のみです
- ROMモニタ、stage1、SDFS.BIN header formatは変更していません

## 未対応事項
- ROMモニタ状態の完全初期化
- ユーザープログラムからSDFS/68へ戻るABI
- SDFS/68の常駐復帰機構