### PR TITLE
fix: SDFS DIRとRUNの表示復帰を整える

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,7 @@ ROM常駐FAT `DIR` / `LF` は互換機能であり、`BOOT + SDFS/68` が今後�
 - [plans/issue-141_sdfs68_load.md](plans/issue-141_sdfs68_load.md): SDFS/68 LOAD正式化
 - [plans/issue-149_sdfs68_run_addr.md](plans/issue-149_sdfs68_run_addr.md): SDFS/68 RUN addr
 - [plans/issue-150_sdfs68_run_file.md](plans/issue-150_sdfs68_run_file.md): SDFS/68 RUN filename
+- [plans/issue-153_sdfs68_dir_run_polish.md](plans/issue-153_sdfs68_dir_run_polish.md): SDFS/68 DIR/RUN表示改善
 - [plans/issue-144_rom_sdfs_docs_boundary.md](plans/issue-144_rom_sdfs_docs_boundary.md): ROMモニタとSDFS/68責務境界のユーザー向け文書整理
 - [testing/sbc6800_bringup.md](testing/sbc6800_bringup.md)
 - [testing/sbc_io_sd_bringup.md](testing/sbc_io_sd_bringup.md): SBC-IO と microSD SPI モジュールで SD/FAT を実機確認する手順

--- a/docs/plans/issue-153_sdfs68_dir_run_polish.md
+++ b/docs/plans/issue-153_sdfs68_dir_run_polish.md
@@ -1,0 +1,40 @@
+# SDFS/68 `DIR` / `RUN` 表示改善計画
+
+## 対象
+
+- Issue: #153
+- 親Issue: #137
+- 関連: #138, #149, #150, #136, #130, #82
+
+## 背景
+
+SDFS/68 V1.2で `DIR`、`LOAD`、`RUN addr`、`RUN filename`、`EXIT` が揃い、通常操作がDOSらしくなってきた。
+一方で実機確認中、MacでSDカード上のファイルを触ったあとにAppleDouble風の副産物が `DIR` に見えた。
+また `RUN KHELL` のような存在しないファイル指定で、実機ログ上は `?` が見えないように見えた。
+
+`TYPE` を追加する前に、既存コマンドの表示対象とエラー復帰を整える。
+
+## 方針
+
+- `DIR` は通常ユーザーファイルだけを表示する。
+- hidden / system / volume label / directory / LFN / deleted entry は表示しない。
+- ファイル名に制御文字や非ASCIIが混じるentryは表示しない。
+- Mac由来のAppleDouble風entryはhidden属性付きの短縮名として見えることがあるため、hidden除外で非表示にする。
+- `_` 始まりの通常ファイルを無条件には隠さない。FAT属性上の通常ファイルなら表示対象に残す。
+- `RUN` の失敗経路は `?` を表示して `SDFS> ` に戻ることをテストで固定する。
+
+## 検証方針
+
+- `DIR` に `SDFS.BIN`、`HELLO.S`、`HELLO2.S` などの通常ファイルが出ること。
+- `DIR` に hidden、system、volume label、directory、LFN、deleted entryが出ないこと。
+- `DIR` にAppleDouble風の `_SDF~*.BIN`、`_HELL~*.S` が出ないこと。
+- `DIR` に制御文字や非ASCIIを含む名前entryが出ないこと。
+- `RUN KHELL`、`RUN HELLO.HEX`、entryなし/壊れたS-Recordで `?` を表示し、プロンプトへ戻ること。
+- 既存の `RUN HELLO.S`、`RUN 0100`、`LOAD`、`EXIT` の回帰を維持すること。
+
+## 対象外
+
+- `TYPE filename`
+- FAT write / delete / rename
+- subdirectory対応
+- AppleDoubleファイル自体をSDから削除する機能

--- a/docs/usage/sdfs68_system_sd.md
+++ b/docs/usage/sdfs68_system_sd.md
@@ -169,8 +169,10 @@ HELLO.S A 0000004A
 HELLO.HEX A 00000022
 ```
 
-`DIR` が表示するのは、root directory直下の8.3 short filename通常ファイルだけである。
-LFN、volume label、directory、deleted entryは表示しない。
+`DIR` が表示するのは、root directory直下の8.3 short filename通常ユーザーファイルだけである。
+LFN、volume label、directory、hidden、system、deleted entryは表示しない。
+ファイル名に制御文字や非ASCIIが混じるentryも表示しない。
+MacでSDカードをマウントしたときにできるAppleDouble風の副産物は、hidden属性付きの短縮名として見える場合があり、SDFS/68の `DIR` では表示しない。
 subdirectory、wildcard、属性詳細表示、FAT writeは対象外である。
 
 通常実行は `RUN` を使う。

--- a/src/sdfs68.asm
+++ b/src/sdfs68.asm
@@ -307,13 +307,8 @@ SDFS_K_DIR_ENTRY_LOOP:
         beq     SDFS_K_DIR_DONE
         cmpa    #$E5
         beq     SDFS_K_DIR_NEXT_ENTRY
-        ldaa    11,x
-        anda    #$0F
-        cmpa    #$0F
-        beq     SDFS_K_DIR_NEXT_ENTRY
-        ldaa    11,x
-        anda    #$18
-        bne     SDFS_K_DIR_NEXT_ENTRY
+        jsr     SDFS_K_DIR_ENTRY_VISIBLE
+        bcs     SDFS_K_DIR_NEXT_ENTRY
         jsr     SDFS_K_PRINT_DIR_ENTRY
 SDFS_K_DIR_NEXT_ENTRY:
         jsr     SDFS_K_ADVANCE_ENTRY_PTR
@@ -422,6 +417,32 @@ SDFS_K_DIR_EXT_CHECK_LOOP:
         rts
 SDFS_K_DIR_EXT_FOUND:
         clc
+        rts
+
+SDFS_K_DIR_ENTRY_VISIBLE:
+        ldx     FAT_ENTRY_PTR
+        ldaa    11,x
+        anda    #$1E
+        bne     SDFS_K_DIR_ENTRY_SKIP
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        beq     SDFS_K_DIR_ENTRY_SKIP
+        ldab    #11
+SDFS_K_DIR_NAME_CHAR_LOOP:
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        beq     SDFS_K_DIR_NAME_CHAR_OK
+        blo     SDFS_K_DIR_ENTRY_SKIP
+        cmpa    #$7F
+        bhs     SDFS_K_DIR_ENTRY_SKIP
+SDFS_K_DIR_NAME_CHAR_OK:
+        inx
+        decb
+        bne     SDFS_K_DIR_NAME_CHAR_LOOP
+        clc
+        rts
+SDFS_K_DIR_ENTRY_SKIP:
+        sec
         rts
 
 SDFS_CHECK_S1:

--- a/tests/test_sdfs68_build.py
+++ b/tests/test_sdfs68_build.py
@@ -195,11 +195,18 @@ def test_sdfs_dir_lists_root_files_and_skips_non_files() -> None:
             sdfs_data=sdfs,
             extra_files=[
                 _file("HELLO.S", _srec_file(0x0200, b"S")),
+                _file("HELLO2.S", _srec_file(0x0203, b"2")),
                 _file("HELLO.HEX", _ihex_file(0x0201, b"I")),
                 _file("README.TXT", b"HELLO\r\n"),
                 _raw_file(b"SKIPVOL    ", b"", attr=0x08),
                 _raw_file(b"SKIPDIR    ", b"", attr=0x10),
                 _raw_file(b"SKIPLFN    ", b"", attr=0x0F),
+                _raw_file(b"SKIPHID TXT", b"", attr=0x22),
+                _raw_file(b"SKIPSYS TXT", b"", attr=0x24),
+                _raw_file(b"_SDF~4  BIN", b"", attr=0x22),
+                _raw_file(b"_HELL~9 S  ", b"", attr=0x22),
+                _raw_file(b"\x01BAD    TXT", b"", attr=0x20),
+                _raw_file(b"\x80BAD    TXT", b"", attr=0x20),
                 _raw_file(bytes([0xE5]) + b"DEL    TXT", b"", attr=0x20),
             ],
         )
@@ -214,6 +221,7 @@ def test_sdfs_dir_lists_root_files_and_skips_non_files() -> None:
         )
         assert "SDFS.BIN A " in stdout, f"SDFS.BIN missing from DIR for {profile}: {stdout!r}"
         assert "HELLO.S A " in stdout, f"HELLO.S missing from DIR for {profile}: {stdout!r}"
+        assert "HELLO2.S A " in stdout, f"HELLO2.S missing from DIR for {profile}: {stdout!r}"
         assert "HELLO.HEX A " in stdout, f"HELLO.HEX missing from DIR for {profile}: {stdout!r}"
         assert "README.TXT A 00000007" in stdout, (
             f"README.TXT missing or size mismatch for {profile}: {stdout!r}"
@@ -221,6 +229,11 @@ def test_sdfs_dir_lists_root_files_and_skips_non_files() -> None:
         assert "SKIPVOL" not in stdout, f"volume label leaked into DIR for {profile}: {stdout!r}"
         assert "SKIPDIR" not in stdout, f"directory entry leaked into DIR for {profile}: {stdout!r}"
         assert "SKIPLFN" not in stdout, f"LFN entry leaked into DIR for {profile}: {stdout!r}"
+        assert "SKIPHID" not in stdout, f"hidden entry leaked into DIR for {profile}: {stdout!r}"
+        assert "SKIPSYS" not in stdout, f"system entry leaked into DIR for {profile}: {stdout!r}"
+        assert "_SDF~4.BIN" not in stdout, f"AppleDouble entry leaked into DIR for {profile}: {stdout!r}"
+        assert "_HELL~9.S" not in stdout, f"AppleDouble entry leaked into DIR for {profile}: {stdout!r}"
+        assert "BAD.TXT" not in stdout, f"invalid name entry leaked into DIR for {profile}: {stdout!r}"
         assert "DEL.TXT" not in stdout, f"deleted entry leaked into DIR for {profile}: {stdout!r}"
         assert stdout.count("SDFS> ") >= 2, f"DIR did not return to prompt for {profile}: {stdout!r}"
     print("[PASS] test_sdfs_dir_lists_root_files_and_skips_non_files")
@@ -463,13 +476,13 @@ def test_sdfs_run_file_requires_srec_entry() -> None:
     )
     stdout, stderr, rc = _run_emu_with_sd(
         rom_path=PROJECT_ROOT / "build" / "mc6800-monitor-sbcio-vdg.bin",
-        input_text="BOOT\rRUN HELLO.HEX\rRUN BAD.S\rX",
+        input_text="BOOT\rRUN KHELL\rRUN HELLO.HEX\rRUN BAD.S\rX",
         sd_image=image,
         max_cycles=120_000_000,
     )
     assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
-    assert stdout.count("?") >= 2, f"RUN files without S-record entry were accepted: {stdout!r}"
-    assert stdout.count("SDFS> ") >= 3, f"prompt did not recover after bad RUN files: {stdout!r}"
+    assert stdout.count("?") >= 3, f"RUN files without S-record entry were accepted: {stdout!r}"
+    assert stdout.count("SDFS> ") >= 4, f"prompt did not recover after bad RUN files: {stdout!r}"
     print("[PASS] test_sdfs_run_file_requires_srec_entry")
 
 


### PR DESCRIPTION
## 対応Issue

Closes #153
Refs #137 #138 #149 #150 #136 #130 #82

## 変更内容

- SDFS/68の `DIR` でhidden / system / volume / directory / LFN / deleted entryを非表示にした
- ファイル名に制御文字や非ASCIIが混じるdirectory entryを `DIR` でskipするようにした
- Mac由来のAppleDouble風entryはhidden属性付き短縮名として見えるため、`DIR` に出さない方針をdocsへ明記した
- `RUN KHELL` のような存在しないファイル指定で `?` を表示してプロンプトへ戻ることをテストで固定した

## テスト

- `make bin`
- `MONITOR_PROFILE=sbcio_vdg make stage1 sdfs`
- `MONITOR_PROFILE=k6802_vdg make stage1 sdfs`
- `python3 tests/test_sdfs68_build.py`
- `python3 tests/test_smoke.py`
- `git diff --check`

## 追加・更新したテスト

- `DIR` で通常ファイル `SDFS.BIN` / `HELLO.S` / `HELLO2.S` を表示すること
- `DIR` でhidden / system / volume / directory / LFN / deleted / AppleDouble風 / 不正名entryを表示しないこと
- `RUN KHELL` / `RUN HELLO.HEX` / 壊れたS-Recordで `?` を表示して戻ること

## 影響範囲

- SDFS/68本体の `DIR` entry判定
- SDFS/68のエミュレータテスト
- SDFS/68 usage文書

ROMモニタ、stage1 API、SDFS.BIN header formatは変更していない。

## 未対応事項

- `TYPE filename`
- FAT write / delete / rename
- subdirectory対応
- AppleDoubleファイル自体をSDから削除する機能