### PR TITLE
feat: SDFS/68ツールサンプル生成を追加する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,21 @@ SDFS_TARGET := SDFS$(TARGET_SUFFIX)
 SDFS_OBJ := $(OUTDIR)/$(SDFS_TARGET).p
 SDFS_LST := $(OUTDIR)/$(SDFS_TARGET).lst
 SDFS_BIN := $(OUTDIR)/$(SDFS_TARGET).BIN
+SDFS_TOOLS_DIR := sdfs_tools
+SDFS_TOOL_HELLO_S_SRC := $(SDFS_TOOLS_DIR)/HELLO_S.ASM
+SDFS_TOOL_HELLO_COM_SRC := $(SDFS_TOOLS_DIR)/HELLO_COM.ASM
+SDFS_TOOL_ARGS_COM_SRC := $(SDFS_TOOLS_DIR)/ARGS_COM.ASM
+SDFS_TOOL_HELLO_S_OBJ := $(OUTDIR)/HELLO_S.p
+SDFS_TOOL_HELLO_S_LST := $(OUTDIR)/HELLO_S.lst
+SDFS_TOOL_HELLO_S := $(OUTDIR)/HELLO.S
+SDFS_TOOL_HELLO_COM_OBJ := $(OUTDIR)/HELLO_COM.p
+SDFS_TOOL_HELLO_COM_LST := $(OUTDIR)/HELLO_COM.lst
+SDFS_TOOL_HELLO_COM := $(OUTDIR)/HELLO.COM
+SDFS_TOOL_ARGS_COM_OBJ := $(OUTDIR)/ARGS_COM.p
+SDFS_TOOL_ARGS_COM_LST := $(OUTDIR)/ARGS_COM.lst
+SDFS_TOOL_ARGS_COM := $(OUTDIR)/ARGS.COM
+SDFS_TOOL_SREC := $(SDFS_TOOL_HELLO_S)
+SDFS_TOOL_COM := $(SDFS_TOOL_HELLO_COM) $(SDFS_TOOL_ARGS_COM)
 CONFIG_INC := $(OUTDIR)/monitor_config.inc
 ROM_KIND ?= 27C64
 ROM_FILL ?= 0xFF
@@ -216,7 +231,7 @@ endif
 
 ASL_INCLUDE := $(CURDIR)/$(OUTDIR)$(ASL_PATHSEP)$(CURDIR)/include$(ASL_PATHSEP)$(CURDIR)/src
 
-.PHONY: all clean bin check-rom-size srec ihex stage1 sdfs check-stage1-profile rombin rombin-27c64 rombin-27c128 rombin-27c256 rombin-28c256 rombin-w27c512 program verify readback program-27c64 program-27c128 program-27c256 program-28c256 program-w27c512 program-upd28c256 FORCE
+.PHONY: all clean bin check-rom-size srec ihex stage1 sdfs sdfs-tools sdfs-tools-srec sdfs-tools-com check-stage1-profile rombin rombin-27c64 rombin-27c128 rombin-27c256 rombin-28c256 rombin-w27c512 program verify readback program-27c64 program-27c128 program-27c256 program-28c256 program-w27c512 program-upd28c256 FORCE
 
 all: check-rom-size srec ihex
 
@@ -255,6 +270,30 @@ $(SDFS_OBJ): FORCE $(SDFS_TOPSRC) include/hardware.inc $(CONFIG_INC) | $(OUTDIR)
 
 $(SDFS_BIN): $(SDFS_OBJ)
 	"$(P2BIN)" $(SDFS_OBJ) $(SDFS_BIN) -q
+
+sdfs-tools: sdfs-tools-srec sdfs-tools-com
+
+sdfs-tools-srec: $(SDFS_TOOL_SREC)
+
+sdfs-tools-com: $(SDFS_TOOL_COM)
+
+$(SDFS_TOOL_HELLO_S_OBJ): $(SDFS_TOOL_HELLO_S_SRC) | $(OUTDIR)
+	"$(ASL)" -q -L -olist $(SDFS_TOOL_HELLO_S_LST) -o $(SDFS_TOOL_HELLO_S_OBJ) $(SDFS_TOOL_HELLO_S_SRC)
+
+$(SDFS_TOOL_HELLO_S): $(SDFS_TOOL_HELLO_S_OBJ)
+	"$(P2HEX)" $(SDFS_TOOL_HELLO_S_OBJ) $(SDFS_TOOL_HELLO_S) -q -F Moto -M 2
+
+$(SDFS_TOOL_HELLO_COM_OBJ): $(SDFS_TOOL_HELLO_COM_SRC) | $(OUTDIR)
+	"$(ASL)" -q -L -olist $(SDFS_TOOL_HELLO_COM_LST) -o $(SDFS_TOOL_HELLO_COM_OBJ) $(SDFS_TOOL_HELLO_COM_SRC)
+
+$(SDFS_TOOL_HELLO_COM): $(SDFS_TOOL_HELLO_COM_OBJ)
+	"$(P2BIN)" $(SDFS_TOOL_HELLO_COM_OBJ) $(SDFS_TOOL_HELLO_COM) -q
+
+$(SDFS_TOOL_ARGS_COM_OBJ): $(SDFS_TOOL_ARGS_COM_SRC) | $(OUTDIR)
+	"$(ASL)" -q -L -olist $(SDFS_TOOL_ARGS_COM_LST) -o $(SDFS_TOOL_ARGS_COM_OBJ) $(SDFS_TOOL_ARGS_COM_SRC)
+
+$(SDFS_TOOL_ARGS_COM): $(SDFS_TOOL_ARGS_COM_OBJ)
+	"$(P2BIN)" $(SDFS_TOOL_ARGS_COM_OBJ) $(SDFS_TOOL_ARGS_COM) -q
 
 srec: $(SREC)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,6 +64,7 @@ ROM常駐FATを確認したい場合は、profileではなく直接構成軸で 
 - [plans/issue-177_sbcio_profile_cleanup.md](plans/issue-177_sbcio_profile_cleanup.md): sbcio profileのSD/FAT整理
 - [plans/issue-144_rom_sdfs_docs_boundary.md](plans/issue-144_rom_sdfs_docs_boundary.md): ROMモニタとSDFS/68責務境界のユーザー向け文書整理
 - [../diagnostics/README.md](../diagnostics/README.md): SDからロードして使う診断用S-Record
+- [../sdfs_tools/README.md](../sdfs_tools/README.md): SDFS/68向け S-Record / `.COM` ツールサンプル
 - [testing/sbc6800_bringup.md](testing/sbc6800_bringup.md)
 - [testing/sbc_io_sd_bringup.md](testing/sbc_io_sd_bringup.md): SBC-IO と microSD SPI モジュールで SD/FAT を実機確認する手順
 - [testing/sbc6800_datapack.md](testing/sbc6800_datapack.md): SBC6800 データパックの扱いと互換確認

--- a/sdfs_tools/ARGS_COM.ASM
+++ b/sdfs_tools/ARGS_COM.ASM
@@ -1,0 +1,38 @@
+        CPU     6800
+; SDFS/68 .COM argument sample.
+; Entry ABI: X=argument tail pointer, B=argument tail length, A=0.
+;
+OUTCH   EQU     $E075
+
+        ORG     $0100
+START   STX     ARG_PTR
+        STAB    ARG_LEN
+        LDX     #MSG
+        JSR     PDATA
+        LDAB    ARG_LEN
+        BEQ     DONE
+        LDX     ARG_PTR
+ARGLOOP LDAA    0,X
+        JSR     OUTCH
+        INX
+        DECB
+        BNE     ARGLOOP
+DONE    LDAA    #$0D
+        JSR     OUTCH
+        LDAA    #$0A
+        JSR     OUTCH
+        RTS
+
+PDATA   LDAA    0,X
+        BEQ     PEND
+        JSR     OUTCH
+        INX
+        BRA     PDATA
+PEND    RTS
+
+ARG_PTR FDB     0
+ARG_LEN FCB     0
+MSG     FCB     $0D,$0A
+        FCC     'ARGS '
+        FCB     0
+        END     START

--- a/sdfs_tools/HELLO_COM.ASM
+++ b/sdfs_tools/HELLO_COM.ASM
@@ -1,0 +1,22 @@
+        CPU     6800
+; SDFS/68 .COM sample.
+; Load address and entry are both $0100. RTS returns to SDFS/68.
+;
+OUTCH   EQU     $E075
+
+        ORG     $0100
+START   LDX     #MSG
+        JSR     PDATA
+        RTS
+
+PDATA   LDAA    0,X
+        BEQ     PEND
+        JSR     OUTCH
+        INX
+        BRA     PDATA
+PEND    RTS
+
+MSG     FCB     $0D,$0A
+        FCC     'HELLO COM'
+        FCB     $0D,$0A,0
+        END     START

--- a/sdfs_tools/HELLO_S.ASM
+++ b/sdfs_tools/HELLO_S.ASM
@@ -1,0 +1,22 @@
+        CPU     6800
+; SDFS/68 S-Record sample.
+; Load with RUN HELLO.S. SWI returns to the ROM monitor.
+;
+OUTCH   EQU     $E075
+
+        ORG     $0200
+START   LDX     #MSG
+        JSR     PDATA
+        SWI
+
+PDATA   LDAA    0,X
+        BEQ     PEND
+        JSR     OUTCH
+        INX
+        BRA     PDATA
+PEND    RTS
+
+MSG     FCB     $0D,$0A
+        FCC     'HELLO SREC'
+        FCB     $0D,$0A,0
+        END     START

--- a/sdfs_tools/README.md
+++ b/sdfs_tools/README.md
@@ -1,0 +1,44 @@
+# SDFS/68 ツールサンプル
+
+このディレクトリには、SDFS/68 から実行する小さなツールのサンプルを置く。
+目的は、従来の S-Record 実行と `.COM` トランジェントコマンド実行の作り分けを Makefile 上で確認できるようにすることである。
+
+## 生成ターゲット
+
+```sh
+make sdfs-tools-srec
+make sdfs-tools-com
+make sdfs-tools
+```
+
+生成物は `build/` に出力する。
+
+| 生成物 | 入力ソース | 用途 |
+| --- | --- | --- |
+| `build/HELLO.S` | `HELLO_S.ASM` | 従来の `RUN HELLO.S` 確認用S-Record |
+| `build/HELLO.COM` | `HELLO_COM.ASM` | `.COM` トランジェントコマンドの最小確認 |
+| `build/ARGS.COM` | `ARGS_COM.ASM` | `.COM` 引数ABIの確認 |
+
+## 形式差分
+
+S-Record サンプルは現行 SDFS/68 の `RUN filename` 用である。
+`ORG $0200` で配置し、終了は `SWI` で ROM モニタへ落ちる。
+
+`.COM` サンプルは SDFS/68 のトランジェントコマンド用である。
+`ORG $0100` で配置し、終了は `RTS` で SDFS/68 へ戻る。
+引数付き `.COM` では、SDFS/68 が `X=引数テール先頭`, `B=引数テール長`, `A=0` で起動する前提にする。
+
+## 実行例
+
+現行の SDFS/68 では、S-Record は次のように実行する。
+
+```text
+SDFS> RUN HELLO.S
+```
+
+`.COM` は #192 の実装後に次のように実行する想定である。
+
+```text
+SDFS> HELLO.COM
+SDFS> ARGS.COM AAA BBB
+```


### PR DESCRIPTION
## 概要
- SDFS/68向けツールサンプル置き場 `sdfs_tools/` を追加
- `HELLO.S` 用のS-Recordサンプルと、`HELLO.COM` / `ARGS.COM` 用のCOMサンプルを追加
- Makefileに `sdfs-tools-srec`、`sdfs-tools-com`、`sdfs-tools` ターゲットを追加
- docs目次から `sdfs_tools/README.md` へリンク

## 確認内容
- `make sdfs-tools-srec`
- `make sdfs-tools-com`
- `make -B sdfs-tools`
- `make sdfs MONITOR_PROFILE=sbcio_vdg`
- `wc -c build/HELLO.S build/HELLO.COM build/ARGS.COM`
- `build/HELLO.S` が `$0200` 起点のS-Recordであることを先頭レコードで確認
- `build/HELLO.COM` が raw binary 32 byteであることを確認

## レビュー
- 批判的レビューで、既存ターゲットとの衝突なし、S-Record / `.COM` の `ORG` と終了規約の分離は意図どおりと確認
- 残リスク: `.COM` 実行時ABIとの最終噛み合わせは #192 の実装時に確認する

## 影響範囲
- Makefileの追加ターゲット
- SDFS/68向けサンプルソースとREADME
- SDFS/68本体コードの変更なし

## 未対応事項
- SDFS/68本体で `.COM` を実行する処理は #192 で対応
- `FOO` から `FOO.COM` を補完探索する機能は対象外

Closes #194
Refs #192 #190 #191 #157