### PR TITLE
feat: SDFS/68にLOADコマンドを追加

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,7 @@ ROM常駐FAT `DIR` / `LF` は互換機能であり、`BOOT + SDFS/68` が今後�
 - [plans/issue-130_sdfs68_loader.md](plans/issue-130_sdfs68_loader.md): SDFS/68 v1 HEX/S-recordロード
 - [plans/issue-sdfs68_responsibility_boundary.md](plans/issue-sdfs68_responsibility_boundary.md): SDFS/68とROMモニタの責務境界
 - [plans/issue-sdfs68_v2_roadmap.md](plans/issue-sdfs68_v2_roadmap.md): SDFS/68 v2 第2段DOS基本操作ロードマップ
+- [plans/issue-141_sdfs68_load.md](plans/issue-141_sdfs68_load.md): SDFS/68 LOAD正式化
 - [plans/issue-144_rom_sdfs_docs_boundary.md](plans/issue-144_rom_sdfs_docs_boundary.md): ROMモニタとSDFS/68責務境界のユーザー向け文書整理
 - [testing/sbc6800_bringup.md](testing/sbc6800_bringup.md)
 - [testing/sbc_io_sd_bringup.md](testing/sbc_io_sd_bringup.md): SBC-IO と microSD SPI モジュールで SD/FAT を実機確認する手順

--- a/docs/plans/issue-141_sdfs68_load.md
+++ b/docs/plans/issue-141_sdfs68_load.md
@@ -1,0 +1,44 @@
+# Issue #141 SDFS/68 LOAD 正式化
+
+## 背景
+
+SDFS/68 v1の `L filename` は、S-Record / Intel HEXをロードするための最小入口として実装した。
+v2では通常実行を `RUN` へ寄せ、ロードだけ行う操作は開発補助コマンドとして整理する。
+
+## 採用仕様
+
+- `SDFS> LOAD filename` を正式名として追加する。
+- 既存の `SDFS> L filename` は `LOAD filename` の短縮エイリアスとして維持する。
+- `LOAD` はロードだけを行い、自動実行しない。
+- `LOAD` と `L` は同じ内部ロード処理を呼ぶ。
+- `LOAD filename` はコマンド名とファイル名の間に空白を要求する。
+- `LOADHELLO.S` のような曖昧な入力は `?` として扱う。
+
+## 実装判断
+
+`LOAD` はSDFS/68本体のshell commandであり、stage1 APIは増やさない。
+既存の `L` 実装を `SDFS_K_LOAD_FILE` として共通化し、`SDFS_CMD_LOAD_LONG` と `SDFS_CMD_LOAD_ALIAS` の両方から呼ぶ。
+
+表示上のbuild番号は元Issue番号に合わせ、起動メッセージは `SDFS/68 V1.2 #141` とする。
+SDFS.BIN headerのformat versionはstage1互換のため `1` のまま変更しない。
+
+## 確認内容
+
+- `LOAD HELLO.S` でS-Recordをロードできること。
+- `L HELLO.HEX` で既存aliasが動くこと。
+- `LOAD EOF.HEX` でIntel HEX EOF終端を処理できること。
+- `LOAD MISSING.S`、`LOADHELLO.S`、壊れたHEX、終端recordなしS-Recordで `?` を出してプロンプトへ戻ること。
+
+## 実機確認手順
+
+1. 新しい `SDFS.BIN` をsystem SDのrootへコピーする。
+2. `] BOOT` でSDFS/68を起動する。
+3. `SDFS> LOAD HELLO.S` を実行する。
+4. `SDFS> D0100` などでロード済みであることを確認する。
+5. `SDFS> L HELLO.S` も同じように動くことを確認する。
+
+## 対象外
+
+- `RUN` の実装。
+- 実行ファイル形式の追加。
+- ロード先メモリ保護。

--- a/docs/usage/sdfs68_system_sd.md
+++ b/docs/usage/sdfs68_system_sd.md
@@ -125,7 +125,7 @@ ROM `BOOT` 後にSDFS/68上で動くロード手段であり、stage1 boot servi
 例:
 
 ```text
-SDFS> L HELLO.S
+SDFS> LOAD HELLO.S
 OK
 SDFS> L HELLO.HEX
 OK
@@ -142,8 +142,8 @@ SDFS/68 v1 はloaderの書き込み先アドレスを保護しない。`SDFS.BIN
 ## SDFS/68 v2 コマンド
 
 SDFS/68 v2では、DOS風の通常操作を本線にする。
-ただし現時点ではメジャーバージョンを変えるほどのアーキテクチャ変更ではないため、起動時は `SDFS/68 V1.2 #142` のように表示する。
-`#142` は元Issue番号をbuild番号相当として扱う。
+ただし現時点ではメジャーバージョンを変えるほどのアーキテクチャ変更ではないため、起動時は `SDFS/68 V1.2 #141` のように表示する。
+`#141` は元Issue番号をbuild番号相当として扱う。
 SDFS.BIN headerのversion byteはstage1が読むバイナリ形式versionであり、起動表示のバージョンとは別に扱う。
 
 | コマンド | 用途 |
@@ -152,8 +152,8 @@ SDFS.BIN headerのversion byteはstage1が読むバイナリ形式versionであ�
 | `TYPE filename` | 予定。テキストファイルをコンソールへ表示する |
 | `RUN filename` | 予定。ファイルをロードし、entryが取れれば実行する |
 | `RUN addr` | 予定。指定アドレスへジャンプする |
-| `LOAD filename` | 予定。ファイルをロードする。自動実行しない |
-| `L filename` | 実装済み。現時点では `LOAD filename` の短縮ではなく、S-Record / Intel HEXロード用コマンド |
+| `LOAD filename` | 実装済み。ファイルをロードする。自動実行しない |
+| `L filename` | 実装済み。`LOAD filename` の短縮エイリアス |
 | `Dhhhh` | 実装済み。16bit hexadecimal address の1 byteを表示する |
 | `EXIT` | 実装済み。ROMモニタへ戻る |
 
@@ -174,6 +174,7 @@ LFN、volume label、directory、deleted entryは表示しない。
 subdirectory、wildcard、属性詳細表示、FAT writeは対象外である。
 
 通常実行は `RUN` を使う。`LOAD` / `L` はロード確認やデバッグ用の補助コマンドとして扱う。
+`LOAD` はロードのみを行い、自動ジャンプしない。
 
 メモリ変更、ブレークポイント、逆アセンブルなどの低レベルデバッグはSDFS/68に取り込まず、`EXIT` でROMモニタへ戻って行う。
 ROMへ戻った後は `] ` プロンプトで `M`、`D`、`U`、`B`、`R` などを使い、必要に応じて再度 `BOOT` する。

--- a/src/sdfs68.asm
+++ b/src/sdfs68.asm
@@ -42,7 +42,15 @@ SDFS_LOOP:
         jsr     SDFS_TO_UPPER
         cmpa    #'L'
         bne     SDFS_CHECK_DUMP
-        jsr     SDFS_CMD_LOAD
+        jsr     SDFS_CMD_IS_LOAD_LONG
+        bcc     SDFS_DO_LOAD_LONG
+        jsr     SDFS_CMD_IS_LOAD_LONG_PREFIX
+        bcc     SDFS_COMMAND_ERROR
+        jsr     SDFS_CMD_LOAD_ALIAS
+        bra     SDFS_LOAD_RESULT
+SDFS_DO_LOAD_LONG:
+        jsr     SDFS_CMD_LOAD_LONG
+SDFS_LOAD_RESULT:
         bcc     SDFS_LOAD_OK
         jsr     SDFS_SHOW_LOADER_ERROR
         bra     SDFS_PROMPT_NEXT
@@ -77,14 +85,66 @@ SDFS_COMMAND_ERROR:
         jsr     SDFS_SHOW_ERROR
         bra     SDFS_PROMPT_NEXT
 
-SDFS_CMD_LOAD:
-        clr     LOADER_MODE
-        clr     LOADER_STAGE
+SDFS_CMD_LOAD_ALIAS:
         ldab    LINE_LEN
         cmpb    #2
-        blo     SDFS_CMD_LOAD_FAIL
+        blo     SDFS_CMD_LOAD_FAIL_NEAR
         subb    #1
         ldx     #LINE_BUF+1
+        jmp     SDFS_K_LOAD_FILE
+
+SDFS_CMD_LOAD_LONG:
+        ldab    LINE_LEN
+        cmpb    #5
+        blo     SDFS_CMD_LOAD_FAIL_NEAR
+        ldaa    LINE_BUF+4
+        cmpa    #CHR_SPACE
+        bne     SDFS_CMD_LOAD_FAIL_NEAR
+        subb    #4
+        ldx     #LINE_BUF+4
+        jmp     SDFS_K_LOAD_FILE
+SDFS_CMD_LOAD_FAIL_NEAR:
+        jmp     SDFS_CMD_LOAD_FAIL
+
+SDFS_CMD_IS_LOAD_LONG:
+        ldab    LINE_LEN
+        cmpb    #4
+        blo     SDFS_CMD_IS_LOAD_LONG_FAIL
+        ldaa    LINE_BUF+1
+        jsr     SDFS_TO_UPPER
+        cmpa    #'O'
+        bne     SDFS_CMD_IS_LOAD_LONG_FAIL
+        ldaa    LINE_BUF+2
+        jsr     SDFS_TO_UPPER
+        cmpa    #'A'
+        bne     SDFS_CMD_IS_LOAD_LONG_FAIL
+        ldaa    LINE_BUF+3
+        jsr     SDFS_TO_UPPER
+        cmpa    #'D'
+        bne     SDFS_CMD_IS_LOAD_LONG_FAIL
+        clc
+        rts
+SDFS_CMD_IS_LOAD_LONG_FAIL:
+        sec
+        rts
+
+SDFS_CMD_IS_LOAD_LONG_PREFIX:
+        ldab    LINE_LEN
+        cmpb    #2
+        blo     SDFS_CMD_IS_LOAD_LONG_PREFIX_FAIL
+        ldaa    LINE_BUF+1
+        jsr     SDFS_TO_UPPER
+        cmpa    #'O'
+        bne     SDFS_CMD_IS_LOAD_LONG_PREFIX_FAIL
+        clc
+        rts
+SDFS_CMD_IS_LOAD_LONG_PREFIX_FAIL:
+        sec
+        rts
+
+SDFS_K_LOAD_FILE:
+        clr     LOADER_MODE
+        clr     LOADER_STAGE
         jsr     SDFS_PARSE_FILENAME_83
         bcs     SDFS_CMD_LOAD_FAIL
         jsr     SDFS_API_MOUNT
@@ -1322,7 +1382,7 @@ SDFS_PUTC_DONE:
 
 TXT_BANNER:
         fcb     CHR_CR
-        fcc     "SDFS/68 V1.2 #142"
+        fcc     "SDFS/68 V1.2 #141"
         fcb     CHR_CR,0
 
 TXT_PROMPT:

--- a/tests/test_sdfs68_build.py
+++ b/tests/test_sdfs68_build.py
@@ -131,7 +131,7 @@ def test_stage1_boot_runs_built_sdfs_binary() -> None:
         assert rc == 0 and "[TIMEOUT]" not in stderr, (
             f"emulator failed for {profile}: rc={rc} stderr={stderr!r}"
         )
-        assert "SDFS/68 V1.2 #142" in stdout, f"missing SDFS banner for {profile}: {stdout!r}"
+        assert "SDFS/68 V1.2 #141" in stdout, f"missing SDFS banner for {profile}: {stdout!r}"
         assert "SDFS> " in stdout, f"missing SDFS prompt for {profile}: {stdout!r}"
     print("[PASS] test_stage1_boot_runs_built_sdfs_binary")
 
@@ -155,7 +155,7 @@ def test_sdfs_loads_srec_and_ihex_files() -> None:
         )
         stdout, stderr, rc = _run_emu_with_sd(
             rom_path=PROJECT_ROOT / "build" / f"mc6800-monitor{suffix}.bin",
-            input_text="BOOT\rL HELLO.S\rD0200\rL HELLO.HEX\rD0201\rL EOF.HEX\rD0202\rX",
+            input_text="BOOT\rLOAD HELLO.S\rD0200\rL HELLO.HEX\rD0201\rLOAD EOF.HEX\rD0202\rX",
             sd_image=image,
             max_cycles=160_000_000,
         )
@@ -320,7 +320,7 @@ def test_sdfs_exit_returns_to_monitor_and_boots_again() -> None:
         max_cycles=180_000_000,
     )
     assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
-    assert stdout.count("SDFS/68 V1.2 #142") >= 2, f"EXIT did not allow BOOT again: {stdout!r}"
+    assert stdout.count("SDFS/68 V1.2 #141") >= 2, f"EXIT did not allow BOOT again: {stdout!r}"
     assert stdout.count("] ") >= 2, f"monitor prompt did not return after EXIT: {stdout!r}"
     print("[PASS] test_sdfs_exit_returns_to_monitor_and_boots_again")
 
@@ -343,13 +343,14 @@ def test_sdfs_loader_errors_return_to_prompt() -> None:
     )
     stdout, stderr, rc = _run_emu_with_sd(
         rom_path=PROJECT_ROOT / "build" / "mc6800-monitor-sbcio-vdg.bin",
-        input_text="BOOT\rL MISSING.S\rL BAD.HEX\rL NOEND.S\rX",
+        input_text="BOOT\rLOAD MISSING.S\rLOADHELLO.S\rL BAD.HEX\rL NOEND.S\rX",
         sd_image=image,
         max_cycles=140_000_000,
     )
     assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
-    assert "MISSING.S" in stdout and "BAD.HEX" in stdout and "NOEND.S" in stdout
-    assert stdout.count("SDFS> ") >= 4, f"SDFS prompt did not recover after errors: {stdout!r}"
+    assert "MISSING.S" in stdout and "LOADHELLO.S" in stdout
+    assert "BAD.HEX" in stdout and "NOEND.S" in stdout
+    assert stdout.count("SDFS> ") >= 5, f"SDFS prompt did not recover after errors: {stdout!r}"
     assert "?" in stdout, f"missing loader error output: {stdout!r}"
     print("[PASS] test_sdfs_loader_errors_return_to_prompt")
 


### PR DESCRIPTION
## 対応Issue
- Closes #141
- Refs #137 #136 #130 #82

## 変更内容
- `LOAD filename` をSDFS/68の正式コマンドとして追加しました
- 既存の `L filename` は `LOAD filename` の短縮エイリアスとして維持しました
- `LOAD` と `L` が同じ内部ロード処理を呼ぶように整理しました
- `LOADHELLO.S` のような曖昧な入力は `?` として扱います
- usage文書と `docs/plans/issue-141_sdfs68_load.md` を更新しました

## テスト結果
- `make bin`
- `MONITOR_PROFILE=sbcio_vdg make stage1 sdfs`
- `MONITOR_PROFILE=k6802_vdg make stage1 sdfs`
- `python3 tests/test_sdfs68_build.py`
- `git diff --check`

## 影響範囲
- SDFS/68本体とSDFS/68ビルドテストです
- ROMモニタ、stage1、SDFS.BIN header formatは変更していません

## 未対応事項
- `RUN` の実装
- 実行ファイル形式の追加
- ロード先メモリ保護