### PR TITLE
build: stage1とSDFS生成条件を構成軸へ整理する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ endif
 
 ASL_INCLUDE := $(CURDIR)/$(OUTDIR)$(ASL_PATHSEP)$(CURDIR)/include$(ASL_PATHSEP)$(CURDIR)/src
 
-.PHONY: all clean bin check-rom-size srec ihex stage1 sdfs sdfs-tools sdfs-tools-srec sdfs-tools-com check-stage1-profile rombin rombin-27c64 rombin-27c128 rombin-27c256 rombin-28c256 rombin-w27c512 program verify readback program-27c64 program-27c128 program-27c256 program-28c256 program-w27c512 program-upd28c256 FORCE
+.PHONY: all clean bin check-rom-size srec ihex stage1 sdfs sdfs-tools sdfs-tools-srec sdfs-tools-com check-stage1-config rombin rombin-27c64 rombin-27c128 rombin-27c256 rombin-28c256 rombin-w27c512 program verify readback program-27c64 program-27c128 program-27c256 program-28c256 program-w27c512 program-upd28c256 FORCE
 
 all: check-rom-size srec ihex
 
@@ -252,12 +252,12 @@ $(BIN): $(OBJ)
 check-rom-size: $(BIN)
 	"$(PYTHON)" -c "from pathlib import Path; import sys; p=Path('$(BIN)'); size=p.stat().st_size; limit=int('$(ROM_CODE_LIMIT)', 0); print(f'{p}: {size}/{limit} bytes'); sys.exit(0 if limit <= 0 or size <= limit else 1)"
 
-stage1: check-stage1-profile $(STAGE1_BIN)
+stage1: check-stage1-config $(STAGE1_BIN)
 
-sdfs: check-stage1-profile $(SDFS_BIN)
+sdfs: check-stage1-config $(SDFS_BIN)
 
-check-stage1-profile:
-	"$(PYTHON)" -c "import sys; profile='$(MONITOR_PROFILE)'; sys.exit(0 if profile in ('sbcio_vdg', 'k6802_vdg') else 1)" || (echo "stage1 target requires MONITOR_PROFILE=sbcio_vdg or MONITOR_PROFILE=k6802_vdg" && exit 1)
+check-stage1-config:
+	"$(PYTHON)" -c "import sys; sd='$(FEATURE_SD)'; board='$(BOARD_IO)'; memory='$(MEMORY_CONFIG)'; ok = sd == '1' and board == 'sbcio' and memory in ('ram64_c000_work', 'ram64_a000_work'); sys.exit(0 if ok else 1)" || (echo "stage1 target requires FEATURE_SD=1 BOARD_IO=sbcio and MEMORY_CONFIG=ram64_c000_work or ram64_a000_work" && exit 1)
 
 $(STAGE1_OBJ): FORCE $(STAGE1_TOPSRC) include/hardware.inc $(CONFIG_INC) src/sdcard.asm src/fat32.asm | $(OUTDIR)
 	"$(ASL)" -q -L -olist $(STAGE1_LST) -o $(STAGE1_OBJ) -i $(ASL_INCLUDE_ARG) $(STAGE1_TOPSRC)

--- a/docs/development/build_configuration_axes.md
+++ b/docs/development/build_configuration_axes.md
@@ -55,7 +55,8 @@ VDGはSBC-IOとは独立した外部表示装備として扱い、VRAM範囲は 
 
 ただし、I2CはRTC、EEPROM、OLED/LCDなど個別デバイス処理を含めるとROM容量を急速に消費する。8KB ROM互換を維持する間は、`FEATURE_I2C=1` を「I2C関連コードを無条件にROMへ押し込む入口」として使わない。ROM側へ入れる場合でも、最小BOOTや診断用の薄い入口に限定し、I2Cバスドライバ本体や個別デバイス機能はシリアル `L`、ROM常駐FATがある構成の `LF`、または `SDFS.BIN` など第2段のRAMロード機能として検証する。
 
-`FEATURE_SD=1` はraw SD sector readと固定LBA stage1 `BOOT` の前提を表す。ROM常駐のFAT32 `DIR` / `LF` は `FEATURE_FAT=1` として分ける。標準profileではROM容量確保と責務整理のため `FEATURE_FAT=0` を基本にし、`base` / `sbcio` は `FEATURE_SD=0`、VDG付きprofileだけを `FEATURE_SD=1` / `FEATURE_FAT=0` にする。
+`FEATURE_SD=1` はraw SD sector readと固定LBA stage1 `BOOT` の前提を表す。ROM常駐のFAT32 `DIR` / `LF` は `FEATURE_FAT=1` として分ける。標準profileではROM容量確保と責務整理のため `FEATURE_FAT=0` を基本にし、`base` / `sbcio` は `FEATURE_SD=0`、VDG付きprofileは `FEATURE_SD=1` / `FEATURE_FAT=0` にする。
+ただし、stage1 / SDFS/68生成可否はprofile名ではなく構成軸で判断する。`BOARD_IO=sbcio`、`FEATURE_SD=1`、`MEMORY_CONFIG=ram64_c000_work` または `ram64_a000_work` の組み合わせなら、VDGなしのSBC-IO構成でも `BOOT + SDFS/68` 用のROM、stage1、`SDFS.BIN` を生成できる。
 
 ## 既存profileの展開
 
@@ -106,6 +107,12 @@ make bin MEMORY_CONFIG=ram64_a000_work BOARD_IO=sbcio FEATURE_SD=1 FEATURE_FAT=0
 不正な組み合わせはMake時に失敗させる。
 `FEATURE_SD=1`、`FEATURE_KEYBOARD=1`、`FEATURE_I2C=1` は `BOARD_IO=sbcio` を必須とする。
 `FEATURE_VDG=1` は `VDG_VRAM_CONFIG` の明示的な配置を使う。
+`make stage1` / `make sdfs` は `FEATURE_SD=1`、`BOARD_IO=sbcio`、stage1対応RAM配置を必須にする。
+標準 `sbcio` profileはSDなしのまま維持し、VDGなしSDFS/68構成を試す場合は次のように軸指定で有効化する。
+
+```sh
+MONITOR_PROFILE=sbcio FEATURE_SD=1 FEATURE_FAT=0 BUILD_CONFIG_NAME=sbcio-sdfs make bin stage1 sdfs
+```
 
 アセンブル時には、Makefileが `build/monitor_config.inc` を生成し、ROM本体はこの生成ファイルだけをincludeする。
 過去の `include/profiles/*.inc` はprofileプリセットのコピー元としては使わない。

--- a/docs/plans/issue-184_stage1_sdfs_build_axes.md
+++ b/docs/plans/issue-184_stage1_sdfs_build_axes.md
@@ -1,0 +1,37 @@
+# #184 stage1 / SDFS/68生成条件の構成軸整理
+
+## 背景
+
+`make stage1` / `make sdfs` は、これまで `MONITOR_PROFILE=sbcio_vdg` または `MONITOR_PROFILE=k6802_vdg` の場合だけ許可していた。
+一方で、SDFS/68 の起動に必要なのはVDGそのものではなく、ROM側のraw SD sector read / `BOOT`、SBC-IO、stage1を置けるワークRAM配置である。
+
+標準 `sbcio` profileは引き続き `FEATURE_SD=0` のSBC-IO RAM拡張 + 2nd ACIAキーボード構成として残す。
+ただし、VDGなしSBC-IOでSDFS/68を試す場合は、profile名を増やさず構成軸の直接指定で扱えるようにする。
+
+## 採用方針
+
+- `stage1` / `sdfs` の生成可否をprofile名ではなく構成軸で判断する。
+- 許可条件は `FEATURE_SD=1`、`BOARD_IO=sbcio`、`MEMORY_CONFIG=ram64_c000_work` または `ram64_a000_work` とする。
+- `FEATURE_FAT` は条件に含めない。SDFS/68本線では `FEATURE_FAT=0` を推奨するが、ROM常駐FAT互換構成の確認は別軸として残す。
+- VDGなしSBC-IOのSDFS/68構成は、次のように直接指定する。
+
+```sh
+MONITOR_PROFILE=sbcio FEATURE_SD=1 FEATURE_FAT=0 BUILD_CONFIG_NAME=sbcio-sdfs make bin stage1 sdfs
+```
+
+## 生成物名
+
+`BUILD_CONFIG_NAME=sbcio-sdfs` を使うと、次の生成物名になる。
+
+- `build/mc6800-monitor-sbcio-sdfs.bin`
+- `build/stage1-sbcio-sdfs.bin`
+- `build/SDFS-sbcio-sdfs.BIN`
+
+SDへ置くときは、他のSDFS/68構成と同じく `stage1` はfixed boot areaへ、SDFS/68本体はrootの `SDFS.BIN` として格納する。
+
+## 検証方針
+
+- `base` profileの `make stage1` / `make sdfs` は引き続き失敗することを確認する。
+- `sbcio FEATURE_SD=1 FEATURE_FAT=0 BUILD_CONFIG_NAME=sbcio-sdfs` でROM、stage1、SDFS/68本体を生成できることを確認する。
+- 生成したVDGなしSBC-IO構成のROM、stage1、SDFS/68本体で、エミュレータ上の `BOOT` がSDFS/68プロンプトへ到達することを確認する。
+- 既存の `sbcio_vdg` / `k6802_vdg` のstage1 / SDFS/68テストを維持する。

--- a/docs/usage/build_commands.md
+++ b/docs/usage/build_commands.md
@@ -109,7 +109,10 @@ ROM_CODE_LIMIT=0 make bin
 
 ## SDFS/68 stage1
 
-`stage1` ターゲットは SDFS/68 の固定LBA boot areaへ置くstage1 loaderを単体生成する。対象は当面 `sbcio_vdg` と `k6802_vdg` だけで、`base` profileでは生成しない。
+`stage1` ターゲットは SDFS/68 の固定LBA boot areaへ置くstage1 loaderを単体生成する。
+生成可否はprofile名ではなく構成軸で決まる。
+`FEATURE_SD=1`、`BOARD_IO=sbcio`、stage1対応RAM配置である `MEMORY_CONFIG=ram64_c000_work` または `ram64_a000_work` の組み合わせで有効になる。
+`base` profileや `FEATURE_SD=0` の構成では生成しない。
 
 ```sh
 MONITOR_PROFILE=sbcio_vdg make stage1
@@ -118,18 +121,33 @@ MONITOR_PROFILE=sbcio_vdg make sdfs
 MONITOR_PROFILE=k6802_vdg make sdfs
 ```
 
+VDGなしのSBC-IOでSDFS/68を使う場合は、標準 `sbcio` profileを直接変更せず、構成軸で `FEATURE_SD=1` を明示する。
+出力名を短く安定させるため、`BUILD_CONFIG_NAME` を付ける。
+
+```sh
+MONITOR_PROFILE=sbcio FEATURE_SD=1 FEATURE_FAT=0 BUILD_CONFIG_NAME=sbcio-sdfs make bin
+MONITOR_PROFILE=sbcio FEATURE_SD=1 FEATURE_FAT=0 BUILD_CONFIG_NAME=sbcio-sdfs make stage1
+MONITOR_PROFILE=sbcio FEATURE_SD=1 FEATURE_FAT=0 BUILD_CONFIG_NAME=sbcio-sdfs make sdfs
+```
+
 主な出力:
 
-| profile | 出力 |
+| 構成 | 出力 |
 | --- | --- |
 | `sbcio_vdg` | `build/stage1-sbcio-vdg.bin` |
 | `k6802_vdg` | `build/stage1-k6802-vdg.bin` |
+| `sbcio` + `FEATURE_SD=1 BUILD_CONFIG_NAME=sbcio-sdfs` | `build/stage1-sbcio-sdfs.bin` |
 
-stage1 v1の配置は、`sbcio_vdg` が `$C400-$CFFF`、`k6802_vdg` が `$A400-$AFFF` である。SDFS/68本体の初期ロード領域はそれぞれ `$D000-$DEFF`、`$B000-$BEFF` とする。
+stage1 v1の配置は、`MEMORY_CONFIG=ram64_c000_work` が `$C400-$CFFF`、`MEMORY_CONFIG=ram64_a000_work` が `$A400-$AFFF` である。
+SDFS/68本体の初期ロード領域はそれぞれ `$D000-$DEFF`、`$B000-$BEFF` とする。
 
-`sdfs` ターゲットは FAT root の `SDFS.BIN` として配置するSDFS/68本体を生成する。出力はprofile suffix付きの `build/SDFS-sbcio-vdg.BIN` / `build/SDFS-k6802-vdg.BIN` で、SDイメージ作成時に root の8.3名 `SDFS.BIN` として格納する。
+`sdfs` ターゲットは FAT root の `SDFS.BIN` として配置するSDFS/68本体を生成する。
+出力はsuffix付きの `build/SDFS-sbcio-vdg.BIN`、`build/SDFS-k6802-vdg.BIN`、`build/SDFS-sbcio-sdfs.BIN` などで、SDイメージ作成時に root の8.3名 `SDFS.BIN` として格納する。
 
-ROM profileでは `FEATURE_SD` と `FEATURE_FAT` を分ける。`FEATURE_SD=1` はraw SD sector readと `BOOT` の前提、`FEATURE_FAT=1` はROM常駐の `DIR` / `LF` を含める設定である。標準profileではROM FATを外し、`sbcio_vdg` / `k6802_vdg` だけを固定LBA stage1 `BOOT` に寄せる。ROM FAT互換を確認したい場合は、直接指定ビルドで `FEATURE_SD=1 FEATURE_FAT=1` を指定する。
+ROM profileでは `FEATURE_SD` と `FEATURE_FAT` を分ける。
+`FEATURE_SD=1` はraw SD sector readと `BOOT` の前提、`FEATURE_FAT=1` はROM常駐の `DIR` / `LF` を含める設定である。
+標準profileではROM FATを外し、`sbcio_vdg` / `k6802_vdg` と、必要に応じた軸指定 `sbcio FEATURE_SD=1` を固定LBA stage1 `BOOT` に寄せる。
+ROM FAT互換を確認したい場合は、直接指定ビルドで `FEATURE_SD=1 FEATURE_FAT=1` を指定する。
 stage1と `SDFS.BIN` はROMモニタの一部ではなく、system SD側へ置く別成果物である。
 
 ## ROM_KIND

--- a/docs/usage/sdfs68_system_sd.md
+++ b/docs/usage/sdfs68_system_sd.md
@@ -44,7 +44,8 @@ flowchart TD
 ROM常駐FATは `FEATURE_SD=1 FEATURE_FAT=1` を直接指定したときだけ使う互換機能であり、SDFS/68本線ではない。
 ここで不要としているのは、fixed boot area のstage1と root の `SDFS.BIN` を含むSDFS/68用system SDである。
 ROM常駐FAT `DIR` / `LF` を使う場合でも、FAT32形式のSDカード自体は別途必要である。
-標準profileではROM常駐FATを外し、`sbcio_vdg` / `k6802_vdg` は `BOOT` でSDFS/68へ移行してからSD上ファイルを扱う。
+標準profileではROM常駐FATを外し、`FEATURE_SD=1 FEATURE_FAT=0` の構成は `BOOT` でSDFS/68へ移行してからSD上ファイルを扱う。
+この構成は `sbcio_vdg` / `k6802_vdg` のprofileで使えるほか、VDGなしのSBC-IOでも `MONITOR_PROFILE=sbcio FEATURE_SD=1 FEATURE_FAT=0 BUILD_CONFIG_NAME=sbcio-sdfs` のように軸指定で作れる。
 
 ## システムSDイメージ生成
 

--- a/tests/test_sdfs68_build.py
+++ b/tests/test_sdfs68_build.py
@@ -40,12 +40,65 @@ EXPECTED = {
     },
 }
 
+SBCIO_SD_AXIS = {
+    "profile": "sbcio",
+    "suffix": "-sbcio-sdfs",
+    "SDFS_LOAD_BASE": 0xD000,
+    "SDFS_LOAD_LIMIT": 0xDEFF,
+    "make_args": [
+        "FEATURE_SD=1",
+        "FEATURE_FAT=0",
+        "BUILD_CONFIG_NAME=sbcio-sdfs",
+    ],
+}
+
 
 def test_sdfs_rejects_base_profile() -> None:
     result = _run_make("base", "sdfs", expect_success=False)
     assert result.returncode != 0
-    assert "stage1 target requires" in result.stdout or "stage1 target requires" in result.stderr
+    assert "FEATURE_SD=1" in result.stdout or "FEATURE_SD=1" in result.stderr
     print("[PASS] test_sdfs_rejects_base_profile")
+
+
+def test_sdfs_accepts_sd_axis_without_vdg() -> None:
+    config = SBCIO_SD_AXIS
+    make_args = config["make_args"]
+    _run_make(config["profile"], "bin", make_args=make_args)
+    _run_make(config["profile"], "stage1", make_args=make_args)
+    _run_make(config["profile"], "sdfs", make_args=make_args)
+    suffix = config["suffix"]
+    rom_path = PROJECT_ROOT / "build" / f"mc6800-monitor{suffix}.bin"
+    stage1_path = PROJECT_ROOT / "build" / f"stage1{suffix}.bin"
+    sdfs_path = PROJECT_ROOT / "build" / f"SDFS{suffix}.BIN"
+    lst_path = PROJECT_ROOT / "build" / f"SDFS{suffix}.lst"
+    assert rom_path.exists(), f"missing axis ROM: {rom_path}"
+    assert stage1_path.exists(), f"missing axis stage1: {stage1_path}"
+    assert sdfs_path.exists(), f"missing axis SDFS: {sdfs_path}"
+    symbols = _load_symbols(
+        lst_path,
+        "SDFS_LOAD_BASE",
+        "SDFS_LOAD_LIMIT",
+    )
+    assert symbols["SDFS_LOAD_BASE"] == config["SDFS_LOAD_BASE"]
+    assert symbols["SDFS_LOAD_LIMIT"] == config["SDFS_LOAD_LIMIT"]
+
+    image = build_sdfs_image(
+        stage1_data=stage1_path.read_bytes(),
+        sdfs_data=sdfs_path.read_bytes(),
+        extra_files=[],
+    )
+    stdout, stderr, rc = _run_emu_with_sd(
+        rom_path=rom_path,
+        input_text="BOOT\rEXIT\r",
+        sd_image=image,
+        max_cycles=40_000_000,
+    )
+    assert rc == 0 and "[TIMEOUT]" not in stderr, (
+        f"emulator failed for sbcio SD axis: rc={rc} stderr={stderr!r}"
+    )
+    assert "SDFS/68 V1.2 #150" in stdout, f"missing SDFS banner: {stdout!r}"
+    assert "SDFS> " in stdout, f"missing SDFS prompt: {stdout!r}"
+    print("[PASS] test_sdfs_accepts_sd_axis_without_vdg")
 
 
 def test_sdfs_profiles_build_and_match_header() -> None:
@@ -775,9 +828,10 @@ def _run_make(
     profile: str,
     target: str,
     expect_success: bool = True,
+    make_args: list[str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     result = subprocess.run(
-        ["make", target, f"MONITOR_PROFILE={profile}"],
+        ["make", target, f"MONITOR_PROFILE={profile}", *(make_args or [])],
         cwd=PROJECT_ROOT,
         capture_output=True,
         text=True,
@@ -1008,6 +1062,7 @@ def main() -> None:
     print("=" * 50)
     tests = [
         test_sdfs_rejects_base_profile,
+        test_sdfs_accepts_sd_axis_without_vdg,
         test_sdfs_profiles_build_and_match_header,
         test_sdfs_api_wrappers_target_stage1_jump_table,
         test_stage1_boot_runs_built_sdfs_binary,

--- a/tests/test_stage1_build.py
+++ b/tests/test_stage1_build.py
@@ -44,12 +44,50 @@ EXPECTED = {
     },
 }
 
+SBCIO_SD_AXIS = {
+    "profile": "sbcio",
+    "suffix": "-sbcio-sdfs",
+    "S1_BASE": 0xC400,
+    "S1_LIMIT": 0xCFFF,
+    "SDFS_LOAD_BASE": 0xD000,
+    "SDFS_LOAD_LIMIT": 0xDEFF,
+    "make_args": [
+        "FEATURE_SD=1",
+        "FEATURE_FAT=0",
+        "BUILD_CONFIG_NAME=sbcio-sdfs",
+    ],
+}
+
 
 def test_stage1_rejects_base_profile() -> None:
     result = _run_make("base", expect_success=False)
     assert result.returncode != 0
-    assert "stage1 target requires" in result.stdout or "stage1 target requires" in result.stderr
+    assert "FEATURE_SD=1" in result.stdout or "FEATURE_SD=1" in result.stderr
     print("[PASS] test_stage1_rejects_base_profile")
+
+
+def test_stage1_accepts_sd_axis_without_vdg() -> None:
+    config = SBCIO_SD_AXIS
+    _run_make(config["profile"], make_args=config["make_args"])
+    suffix = config["suffix"]
+    bin_path = PROJECT_ROOT / "build" / f"stage1{suffix}.bin"
+    lst_path = PROJECT_ROOT / "build" / f"stage1{suffix}.lst"
+    data = bin_path.read_bytes()
+    symbols = _load_symbols(
+        lst_path,
+        "S1_BASE",
+        "S1_LIMIT",
+        "SDFS_LOAD_BASE",
+        "SDFS_LOAD_LIMIT",
+        "S1_BOOT_SDFS",
+    )
+    assert symbols["S1_BASE"] == config["S1_BASE"]
+    assert symbols["S1_LIMIT"] == config["S1_LIMIT"]
+    assert symbols["SDFS_LOAD_BASE"] == config["SDFS_LOAD_BASE"]
+    assert symbols["SDFS_LOAD_LIMIT"] == config["SDFS_LOAD_LIMIT"]
+    assert len(data) <= symbols["S1_LIMIT"] - symbols["S1_BASE"] + 1
+    _assert_stage1_header(data, symbols["S1_BOOT_SDFS"])
+    print("[PASS] test_stage1_accepts_sd_axis_without_vdg")
 
 
 def test_stage1_profiles_build_and_match_layout() -> None:
@@ -285,9 +323,10 @@ def _run_make(
     profile: str,
     target: str = "stage1",
     expect_success: bool = True,
+    make_args: list[str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     result = subprocess.run(
-        ["make", target, f"MONITOR_PROFILE={profile}"],
+        ["make", target, f"MONITOR_PROFILE={profile}", *(make_args or [])],
         cwd=PROJECT_ROOT,
         capture_output=True,
         text=True,
@@ -660,6 +699,7 @@ def main() -> None:
     print("=" * 50)
     tests = [
         test_stage1_rejects_base_profile,
+        test_stage1_accepts_sd_axis_without_vdg,
         test_stage1_profiles_build_and_match_layout,
         test_stage1_read_sector_service_reads_known_fixture_sector,
         test_stage1_mount_service_accepts_fat32_fixtures,


### PR DESCRIPTION
## 対応Issue
Closes #184

## 変更内容
- `make stage1` / `make sdfs` の許可条件を `MONITOR_PROFILE` 名固定から構成軸判定へ変更
- 許可条件を `FEATURE_SD=1`、`BOARD_IO=sbcio`、`MEMORY_CONFIG=ram64_c000_work` または `ram64_a000_work` に整理
- VDGなしSBC-IO向けに `MONITOR_PROFILE=sbcio FEATURE_SD=1 FEATURE_FAT=0 BUILD_CONFIG_NAME=sbcio-sdfs` の導線を追加
- stage1 / SDFS/68テストにVDGなしSBC-IO + SD軸指定の正系を追加
- build構成軸、build手順、SDFS/68 system SD文書を更新
- #184の判断を `docs/plans/issue-184_stage1_sdfs_build_axes.md` に記録

## テスト結果
- `make sdfs MONITOR_PROFILE=base` → 期待どおり失敗
- `MONITOR_PROFILE=sbcio FEATURE_SD=1 FEATURE_FAT=0 BUILD_CONFIG_NAME=sbcio-sdfs make bin stage1 sdfs`
- `MONITOR_PROFILE=sbcio_vdg make stage1 sdfs`
- `MONITOR_PROFILE=k6802_vdg make stage1 sdfs`
- `python3 tests/test_stage1_build.py` → 14 passed
- `python3 tests/test_sdfs68_build.py` → 23 passed
- `MONITOR_PROFILE=sbcio FEATURE_SD=1 FEATURE_FAT=0 MONITOR_ROM_PATH=build/mc6800-monitor-sbcio-sdfs.bin REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py` → 37 passed
- `MONITOR_PROFILE=sbcio FEATURE_SD=1 FEATURE_FAT=0 MONITOR_ROM_PATH=build/mc6800-monitor-sbcio-sdfs.bin REQUIRE_BUILD_ROM=1 python3 tests/test_sd_fixture.py` → 15 passed

## 追加・更新したテスト
- `test_stage1_accepts_sd_axis_without_vdg`
- `test_sdfs_accepts_sd_axis_without_vdg`
- 既存の `base` 拒否テストを新しい構成軸エラーメッセージへ更新

## 影響範囲
- 標準 `sbcio` profileは引き続き `FEATURE_SD=0` のまま
- VDGなしSBC-IOでSDFS/68を使う場合は、明示的に `FEATURE_SD=1` と `BUILD_CONFIG_NAME` を指定する
- 既存の `sbcio_vdg` / `k6802_vdg` のstage1/SDFS生成は維持

## 未対応事項
- サブディレクトリ対応は対象外
- 新しい正式profile追加は対象外
