### PR TITLE
feat: SDFS/68で.COMトランジェントコマンドを実行する

### DIFF
--- a/docs/plans/issue-192_sdfs68_com_runner.md
+++ b/docs/plans/issue-192_sdfs68_com_runner.md
@@ -1,0 +1,36 @@
+# Issue #192 SDFS/68 .COMトランジェントコマンド実装メモ
+
+## 対象
+
+- Issue: #192
+- 親Issue: #190
+- 設計: [SDFS/68 .COM トランジェントコマンドABI](../design/sdfs68_com_abi.md)
+
+## 実装判断
+
+- `FOO.COM` のように拡張子 `.COM` まで明示された入力だけを外部コマンド候補にする。
+- `FOO` から `FOO.COM` を補完探索する処理は、設計どおり後続Issueへ残す。
+- `.COM` は raw binary として `$0100` へ固定ロードし、`JSR $0100` 相当で起動する。
+- `.COM` 側は `RTS` で SDFS/68 へ戻る。`RUN addr` と `RUN filename` は従来どおり `JMP` 実行のまま変更しない。
+- 引数テールは `X` に先頭ポインタ、`B` に長さ、`A=0` で渡す。引数文字列は `LINE_BUF` 上の一時データとして扱う。
+- `$0100` から `USER_RAM_END` までに収まらない `.COM` と、0 byte の `.COM` は `?` で拒否する。
+
+## コマンド解釈
+
+内蔵コマンドを優先しつつ、未定義コマンド経路で `.COM` 候補を判定する。
+ただし `DUMP.COM`、`READ.COM`、`LIST.COM`、`LOAD.COM` のように先頭文字や `LOAD` prefix が内蔵コマンド判定に入る名前でも、内蔵コマンドとして成立しなければ `.COM` として再判定する。
+
+## 検証
+
+- `python3 tests/test_sdfs68_build.py`
+  - `21 passed, 0 failed`
+- `build/SDFS-sbcio-vdg.BIN`: 3115 byte
+- `build/SDFS-k6802-vdg.BIN`: 3115 byte
+
+テストでは、通常の `.COM` 実行、引数渡し、内蔵コマンド名との衝突、ネストした `JSR` / `RTS` を使う `.COM`、存在しない `.COM`、0 byte `.COM`、サイズ超過 `.COM`、`.COM` ではない未定義入力を確認した。
+
+## 残課題
+
+- `FOO` から `FOO.COM` を探す本格トランジェントコマンド探索。
+- `.COM` から呼び出す SDFS/68 API の整理。
+- path 対応後の `.COM` 探索範囲の再設計。

--- a/docs/usage/sdfs68_system_sd.md
+++ b/docs/usage/sdfs68_system_sd.md
@@ -154,6 +154,7 @@ SDFS.BIN headerのversion byteはstage1が読むバイナリ形式versionであ�
 | `RUN addr` | 実装済み。16bit hexadecimal address へジャンプする |
 | `LOAD filename` | 実装済み。ファイルをロードする。自動実行しない |
 | `L filename` | 実装済み。`LOAD filename` の短縮エイリアス |
+| `FOO.COM [args]` | 実装済み。`.COM` トランジェントコマンドをロードして実行する |
 | `Dhhhh` | 実装済み。16bit hexadecimal address の1 byteを表示する |
 | `EXIT` | 実装済み。ROMモニタへ戻る |
 
@@ -197,8 +198,10 @@ Intel HEXを実行したい場合は、`LOAD filename` でロードしてから 
 `RUN addr` は指定アドレスへ直接ジャンプする。プログラム終了後にSDFS/68へ戻る保証はない。
 ROMモニタの `G addr` 相当の実行入口として扱う。
 
-`.COM` トランジェントコマンドは V1.3 以降の候補であり、`RUN` とは別の復帰前提ABIとして設計する。
-初期案では `FOO.COM` 明示指定、`$0100` 固定ロード、`JSR $0100` / `RTS` 復帰、`X` / `B` による引数渡しを採用する。
+`.COM` トランジェントコマンドは `RUN` とは別の復帰前提ABIである。
+`FOO.COM` のように拡張子まで明示して入力すると、SDFS/68 は raw binary を `$0100` へ固定ロードし、`JSR $0100` 相当で起動する。
+`.COM` 側は `RTS` で SDFS/68 へ戻る。
+`FOO.COM AAA BBB` のように引数を付けた場合、SDFS/68 は `X` / `B` で引数テールを渡す。
 詳細は [SDFS/68 .COM トランジェントコマンドABI](../design/sdfs68_com_abi.md) を参照する。
 
 メモリ変更、ブレークポイント、逆アセンブルなどの低レベルデバッグはSDFS/68に取り込まず、`EXIT` でROMモニタへ戻って行う。

--- a/src/sdfs68.asm
+++ b/src/sdfs68.asm
@@ -6,6 +6,10 @@ SDFS_FORMAT_VERSION equ 1
 SDFS_HDR_SIZE   equ 16
 SDFS_S1_VERSION equ 1
 SDFS_S1_COUNT   equ 6
+SDFS_COM_LOAD_BASE equ $0100
+SDFS_COM_MAX_SIZE equ USER_RAM_END-SDFS_COM_LOAD_BASE+1
+SDFS_COM_MAX_HI equ SDFS_COM_MAX_SIZE/256
+SDFS_COM_MAX_LO equ SDFS_COM_MAX_SIZE-SDFS_COM_MAX_HI*256
 
         if S1_SUPPORTED = 0
         error   "SDFS/68 is not supported for this memory configuration"
@@ -46,10 +50,17 @@ SDFS_LOOP:
         bcc     SDFS_DO_LOAD_LONG
         jsr     SDFS_CMD_IS_LOAD_LONG_PREFIX
         bcc     SDFS_COMMAND_ERROR
+        jsr     SDFS_CMD_COM
+        bcs     SDFS_TRY_LOAD_ALIAS
+        bra     SDFS_PROMPT_NEXT
+SDFS_TRY_LOAD_ALIAS:
         jsr     SDFS_CMD_LOAD_ALIAS
         bra     SDFS_LOAD_RESULT
 SDFS_DO_LOAD_LONG:
         jsr     SDFS_CMD_LOAD_LONG
+        bcc     SDFS_LOAD_RESULT
+        jsr     SDFS_CMD_COM
+        bcc     SDFS_PROMPT_NEXT
 SDFS_LOAD_RESULT:
         bcc     SDFS_LOAD_OK
         jsr     SDFS_SHOW_LOADER_ERROR
@@ -70,8 +81,7 @@ SDFS_CHECK_DUMP:
 SDFS_CHECK_DUMP_BYTE:
         jsr     SDFS_CMD_DUMP_BYTE
         bcc     SDFS_PROMPT_NEXT
-        jsr     SDFS_SHOW_ERROR
-        bra     SDFS_PROMPT_NEXT
+        bra     SDFS_COMMAND_ERROR
 SDFS_CHECK_EXIT:
         cmpa    #'E'
         bne     SDFS_CHECK_RUN
@@ -83,12 +93,13 @@ SDFS_CHECK_RUN:
         bne     SDFS_COMMAND_ERROR
         jsr     SDFS_CMD_RUN
         bcc     SDFS_PROMPT_NEXT
-        jsr     SDFS_SHOW_ERROR
-        bra     SDFS_PROMPT_NEXT
+        bra     SDFS_COMMAND_ERROR
 SDFS_PROMPT_NEXT:
         jsr     SDFS_PRINT_PROMPT
         bra     SDFS_LOOP
 SDFS_COMMAND_ERROR:
+        jsr     SDFS_CMD_COM
+        bcc     SDFS_PROMPT_NEXT
         jsr     SDFS_SHOW_ERROR
         bra     SDFS_PROMPT_NEXT
 
@@ -281,6 +292,73 @@ SDFS_CMD_RUN_FILE:
         ldx     SDFS_RUN_ENTRY
         jmp     0,x
 SDFS_CMD_RUN_FAIL:
+        sec
+        rts
+
+SDFS_CMD_COM:
+        ldab    LINE_LEN
+        ldx     #LINE_BUF
+        jsr     SDFS_PARSE_COM_COMMAND
+        bcs     SDFS_CMD_COM_FAIL
+        jsr     SDFS_API_MOUNT
+        bcs     SDFS_CMD_COM_FAIL
+        ldx     #FAT_FIND_NAME0
+        jsr     SDFS_API_FIND_83
+        bcs     SDFS_CMD_COM_FAIL
+        jsr     SDFS_COM_CHECK_SIZE
+        bcs     SDFS_CMD_COM_FAIL
+        jsr     SDFS_STREAM_OPEN
+        bcs     SDFS_CMD_COM_FAIL
+        jsr     SDFS_COM_LOAD_RAW
+        bcs     SDFS_CMD_COM_FAIL
+        lds     #STACK_TOP
+        ldx     ARG2_PTR
+        ldab    ARG2_LEN
+        clra
+        jsr     SDFS_COM_LOAD_BASE
+        jmp     SDFS_PROMPT_NEXT
+SDFS_CMD_COM_FAIL:
+        sec
+        rts
+
+SDFS_COM_CHECK_SIZE:
+        ldaa    FAT_FILE_SIZE0
+        oraa    FAT_FILE_SIZE1
+        bne     SDFS_COM_CHECK_FAIL
+        ldaa    FAT_FILE_SIZE2
+        oraa    FAT_FILE_SIZE3
+        beq     SDFS_COM_CHECK_FAIL
+        ldaa    FAT_FILE_SIZE2
+        cmpa    #SDFS_COM_MAX_HI
+        bhi     SDFS_COM_CHECK_FAIL
+        blo     SDFS_COM_CHECK_OK
+        ldaa    FAT_FILE_SIZE3
+        cmpa    #SDFS_COM_MAX_LO
+        bhi     SDFS_COM_CHECK_FAIL
+SDFS_COM_CHECK_OK:
+        clc
+        rts
+SDFS_COM_CHECK_FAIL:
+        sec
+        rts
+
+SDFS_COM_LOAD_RAW:
+        ldx     #SDFS_COM_LOAD_BASE
+        stx     FAT_READ_PTR
+SDFS_COM_LOAD_LOOP:
+        jsr     SDFS_BYTES_REMAIN
+        bcc     SDFS_COM_LOAD_DONE
+        jsr     SDFS_STREAM_GETC
+        bcs     SDFS_COM_LOAD_FAIL
+        ldx     FAT_READ_PTR
+        staa    0,x
+        inx
+        stx     FAT_READ_PTR
+        bra     SDFS_COM_LOAD_LOOP
+SDFS_COM_LOAD_DONE:
+        clc
+        rts
+SDFS_COM_LOAD_FAIL:
         sec
         rts
 
@@ -692,6 +770,141 @@ SDFS_PARSE_FILENAME_OK:
         clc
         rts
 SDFS_PARSE_FILENAME_FAIL:
+        sec
+        rts
+
+SDFS_PARSE_COM_COMMAND:
+        stx     ARG_PTR
+        stab    ARG_LEN
+        jsr     SDFS_CLEAR_FIND_NAME
+SDFS_PARSE_COM_SKIP_HEAD:
+        tst     ARG_LEN
+        bne     SDFS_PARSE_COM_SKIP_HAS
+        jmp     SDFS_PARSE_COM_FAIL
+SDFS_PARSE_COM_SKIP_HAS:
+        ldx     ARG_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        bne     SDFS_PARSE_COM_NAME_START
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        bra     SDFS_PARSE_COM_SKIP_HEAD
+
+SDFS_PARSE_COM_NAME_START:
+        ldx     #FAT_FIND_NAME0
+        stx     FAT_ENTRY_PTR
+        clr     ARG2_LEN
+SDFS_PARSE_COM_NAME_LOOP:
+        tst     ARG_LEN
+        bne     SDFS_PARSE_COM_NAME_HAS_LEN
+        jmp     SDFS_PARSE_COM_FAIL
+SDFS_PARSE_COM_NAME_HAS_LEN:
+        ldx     ARG_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        bne     SDFS_PARSE_COM_NAME_NOT_SPACE
+        jmp     SDFS_PARSE_COM_FAIL
+SDFS_PARSE_COM_NAME_NOT_SPACE:
+        cmpa    #'.'
+        beq     SDFS_PARSE_COM_EXT_START
+        ldab    ARG2_LEN
+        cmpb    #8
+        blo     SDFS_PARSE_COM_NAME_ROOM
+        jmp     SDFS_PARSE_COM_FAIL
+SDFS_PARSE_COM_NAME_ROOM:
+        jsr     SDFS_TO_UPPER
+        ldx     FAT_ENTRY_PTR
+        staa    0,x
+        inx
+        stx     FAT_ENTRY_PTR
+        inc     ARG2_LEN
+        ldx     ARG_PTR
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        bra     SDFS_PARSE_COM_NAME_LOOP
+
+SDFS_PARSE_COM_EXT_START:
+        tst     ARG2_LEN
+        bne     SDFS_PARSE_COM_EXT_NAME_OK
+        jmp     SDFS_PARSE_COM_FAIL
+SDFS_PARSE_COM_EXT_NAME_OK:
+        ldx     ARG_PTR
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        ldx     #FAT_FIND_NAME8
+        stx     FAT_ENTRY_PTR
+        clr     ARG2_LEN
+SDFS_PARSE_COM_EXT_LOOP:
+        tst     ARG_LEN
+        beq     SDFS_PARSE_COM_TOKEN_DONE
+        ldx     ARG_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        beq     SDFS_PARSE_COM_TOKEN_DONE
+        cmpa    #'.'
+        beq     SDFS_PARSE_COM_FAIL
+        ldab    ARG2_LEN
+        cmpb    #3
+        bhs     SDFS_PARSE_COM_FAIL
+        jsr     SDFS_TO_UPPER
+        ldx     FAT_ENTRY_PTR
+        staa    0,x
+        inx
+        stx     FAT_ENTRY_PTR
+        inc     ARG2_LEN
+        ldx     ARG_PTR
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        bra     SDFS_PARSE_COM_EXT_LOOP
+
+SDFS_PARSE_COM_TOKEN_DONE:
+        jsr     SDFS_PARSE_COM_CHECK_EXT
+        bcs     SDFS_PARSE_COM_FAIL
+SDFS_PARSE_COM_ARG_SKIP:
+        tst     ARG_LEN
+        beq     SDFS_PARSE_COM_NO_ARGS
+        ldx     ARG_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        bne     SDFS_PARSE_COM_ARGS_DONE
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        bra     SDFS_PARSE_COM_ARG_SKIP
+SDFS_PARSE_COM_ARGS_DONE:
+        ldx     ARG_PTR
+        stx     ARG2_PTR
+        ldaa    ARG_LEN
+        staa    ARG2_LEN
+        clc
+        rts
+SDFS_PARSE_COM_NO_ARGS:
+        ldx     ARG_PTR
+        stx     ARG2_PTR
+        clr     ARG2_LEN
+        clc
+        rts
+
+SDFS_PARSE_COM_CHECK_EXT:
+        ldaa    FAT_FIND_NAME8
+        cmpa    #'C'
+        bne     SDFS_PARSE_COM_CHECK_FAIL
+        ldaa    FAT_FIND_NAME9
+        cmpa    #'O'
+        bne     SDFS_PARSE_COM_CHECK_FAIL
+        ldaa    FAT_FIND_NAME10
+        cmpa    #'M'
+        bne     SDFS_PARSE_COM_CHECK_FAIL
+        clc
+        rts
+SDFS_PARSE_COM_CHECK_FAIL:
+        sec
+        rts
+SDFS_PARSE_COM_FAIL:
         sec
         rts
 

--- a/tests/test_sdfs68_build.py
+++ b/tests/test_sdfs68_build.py
@@ -486,6 +486,96 @@ def test_sdfs_run_file_requires_srec_entry() -> None:
     print("[PASS] test_sdfs_run_file_requires_srec_entry")
 
 
+def test_sdfs_com_runs_transient_commands_and_arguments() -> None:
+    for profile, expected in EXPECTED.items():
+        _run_make(profile, "bin")
+        _run_make(profile, "stage1")
+        _run_make(profile, "sdfs")
+        _run_make(profile, "sdfs-tools")
+        suffix = expected["suffix"]
+        stage1 = (PROJECT_ROOT / "build" / f"stage1{suffix}.bin").read_bytes()
+        sdfs = (PROJECT_ROOT / "build" / f"SDFS{suffix}.BIN").read_bytes()
+        hello_com = (PROJECT_ROOT / "build" / "HELLO.COM").read_bytes()
+        args_com = (PROJECT_ROOT / "build" / "ARGS.COM").read_bytes()
+        stack_com = bytes.fromhex("BD010439BD01083939")
+        image = build_sdfs_image(
+            stage1_data=stage1,
+            sdfs_data=sdfs,
+            extra_files=[
+                _file("HELLO.COM", hello_com),
+                _file("DUMP.COM", hello_com),
+                _file("LIST.COM", hello_com),
+                _file("EDIT.COM", hello_com),
+                _file("READ.COM", hello_com),
+                _file("LOAD.COM", hello_com),
+                _file("STACK.COM", stack_com),
+                _file("ARGS.COM", args_com),
+            ],
+        )
+        stdout, stderr, rc = _run_emu_with_sd(
+            rom_path=PROJECT_ROOT / "build" / f"mc6800-monitor{suffix}.bin",
+            input_text=(
+                "BOOT\r"
+                "HELLO.COM\r"
+                "DUMP.COM\r"
+                "LIST.COM\r"
+                "EDIT.COM\r"
+                "READ.COM\r"
+                "LOAD.COM\r"
+                "STACK.COM\r"
+                "ARGS.COM AAA BBB\r"
+                "DIR\r"
+                "X"
+            ),
+            sd_image=image,
+            max_cycles=260_000_000,
+        )
+        assert rc == 0 and "[TIMEOUT]" not in stderr, (
+            f"emulator failed for {profile}: rc={rc} stderr={stderr!r}"
+        )
+        assert stdout.count("HELLO COM") >= 6, (
+            f".COM transient commands did not all execute for {profile}: {stdout!r}"
+        )
+        assert "ARGS AAA BBB" in stdout, f".COM arguments were not passed for {profile}: {stdout!r}"
+        assert "HELLO.COM A " in stdout, f"DIR did not run after .COM return for {profile}: {stdout!r}"
+        assert stdout.count("SDFS> ") >= 10, f".COM did not return to prompt for {profile}: {stdout!r}"
+    print("[PASS] test_sdfs_com_runs_transient_commands_and_arguments")
+
+
+def test_sdfs_com_rejects_bad_transient_commands() -> None:
+    profile = "sbcio_vdg"
+    _run_make(profile, "bin")
+    _run_make(profile, "stage1")
+    _run_make(profile, "sdfs")
+    _run_make(profile, "sdfs-tools")
+    suffix = EXPECTED[profile]["suffix"]
+    stage1 = (PROJECT_ROOT / "build" / f"stage1{suffix}.bin").read_bytes()
+    sdfs = (PROJECT_ROOT / "build" / f"SDFS{suffix}.BIN").read_bytes()
+    hello_com = (PROJECT_ROOT / "build" / "HELLO.COM").read_bytes()
+    image = build_sdfs_image(
+        stage1_data=stage1,
+        sdfs_data=sdfs,
+        extra_files=[
+            _file("HELLO.COM", hello_com),
+            _file("HELLO.S", _srec_file(0x0200, b"S")),
+            _file("EMPTY.COM", b""),
+            _file("BIG.COM", b"\x39" * 0x7F01),
+        ],
+    )
+    stdout, stderr, rc = _run_emu_with_sd(
+        rom_path=PROJECT_ROOT / "build" / "mc6800-monitor-sbcio-vdg.bin",
+        input_text="BOOT\rNOFILE.COM\rEMPTY.COM\rBIG.COM\rHELLO\rHELLO.S\rDIR\rX",
+        sd_image=image,
+        max_cycles=220_000_000,
+    )
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    assert stdout.count("?") >= 5, f"bad .COM commands were not rejected: {stdout!r}"
+    assert "HELLO COM" not in stdout, f"bad .COM command unexpectedly executed: {stdout!r}"
+    assert "SDFS.BIN A " in stdout, f"prompt did not recover after bad .COM commands: {stdout!r}"
+    assert stdout.count("SDFS> ") >= 7, f"prompt did not recover after bad .COM commands: {stdout!r}"
+    print("[PASS] test_sdfs_com_rejects_bad_transient_commands")
+
+
 def test_sdfs_line_editing_backspace_delete_and_lowercase() -> None:
     profile = "sbcio_vdg"
     _run_make(profile, "bin")
@@ -855,6 +945,8 @@ def main() -> None:
         test_sdfs_run_addr_rejects_bad_arguments,
         test_sdfs_run_srec_file_executes_entry_address,
         test_sdfs_run_file_requires_srec_entry,
+        test_sdfs_com_runs_transient_commands_and_arguments,
+        test_sdfs_com_rejects_bad_transient_commands,
         test_sdfs_line_editing_backspace_delete_and_lowercase,
         test_sdfs_line_input_ignores_overlong_command,
         test_sdfs_loader_errors_return_to_prompt,


### PR DESCRIPTION
## 概要
- SDFS/68で `FOO.COM [args]` をSD上のトランジェントコマンドとしてロード・実行できるようにしました
- `.COM` raw binaryを `$0100` に固定ロードし、`X` / `B` / `A=0` のABIで `JSR $0100` します
- 引数渡し、内蔵コマンド名との衝突、異常系、ネストした `JSR` / `RTS` 復帰をテストに追加しました
- 利用ドキュメントとIssue #192の実装メモを更新しました

## 確認内容
- `python3 tests/test_sdfs68_build.py`
  - `21 passed, 0 failed`
- `build/SDFS-sbcio-vdg.BIN`: 3115 bytes
- `build/SDFS-k6802-vdg.BIN`: 3115 bytes
- `git diff --check`

Closes #192
Refs #190 #191 #194 #157