### PR TITLE
fix: 2nd ACIAキーボードを入力経路へ統合する

### DIFF
--- a/docs/plans/issue-169_keyboard_console_input.md
+++ b/docs/plans/issue-169_keyboard_console_input.md
@@ -1,0 +1,45 @@
+# Issue #169 2nd ACIAキーボード入力統合
+
+## 背景
+
+#78 で2nd ACIA `$8094/$8095` と KKBD-USB による1文字入力PoCを確認した。
+#167 と #168 でVDGへの出力と行制御が入ったため、#169 では入力側もROMモニタの通常操作へ統合する。
+
+## 採用方針
+
+- 外部から見える入力入口は増やさない。
+- `INCH` / `INEEE` は従来通り単一のMIKBUG互換入力入口として維持する。
+- 外部プログラムやBASICには、入力元が1st ACIAか2nd ACIAかを意識させない。
+- `MONITOR_FEATURE_KEYBOARD=1` のときだけ、内部入力ルーチンで2nd ACIAと1st ACIAを多重化する。
+- 優先順位は2nd ACIAキーボード優先、1st ACIA UART fallbackとする。
+- 2nd ACIAと1st ACIAのステータスをポーリングし、2nd ACIAに受信文字があればそれを返す。
+- 2nd ACIAに文字がない場合は1st ACIAを確認し、どちらにも文字がない場合は待つ。
+- `MONITOR_FEATURE_KEYBOARD=0` では従来通り1st ACIAのみを待つ。
+
+## 実装方針
+
+- `src/acia6850.asm` に内部用の `CONSOLE_GETC` を追加する。
+- `READ_LINE` と `MIKBUG_INEEE_IMPL` は `ACIA_GETC` ではなく `CONSOLE_GETC` を呼ぶ。
+- `MIKBUG_INEEE_IMPL` の `LF` 読み飛ばしと echo は維持する。
+- `MON_OUTEEE` / `MIKBUG_OUTEEE_IMPL` など出力経路は変更しない。
+- ROM常駐 `KEYTEST` は復活させない。診断は引き続きSD上の `diagnostics/KEYTEST.S` を使う。
+
+## エミュレータ方針
+
+`--key-input` は2nd ACIA入力を固定するテスト補助であり、ROMの外部仕様ではない。
+ただし、key入力スクリプトが空になった場合にCPU実行を終了するとUART fallbackをテストできないため、2nd ACIA側だけはEOF後も「受信データなし」として扱う。
+1st ACIAの `--input` は従来通りEOFでエミュレータ終了に使う。
+
+## 検証方針
+
+- key入力だけで `H` / `MAP` などのROMモニタ操作ができること。
+- key入力とUART入力が同時にある場合、key入力が先に処理されること。
+- key入力が空または未指定でも、UART入力だけで従来通り操作できること。
+- key入力の `BS` / `DEL` / `CR` が `READ_LINE` でUART入力と同じように扱われること。
+- `INEEE` の公開契約や固定アドレスを変えないこと。
+
+## 対象外
+
+- 入力元切替コマンドや入力モード表示。
+- SBCからKKBD-USBへの制御、LED同期、複数キーボード対応。
+- SDFS/68のVDG+keyboard経由の完全操作確認。これは #170 で扱う。

--- a/emu/sbc6800_emu.py
+++ b/emu/sbc6800_emu.py
@@ -76,12 +76,12 @@ def _print_memory_dump(mem, start, end):
 class ACIA:
     """MC6850 ACIA の擬似実装（標準入出力をシリアル端末として扱う）"""
 
-    def __init__(self, input_data=None):
+    def __init__(self, input_data=None, exit_on_eof=None):
         self._input_buf = []
         self._input_data = input_data  # スクリプト入力用
         self._input_pos = 0
         self._interactive = input_data is None
-        self._exit_on_eof = input_data is not None
+        self._exit_on_eof = input_data is not None if exit_on_eof is None else exit_on_eof
         self._old_termios = None
         if self._interactive and sys.stdin.isatty() and not _IS_WINDOWS:
             self._old_termios = termios.tcgetattr(sys.stdin)
@@ -109,9 +109,11 @@ class ACIA:
                 ch = self._input_data[self._input_pos]
                 self._input_pos += 1
                 return ch
-            else:
+            elif self._exit_on_eof:
                 # 入力が尽きたら終了
                 raise SystemExit(0)
+            else:
+                return 0
         else:
             # 対話モード
             if _IS_WINDOWS:
@@ -1690,7 +1692,7 @@ def main():
             key_input_data = list(f.read())
 
     acia = ACIA(input_data=input_data)
-    acia2 = ACIA(input_data=key_input_data) if key_input_data is not None else None
+    acia2 = ACIA(input_data=key_input_data or [], exit_on_eof=False)
     sdcard = SDCard.from_file(args.sd) if args.sd else None
     pia = PIA(sdcard) if sdcard is not None else None
     cpu = MC6800(acia, acia2=acia2, pia=pia)

--- a/src/acia6850.asm
+++ b/src/acia6850.asm
@@ -38,6 +38,25 @@ ACIA_GETC:
         ldaa    ACIA_DATA
         rts
 
+CONSOLE_GETC:
+ if MONITOR_FEATURE_KEYBOARD
+CONSOLE_GETC_LOOP:
+        ldaa    ACIA2_CTRL
+        bita    #ACIA_STAT_RDRF
+        bne     CONSOLE_GETC_KEYBOARD
+        ldaa    ACIA_CTRL
+        bita    #ACIA_STAT_RDRF
+        beq     CONSOLE_GETC_LOOP
+        ldaa    ACIA_DATA
+        rts
+CONSOLE_GETC_KEYBOARD:
+        ldaa    ACIA2_DATA
+        rts
+ else
+        jsr     ACIA_GETC
+        rts
+ endif
+
 MIKBUG_OUTEEE_IMPL:
  if MONITOR_FEATURE_VDG
         psha
@@ -65,7 +84,7 @@ MON_OUTEEE_DONE:
 
 MIKBUG_INEEE_IMPL:
 MIKBUG_INEEE_LOOP:
-        jsr     ACIA_GETC
+        jsr     CONSOLE_GETC
         cmpa    #CHR_LF
         beq     MIKBUG_INEEE_LOOP
         jsr     MIKBUG_OUTEEE_IMPL

--- a/src/main.asm
+++ b/src/main.asm
@@ -1621,7 +1621,7 @@ READ_LINE:
         clr     LINE_LEN
 
 READ_LINE_LOOP:
-        jsr     ACIA_GETC
+        jsr     CONSOLE_GETC
         cmpa    #CHR_LF
         beq     READ_LINE_LOOP
         cmpa    #CHR_CR

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -428,6 +428,56 @@ def test_keytest_command():
     print("[PASS] test_keytest_command")
 
 
+def test_keyboard_console_accepts_key_input_only():
+    if not is_keyboard_build():
+        print("[PASS] test_keyboard_console_accepts_key_input_only")
+        return
+    stdout, stderr, rc = run_emu("\r", key_input="H\r", max_cycles=10_000_000)
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    assert "D M MAP RAMTEST G L" in stdout, f"keyboard input should run H command: {stdout!r}"
+    print("[PASS] test_keyboard_console_accepts_key_input_only")
+
+
+def test_keyboard_console_prefers_key_input_over_uart():
+    if not is_keyboard_build():
+        print("[PASS] test_keyboard_console_prefers_key_input_over_uart")
+        return
+    stdout, stderr, rc = run_emu("H\r\r", key_input="MAP\r", max_cycles=10_000_000)
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    if is_k6802_vdg_build():
+        map_pos = stdout.find("MAP K6802 VDG")
+    elif is_sbcio_build():
+        map_pos = stdout.find("MAP SBCIO")
+    else:
+        map_pos = stdout.find("MAP BASE")
+    help_pos = stdout.find("D M MAP RAMTEST G L")
+    assert map_pos >= 0, f"keyboard MAP command should run: {stdout!r}"
+    assert help_pos >= 0, f"UART H command should still run after key input: {stdout!r}"
+    assert map_pos < help_pos, f"keyboard input should be consumed before UART input: {stdout!r}"
+    print("[PASS] test_keyboard_console_prefers_key_input_over_uart")
+
+
+def test_keyboard_console_falls_back_to_uart_when_key_empty():
+    if not is_keyboard_build():
+        print("[PASS] test_keyboard_console_falls_back_to_uart_when_key_empty")
+        return
+    stdout, stderr, rc = run_emu("H\r\r", key_input="", max_cycles=10_000_000)
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    assert "D M MAP RAMTEST G L" in stdout, f"UART input should work when key input is empty: {stdout!r}"
+    print("[PASS] test_keyboard_console_falls_back_to_uart_when_key_empty")
+
+
+def test_keyboard_console_line_editing_from_key_input():
+    if not is_keyboard_build():
+        print("[PASS] test_keyboard_console_line_editing_from_key_input")
+        return
+    stdout, stderr, rc = run_emu("\r", key_input="HX\b\r", max_cycles=10_000_000)
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    assert "D M MAP RAMTEST G L" in stdout, f"keyboard BS editing should leave H command: {stdout!r}"
+    assert "\b \b" in stdout, f"keyboard BS should emit visible erase sequence: {stdout!r}"
+    print("[PASS] test_keyboard_console_line_editing_from_key_input")
+
+
 def test_ramtest_command():
     input_text = (
         "RAMTEST\r"
@@ -679,6 +729,10 @@ def main():
         test_vdg_console_backspace_erases_character,
         test_vdg_console_scrolls_at_bottom,
         test_keytest_command,
+        test_keyboard_console_accepts_key_input_only,
+        test_keyboard_console_prefers_key_input_over_uart,
+        test_keyboard_console_falls_back_to_uart_when_key_empty,
+        test_keyboard_console_line_editing_from_key_input,
         test_ramtest_command,
         test_breakpoint_query,
         test_breakpoint_resume_and_clear,


### PR DESCRIPTION
## 対応Issue

Closes #169
Refs #165 #78

## 概要

- 内部用の統合入力ルーチン `CONSOLE_GETC` を追加し、`FEATURE_KEYBOARD=1` では 2nd ACIAキーボードを優先、入力がなければUARTへfallbackするようにしました。
- `READ_LINE` と `MIKBUG_INEEE_IMPL` を統合入力経由に変更し、外部から見える `INEEE` / `INCH` の契約は単一コンソール入力のまま維持しました。
- エミュレータでは2nd ACIAを常に空入力デバイスとして用意し、`--key-input` 未指定または空でもUART fallbackが働くようにしました。
- キーボード入力のみ、キーボード優先、空キーボード時のUART fallback、BS編集のsmoke testを追加しました。
- `docs/plans/issue-169_keyboard_console_input.md` に、2nd ACIA優先、UART fallback、外部には単一 `INEEE` として見せる判断を記録しました。

## 影響範囲

- `FEATURE_KEYBOARD=1` profileの入力経路
- `MIKBUG_INEEE_IMPL` / `READ_LINE` の内部入力取得
- エミュレータの2nd ACIA入力モデル

既存コマンド、`INEEE` / `INCH` の公開契約、固定アドレス、出力経路は変更していません。`KEYTEST` はROM常駐に戻していません。

## 確認内容

- `make bin` → `build/mc6800-monitor.bin: 8075/8192 bytes`
- `MONITOR_PROFILE=sbcio make bin` → `build/mc6800-monitor-sbcio.bin: 8075/8192 bytes`
- `MONITOR_PROFILE=sbcio_vdg make bin` → `build/mc6800-monitor-sbcio-vdg.bin: 8075/8192 bytes`
- `MONITOR_PROFILE=k6802_vdg make bin` → `build/mc6800-monitor-k6802-vdg.bin: 8075/8192 bytes`
- `REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py` → 33 passed
- `MONITOR_PROFILE=sbcio REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py` → 33 passed
- `MONITOR_PROFILE=sbcio_vdg REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py` → 33 passed
- `MONITOR_PROFILE=k6802_vdg REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py` → 33 passed
- `MONITOR_PROFILE=sbcio REQUIRE_BUILD_ROM=1 python3 tests/test_sd_fixture.py` → 10 passed
- `MONITOR_PROFILE=sbcio_vdg REQUIRE_BUILD_ROM=1 python3 tests/test_sd_fixture.py` → 15 passed
- `MONITOR_PROFILE=k6802_vdg REQUIRE_BUILD_ROM=1 python3 tests/test_sd_fixture.py` → 15 passed

## 未対応

- KKBD-USB実機確認は未実施です。
- SDFS/68の完全なVDG+keyboard操作確認は #170 で扱います。