### PR TITLE
fix: VDGでSDFS実行後の余計な空行を抑止する

### DIFF
--- a/docs/plans/issue-182_vdg_sdfs_crlf.md
+++ b/docs/plans/issue-182_vdg_sdfs_crlf.md
@@ -1,0 +1,27 @@
+# Issue #182 VDG SDFS/68 CR/LF整理
+
+## 背景
+
+SDFS/68 は行入力に `MIKBUG_INCH` を使う。`MIKBUG_INCH` は入力文字を echo するため、Enter 入力時に `CR` が一度 VDG へ出る。
+その後、SDFS/68 の `SDFS_READ_LINE_DONE` でも行入力完了として `CR` を出し、`SDFS_PUTC` が `CR/LF` を補う。
+
+UART側では従来から許容されていたが、VDG console は `CR` を即改行として扱うため、`DIR` や `RUN` の直後に余計な空行が見える。
+
+## 採用方針
+
+- SDFS/68 の行編集ルーチンは変更しない。
+- UARTの出力仕様は変更しない。
+- VDG console 側で直前 `CR` 状態を見て、連続 `CR` を追加改行として扱わない。
+- `CR/LF` の `LF` 抑止、通常文字での `VDG_LAST_CR` リセット、BS/DELでの状態リセットは維持する。
+
+## 検証方針
+
+- `sbcio_vdg` の system SD 起動後に `DIR` を実行し、VRAM dump上で `SDFS> DIR` の直後行が空行にならないことを固定する。
+- 既存の VDG CR/LF、BS、scroll smoke test を維持する。
+- UART側のSDFS/68既存テストを維持する。
+
+## 対象外
+
+- #183 の 1st ACIA 未接続時スタンドアロン出力。
+- #179 の `DS` 短幅ダンプ。
+- SDFS/68 行編集仕様の作り直し。

--- a/src/main.asm
+++ b/src/main.asm
@@ -1286,6 +1286,8 @@ VDG_PUTC_LF_NEWLINE:
         jsr     VDG_NEWLINE
         bra     VDG_PUTC_DONE
 VDG_PUTC_CR:
+        tst     VDG_LAST_CR
+        bne     VDG_PUTC_DONE
         jsr     VDG_NEWLINE
         ldaa    #1
         staa    VDG_LAST_CR

--- a/tests/test_sdfs68_build.py
+++ b/tests/test_sdfs68_build.py
@@ -239,6 +239,43 @@ def test_sdfs_dir_lists_root_files_and_skips_non_files() -> None:
     print("[PASS] test_sdfs_dir_lists_root_files_and_skips_non_files")
 
 
+def test_sdfs_vdg_dir_does_not_insert_blank_line_after_command() -> None:
+    profile = "sbcio_vdg"
+    expected = EXPECTED[profile]
+    _run_make(profile, "bin")
+    _run_make(profile, "stage1")
+    _run_make(profile, "sdfs")
+    suffix = expected["suffix"]
+    stage1 = (PROJECT_ROOT / "build" / f"stage1{suffix}.bin").read_bytes()
+    sdfs = (PROJECT_ROOT / "build" / f"SDFS{suffix}.BIN").read_bytes()
+    image = build_sdfs_image(
+        stage1_data=stage1,
+        sdfs_data=sdfs,
+        extra_files=[_file("HELLO.S", _srec_file(0x0200, b"S"))],
+    )
+    stdout, stderr, rc = _run_emu_with_sd(
+        rom_path=PROJECT_ROOT / "build" / f"mc6800-monitor{suffix}.bin",
+        input_text="BOOT\rDIR\rX",
+        sd_image=image,
+        max_cycles=160_000_000,
+        extra_args=["--dump-memory", "A000-A1FF"],
+    )
+    assert rc == 0 and "[TIMEOUT]" not in stderr, (
+        f"emulator failed for {profile}: rc={rc} stderr={stderr!r}"
+    )
+    lines = _vdg_text_lines(stdout, start=0xA000, end=0xA1FF)
+    dir_line = next((idx for idx, line in enumerate(lines) if "SDFS> DIR" in line), -1)
+    assert dir_line >= 0, f"VDG DIR command line missing: {lines!r} stdout={stdout!r}"
+    assert dir_line + 1 < len(lines), f"VDG DIR command was on final line: {lines!r}"
+    assert lines[dir_line + 1].strip(), (
+        f"VDG inserted a blank line after DIR command: {lines!r} stdout={stdout!r}"
+    )
+    assert "SDFS.BIN" in "\n".join(lines[dir_line + 1:]), (
+        f"VDG DIR output did not follow command line: {lines!r} stdout={stdout!r}"
+    )
+    print("[PASS] test_sdfs_vdg_dir_does_not_insert_blank_line_after_command")
+
+
 def test_sdfs_dir_scans_root_chain() -> None:
     profile = "sbcio_vdg"
     _run_make(profile, "bin")
@@ -761,6 +798,7 @@ def _run_emu_with_sd(
     input_text: str,
     sd_image: bytes,
     max_cycles: int,
+    extra_args: list[str] | None = None,
 ) -> tuple[str, str, int]:
     with tempfile.NamedTemporaryFile(suffix=".img", delete=False) as sd_file:
         sd_file.write(sd_image)
@@ -770,7 +808,7 @@ def _run_emu_with_sd(
             rom_path=rom_path,
             input_text=input_text,
             max_cycles=max_cycles,
-            extra_args=["--sd", str(sd_path)],
+            extra_args=["--sd", str(sd_path), *(extra_args or [])],
         )
     finally:
         sd_path.unlink(missing_ok=True)
@@ -814,6 +852,44 @@ def _run_emu(
 
 def _hex_bytes(values: list[int]) -> str:
     return "\r".join(f"{value:02X}" for value in values)
+
+
+def _vdg_text_lines(stdout: str, *, start: int, end: int) -> list[str]:
+    data: list[int] = []
+    for line in stdout.splitlines():
+        match = re.search(
+            r"\b([0-9A-Fa-f]{4})\s+((?:[0-9A-Fa-f]{2}\s+){15}[0-9A-Fa-f]{2})\b",
+            line,
+        )
+        if not match:
+            continue
+        addr = int(match.group(1), 16)
+        if not (start <= addr <= end):
+            continue
+        hex_values = match.group(2).split()
+        for value in hex_values[:16]:
+            try:
+                data.append(int(value, 16))
+            except ValueError:
+                break
+    expected_len = end - start + 1
+    assert len(data) >= expected_len, f"missing VDG memory dump: got={len(data)} stdout={stdout!r}"
+    data = data[:expected_len]
+    lines = []
+    for offset in range(0, expected_len, 0x20):
+        row = data[offset:offset + 0x20]
+        lines.append("".join(_vdg_code_to_ascii(value) for value in row).rstrip())
+    return lines
+
+
+def _vdg_code_to_ascii(value: int) -> str:
+    if value == 0x20:
+        return " "
+    if 0x60 <= value <= 0x7F:
+        return chr(value - 0x40)
+    if 0x20 <= value <= 0x5F:
+        return chr(value)
+    return " "
 
 
 def _file(name: str, data: bytes) -> Fat32File:
@@ -937,6 +1013,7 @@ def main() -> None:
         test_stage1_boot_runs_built_sdfs_binary,
         test_sdfs_loads_srec_and_ihex_files,
         test_sdfs_dir_lists_root_files_and_skips_non_files,
+        test_sdfs_vdg_dir_does_not_insert_blank_line_after_command,
         test_sdfs_dir_scans_root_chain,
         test_sdfs_dir_returns_prompt_on_empty_followup_root_cluster,
         test_sdfs_dir_requires_exact_command_and_dump_still_works,


### PR DESCRIPTION
## 対応 Issue

Closes #182
Refs #170
Refs #165

## 変更内容

- VDG consoleで直前が `CR` の場合、連続 `CR` を追加改行として扱わないように変更
- SDFS/68 の `DIR` 実行直後にVRAM上で空行が増えないことを確認するテストを追加
- #182 の判断と検証方針を `docs/plans/` に記録

## テスト結果

- `python3 tests/test_sdfs68_build.py`
- `MONITOR_PROFILE=sbcio_vdg make bin`
- `MONITOR_PROFILE=sbcio_vdg REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py`
- `MONITOR_PROFILE=k6802_vdg make bin`
- `MONITOR_PROFILE=k6802_vdg REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py`

## 追加または更新したテスト

- `test_sdfs_vdg_dir_does_not_insert_blank_line_after_command` を追加

## 影響範囲

- `FEATURE_VDG=1` のVDG表示のみ
- UART側出力仕様、SDFS/68行編集、MIKBUG互換入口の固定アドレスは変更しない

## 未対応事項

- 1st ACIA未接続時のスタンドアロン出力は #183 で扱う
- VDG向け短幅ダンプ `DS` は #179 で扱う

## 関連リンク

- #170
- #165