### PR TITLE
fix: ROM容量削減の小修正を適用する

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -59,6 +59,7 @@ ROM常駐FAT `DIR` / `LF` は互換機能であり、`BOOT + SDFS/68` が今後�
 - [plans/issue-153_sdfs68_dir_run_polish.md](plans/issue-153_sdfs68_dir_run_polish.md): SDFS/68 DIR/RUN表示改善
 - [plans/issue-155_sdfs68_line_input.md](plans/issue-155_sdfs68_line_input.md): SDFS/68 行入力改善
 - [plans/issue-167_vdg_console_output.md](plans/issue-167_vdg_console_output.md): VDG console出力
+- [plans/issue-175_rom_size_audit.md](plans/issue-175_rom_size_audit.md): ROM容量削減とデッドコード探索
 - [plans/issue-144_rom_sdfs_docs_boundary.md](plans/issue-144_rom_sdfs_docs_boundary.md): ROMモニタとSDFS/68責務境界のユーザー向け文書整理
 - [../diagnostics/README.md](../diagnostics/README.md): SDからロードして使う診断用S-Record
 - [testing/sbc6800_bringup.md](testing/sbc6800_bringup.md)

--- a/docs/plans/issue-175_rom_size_audit.md
+++ b/docs/plans/issue-175_rom_size_audit.md
@@ -1,0 +1,55 @@
+# Issue #175 ROM容量削減とデッドコード探索
+
+## 背景
+
+PR #174でVDG console出力、VDGTEST/KEYTESTのSD診断化、MコマンドのVDG出力修正まで入れた。
+一方で、`sbcio_vdg` / `k6802_vdg` は8KB ROM上限に近く、今後のVDG/keyboard/BOOT共存のため、まず削減余地をlistingベースで確認した。
+
+## 初回探索
+
+`main` 更新後、次の2profileをビルドしてlistingを確認した。
+
+```text
+MONITOR_PROFILE=sbcio_vdg make bin
+MONITOR_PROFILE=k6802_vdg make bin
+```
+
+`.bin` の表示サイズは固定ベクタ込みの範囲サイズなので、削減量の確認には向かない。
+実際の削減は、`SD_INIT` や `SPURIOUS_IRQ` など後続ラベルの前倒し量で見る。
+
+## 採用した削減
+
+### VDGハイフン特例削除
+
+K68-VDGでは、ASCII `$20-$3F` をVDG側 `$60-$7F` へ寄せる方針にした。
+そのため、`'-'` だけを特別扱いして `$6D` を返す必要はない。
+
+```text
+'-' = $2D
+$2D + $40 = $6D
+```
+
+`VDG_ASCII_TO_CHAR` は `$40` 未満を一律 `$40` 加算するだけにした。
+
+### MAP文字列のprofile別条件アセンブル
+
+`CMD_MAP` の処理本体はprofile別に条件アセンブルされていたが、MAP用文字列は他profile向けのものもROMへ入っていた。
+これを参照側と同じ条件で囲み、現在のprofileで使う文字列だけをROMへ入れるようにした。
+
+`sbcio_vdg` では、変更前の `SD_INIT` は `F1CC`、変更後は `F114` になった。
+差分は `0xB8`、つまり184バイトぶん後続コードが前倒しになった。
+
+## 見送った候補
+
+| 候補 | 見込み | 見送り理由 |
+| --- | ---: | --- |
+| Intel HEX loader削除 | 約170B+α | ROM `L` の互換性低下がある。SREC専用に割り切る判断が必要 |
+| RAMTESTのSD診断化 | 約294B+文字列 | ROM単体の復旧口として価値が高い |
+| 逆アセンブラ縮小/SD診断化 | 約265B+文字列 | ROM最終形のマシン語デバッグ用途と衝突する |
+| SD rawアクセス削減 | 約644B | `BOOT`方針そのものに影響する |
+
+## 検証方針
+
+MAP文字列条件化は全profileへ影響するため、`base`、`sbcio`、`sbcio_vdg`、`k6802_vdg` のsmoke testで確認する。
+`sbcio` はROM常駐FATありprofileなので、SD fixture testも確認する。
+

--- a/src/main.asm
+++ b/src/main.asm
@@ -1303,15 +1303,10 @@ VDG_WRAP_CURSOR_DONE:
         rts
 
 VDG_ASCII_TO_CHAR:
-        cmpa    #'-'
-        beq     VDG_ASCII_TO_HYPHEN
         cmpa    #$40
         bhs     VDG_ASCII_TO_CHAR_DONE
         adda    #$40
 VDG_ASCII_TO_CHAR_DONE:
-        rts
-VDG_ASCII_TO_HYPHEN:
-        ldaa    #$6D
         rts
  endif
 
@@ -2304,8 +2299,11 @@ TXT_RAMTEST_PREFIX: fcc     "RAMTEST "
                     fcb     $04
 TXT_RAMTEST_NG:     fcc     "NG "
                     fcb     $04
+ if MONITOR_PROFILE_BASE
 TXT_MAP_BASE:       fcc     "MAP BASE"
                     fcb     $04
+ endif
+ if BUILD_MEMORY_CONFIG_BASE8K
 TXT_MAP_BASE_RAM:   fcc     "RAM 0000-1FFF"
                     fcb     $04
 TXT_MAP_BASE_USER:  fcc     "USER 0000-1FFF"
@@ -2318,47 +2316,88 @@ TXT_MAP_BASE_SD:    fcc     "SD 1C00"
  endif
 TXT_MAP_BASE_MON:   fcc     "MON 1E00"
                     fcb     $04
-TXT_MAP_SBCIO:      fcc     "MAP SBCIO"
-                    fcb     $04
+ endif
+ if MONITOR_PROFILE_SBCIO
+ if MONITOR_FEATURE_VDG
 TXT_MAP_SBCIO_VDG:  fcc     "MAP SBCIO VDG"
                     fcb     $04
+ else
+TXT_MAP_SBCIO:      fcc     "MAP SBCIO"
+                    fcb     $04
+ endif
+ endif
+ if MONITOR_PROFILE_K6802_VDG
 TXT_MAP_K6802_VDG:  fcc     "MAP K6802 VDG"
                     fcb     $04
+ endif
+ if BUILD_MEMORY_CONFIG_RAM64_C000_WORK
 TXT_MAP_SBCIO_RAM:  fcc     "RAM 0000-7FFF"
                     fcb     $04
 TXT_MAP_SBCIO_USER: fcc     "USER 0000-7FFF"
                     fcb     $04
+ endif
+ if BUILD_MEMORY_CONFIG_RAM64_A000_WORK
+TXT_MAP_SBCIO_RAM:  fcc     "RAM 0000-7FFF"
+                    fcb     $04
+TXT_MAP_SBCIO_USER: fcc     "USER 0000-7FFF"
+                    fcb     $04
+ endif
+ if BUILD_MEMORY_CONFIG_RAM64_C000_WORK
 TXT_MAP_SBCIO_WORK: fcc     "WORK C000-DFFF"
                     fcb     $04
+ endif
+ if BUILD_MEMORY_CONFIG_RAM64_A000_WORK
 TXT_MAP_K6802_WORK: fcc     "WORK A000-BFFF"
                     fcb     $04
+ endif
  if MONITOR_FEATURE_SD
+ if BUILD_MEMORY_CONFIG_RAM64_C000_WORK
 TXT_MAP_SBCIO_SD:   fcc     "SD C000"
                     fcb     $04
+ endif
+ if BUILD_MEMORY_CONFIG_RAM64_A000_WORK
 TXT_MAP_K6802_SD:   fcc     "SD A000"
                     fcb     $04
  endif
+ endif
+ if BUILD_MEMORY_CONFIG_RAM64_C000_WORK
 TXT_MAP_SBCIO_MON:  fcc     "MON C200"
                     fcb     $04
+ endif
+ if BUILD_MEMORY_CONFIG_RAM64_A000_WORK
 TXT_MAP_K6802_MON:  fcc     "MON A200"
                     fcb     $04
+ endif
+ if BUILD_MEMORY_CONFIG_BASE8K
 TXT_MAP_BASE_MIK:   fcc     "MIK 1F00"
                     fcb     $04
 TXT_MAP_BASE_STK:   fcc     "STK 1F42"
                     fcb     $04
+ endif
+ if BUILD_MEMORY_CONFIG_RAM64_C000_WORK
 TXT_MAP_SBCIO_MIK:  fcc     "MIK C300"
                     fcb     $04
+ endif
+ if BUILD_MEMORY_CONFIG_RAM64_A000_WORK
 TXT_MAP_K6802_MIK:  fcc     "MIK A300"
                     fcb     $04
+ endif
+ if BUILD_MEMORY_CONFIG_RAM64_C000_WORK
 TXT_MAP_SBCIO_STK:  fcc     "STK DFFF"
                     fcb     $04
+ endif
+ if BUILD_MEMORY_CONFIG_RAM64_A000_WORK
 TXT_MAP_K6802_STK:  fcc     "STK BFFF"
                     fcb     $04
+ endif
  if MONITOR_FEATURE_VDG
-TXT_MAP_VDG_VRAM:   fcc     "VRAM A000-BFFF"
-                    fcb     $04
+ if BUILD_VDG_VRAM_C000
 TXT_MAP_K6802_VRAM: fcc     "VRAM C000-DFFF"
                     fcb     $04
+ else
+TXT_MAP_VDG_VRAM:   fcc     "VRAM A000-BFFF"
+                    fcb     $04
+ endif
 TXT_MAP_VDG_CTL:    fcc     "VDG 8110"
                     fcb     $04
  endif


### PR DESCRIPTION
## 対応Issue

Closes #175
Refs #165 #168

## 変更内容

- VDG文字変換から `'-'` 専用分岐を削除し、ASCII `$20-$3F` をVDG側 `$60-$7F` へ一律変換する処理へ整理
- `MAP` 用文字列をprofile別に条件アセンブルし、使わないprofile向け文字列をROMへ入れないように変更
- `docs/plans/issue-175_rom_size_audit.md` を追加し、初回探索結果、採用した削減、見送った候補を記録
- `docs/README.md` に計画メモへのリンクを追加

## 削減結果

- `sbcio_vdg` listing上で `SD_INIT` が `F1CC` から `F114` へ前倒し
- 差分は `0xB8`、184バイト相当
- `.bin` の表示サイズは固定ベクタ込みのため従来通り `8075/8192 bytes`

## テスト結果

```text
MONITOR_PROFILE=sbcio_vdg make bin
MONITOR_PROFILE=sbcio_vdg REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py

MONITOR_PROFILE=k6802_vdg make bin
MONITOR_PROFILE=k6802_vdg REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py

MONITOR_PROFILE=base make bin
MONITOR_PROFILE=base REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py

MONITOR_PROFILE=sbcio make bin
MONITOR_PROFILE=sbcio REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py
MONITOR_PROFILE=sbcio REQUIRE_BUILD_ROM=1 python3 tests/test_sd_fixture.py

git diff --check
```

## 影響範囲

- ROMモニタのVDG文字変換
- `MAP` 表示用文字列のアセンブル条件
- `base` / `sbcio` / `sbcio_vdg` / `k6802_vdg` の全profile

## 未対応事項

- Intel HEX loader削除、RAMTEST/逆アセンブラのSD診断化、SD rawアクセス削減は判断が重いため見送り
