### PR TITLE
docs: ローダ重複削減とasm解析基盤の検討資料を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,25 @@
 - 対応IssueがそのPRで完了する場合、PR本文の対応Issue欄には `Closes #番号` を記載する。
 - 参照だけで完了しないIssueには `Refs #番号` を使う。
 
+## 親子Issue(sub-issue)
+
+- 親子関係のあるIssueは、本文の `Refs` 表記だけで済ませず、GitHub の sub-issue として必ず正式に紐づける。
+- `gh` CLI には sub-issue サブコマンドが無いため、GraphQL API で紐づける。
+  ```sh
+  P=$(gh issue view <親番号> --json id -q .id)
+  C=$(gh issue view <子番号> --json id -q .id)
+  gh api graphql -H "GraphQL-Features: sub_issues" \
+    -f query='mutation($p:ID!,$c:ID!){addSubIssue(input:{issueId:$p,subIssueId:$c}){subIssue{number}}}' \
+    -F p="$P" -F c="$C"
+  ```
+- close済みのIssueも sub-issue として追加できる。
+
+## 生成AIの痕跡を残さない
+
+- GitHub Issue、Pull Request、コミットメッセージに、生成AI由来であることを示す痕跡を一切残さない。
+- コミットに `Co-Authored-By` の生成AI署名を付けない。PR本文に「Generated with ...」等のフッタを付けない。
+- 道具名(解析ツール等)を手段として記載するのは痕跡ではないので可。
+
 このリポジトリで Codex が作業する際のローカル運用ルールを定義する。
 
 ## 言語

--- a/docs/plans/issue-216_bank_memory_sdfs_resident.md
+++ b/docs/plans/issue-216_bank_memory_sdfs_resident.md
@@ -219,6 +219,10 @@ TPA境界を導入するIssueでは、`.COM` ABI文書とテストの更新を�
 | `.COM` ABI更新 | `USER_RAM_END` 低下時の最大サイズ、引数領域、復帰条件を再定義する | ABI文書とSDFS build testが更新される |
 | 実機・基板化前PoC | エミュレータまたは試作回路で `$C000` バンク窓を読み書きする | RAMTESTまたは専用診断でバンク切替が確認できる |
 
+## 関連調査(子Issue #219)
+
+子Issue #219 で、SDFS常駐部のサイズ削減余地として、ROMモニタとSDFSモジュールに二重実装されたS-Record/Intel-HEXローダ(構成正確に48ルーチン)を確認した。ROM側ローダの公開API化でSDFS常駐部から数百バイト回収できる見込みがあり、本検討の常駐サイズ評価に反映する。詳細と指摘表は [issue-219_loader_dedup_asm_analysis.md](issue-219_loader_dedup_asm_analysis.md) を参照。
+
 ## 採用候補
 
 現時点の本命は候補Cとする。

--- a/docs/plans/issue-219_loader_dedup_asm_analysis.md
+++ b/docs/plans/issue-219_loader_dedup_asm_analysis.md
@@ -1,0 +1,81 @@
+# Issue #219 ローダ重複の削減とasm構成別解析基盤の整備
+
+## 対象
+
+- 親Issue: #216(バンクメモリボードとSDFS常駐場所変更検討)
+- 関連: #217(検討計画の初版)
+- 本書は #216 の「SDFS/68常駐部のサイズ削減余地」を具体化する調査メモであり、指摘表と解析手法、後続作業への引き継ぎを残す。
+
+## 背景
+
+#216 で整理したとおり、SDFS/68 は stage1 と本体を含めて現行の8KBワーク領域が窮屈になっている。常駐部のバイト数を削れれば、メモリマップ再設計の自由度が上がる。
+
+そこで ROMモニタ(`main.asm`)と SDFSモジュール(`sdfs68.asm`)の重複を調べたところ、S-Record / Intel-HEX のテキストローダ一式がほぼ丸ごと二重実装されていることが分かった。
+
+## 重要な手法上の注意 — ソース解析と構成別解析は別物
+
+このコードベースは条件アセンブリ(`if MONITOR_FEATURE_*` など)を多用しており(`main.asm` だけで150箇所超)、ビルド構成ごとに実際にアセンブルされるコードが変わる。
+
+| 観点 | ソース索引(構造地図) | アセンブルリスト(`.lst`) |
+| --- | --- | --- |
+| 見ているもの | 生ソースの和集合(全 `if` 分岐) | その構成で実際に出たコード(条件解決済み・実アドレス) |
+| 条件アセンブリ | 評価しない | 解決済み |
+| 「このバイナリに何が入るか」 | 判定不可 | アドレスで判定可 |
+| 構成別の重複/デッドコード | 過大計上 | 正確 |
+
+結論として、**構成依存の無駄削減判断は `.lst` を真実の土台にする**。呼び出し構造やクロス参照の俯瞰には別途ソース索引が有効だが、それ単独では「実際にビルドされるか」を答えられない。
+
+## 指摘表
+
+| # | 指摘 | 区分 | 根拠 | 対応方針 |
+| --- | --- | --- | --- | --- |
+| 1 | S-Record/Intel-HEX ローダが ROM と SDFS モジュールに二重実装 | 重複 | `.lst` 上、両バイナリに live で存在する対 **48組** | 削減方式を検討(下記) |
+| 2 | ソース上の `X`↔`SDFS_X` 対 76組のうち 27組は ROM 側で条件除外され実体なし | 偽重複 | `MONITOR_FEATURE_FAT=0` 等。`PARSE_FILENAME_*` 一式がROMに不在 | 重複対象から除外(削減見積りに含めない) |
+| 3 | `PIA_PRA` / `PIA_CRA` がどの構成でも未参照 | 未使用定数 | 全`.lst`のシンボルテーブルで `*`(unused) | Port A 未使用の裏付け。整理 or I2C流用検討(別軸)で参照 |
+| 4 | `VEC_RESET` / `VEC_NMI` / `VEC_SWI` 等が未参照 | 未使用定数 | ベクタは `org` 直書きで設定されシンボル参照なし | ドキュメント化 or 整理(任意) |
+| 5 | `.lst` の `*`(unused)コードラベルは「未到達」を意味しない | 注意 | フォールスルーラベル(`PARSE_DUMP_ARGS_READY` 等)や別バイナリから呼ばれるAPI入口(`SDFS_API_*`, `S1_JUMP_TABLE`)を含む | デッドルーチン判定は目視併用(機械判定は不可) |
+
+## 真の重複48ルーチン(構成 `sbcio-sdfs`)
+
+`tools/lst_analyze.py` で再現可能。S-Record/Intel-HEX のテキストローダを中心に、以下のファミリが ROM と SDFS の両方に live で存在する。
+
+- S-Record: `READ_SREC_RECORD` / `READ_SREC_HEAD_OK` / `READ_SREC_TYPE_OK` / `READ_SREC_ADDR24` / `READ_SREC_DATA_LOOP` / `READ_SREC_STORE` / `READ_SREC_SKIP_STORE` / `READ_SREC_CHECKSUM` / `READ_SREC_EOF` / `READ_SREC_FAIL*`
+- Intel-HEX: `READ_IHEX_RECORD` / `READ_IHEX_HEAD_OK` / `READ_IHEX_DATA*` / `READ_IHEX_SKIP_STORE` / `READ_IHEX_CHECKSUM` / `READ_IHEX_EOF` / `READ_IHEX_FAIL*`
+- レコード振り分け: `READ_LOADER_RECORD*` / `READ_RECORD_HEAD*` / `READ_RECORD_TRAILER*`
+- 行入力: `READ_LINE` / `READ_LINE_LOOP` / `READ_LINE_BACKSPACE` / `READ_LINE_DONE`
+- HEX入力・変換: `READ_HEXBYTE_INPUT*` / `HEX_TO_NIBBLE*`
+- 出力補助: `PRINT_HEX8` / `PRINT_NIBBLE*` / `PRINT_PROMPT`
+- エラー表示: `SHOW_ERROR` / `SHOW_LOADER_ERROR*`
+- チェックサム: `ADD_TO_LOADER_SUM`
+
+代表的なアドレス対(ROM ↔ SDFS):`READ_SREC_RECORD` EA59 ↔ DB8A、`READ_LINE` E97E ↔ D652、`ADD_TO_LOADER_SUM` EC59 ↔ DD86。命令本体は接頭辞 `SDFS_` を除けば等価。
+
+## 削減方式の選択肢
+
+ROM($E000–$FFFF)は SDFS モジュール実行中も常にマップされている。したがって理論上、SDFS 側は自前コピーを捨てて ROM 側ローダを呼べる。
+
+- **案1: ROM側ローダの公開API化(本命候補)**
+  - ROM に小さなジャンプテーブル(stage1 の `S1_JUMP_TABLE` と同方式)を置き、ローダ入口を固定アドレスで公開する。
+  - SDFS/68・stage1 はそのテーブル経由で呼び、自前の `SDFS_*` コピーを撤去する。
+  - 効果: SDFSモジュールから数百バイトの回収が見込める(48ルーチン分)。#216 の常駐サイズ削減に直接効く。
+  - 留意: ROMローダ入口アドレスが構成で動くため、固定エントリ(ジャンプテーブル)で安定化が必須。ローダが使うゼロページ/ワーク変数の配置共有も要確認。
+
+- **案2: モジュール独立性を優先し二重実装を許容**
+  - SDFS を ROM から独立した自己完結モジュールとして保つ。
+  - 効果: メモリ回収なし。保守時に2コピーを同期するコストが残る(変更漏れリスク)。
+
+## #216 への影響
+
+- 案1採用時、SDFSモジュール常駐部から48ルーチン相当(数百バイト規模)を削減できる見込み。#216 の候補B/Cでの常駐サイズ評価に反映する。
+- 削減後の正確なバイト数は、API化の実装後に `tools/lst_analyze.py` と `make` のサイズ確認で再計測する。
+
+## 整備した解析基盤(保全)
+
+- `tools/lst_analyze.py`: ASL の `.lst` シンボルテーブルをパースし、構成別に「未使用シンボル(`*`)」「ROM↔SDFS の真の重複対」を出力する。構成名を引数で指定(既定 `sbcio-sdfs`)。
+- `tools/codegraph/`: ソース索引ツール(CodeGraph)の asm 拡張プラグインと適用手順。呼び出し構造・クロス参照の俯瞰用。条件アセンブリは評価しないため「構造地図」用途に限定する。
+
+## 検証方法
+
+- `python3 tools/lst_analyze.py sbcio-sdfs` で重複対と未使用シンボルを再生成する(`build/*.lst` が必要)。
+- `make stage1 sdfs MONITOR_PROFILE=sbcio_vdg` 等でビルドし直すと最新の `.lst` が得られる。
+- デッドルーチン候補は、`.lst` の `*` 印字を機械判定の入口にしつつ、フォールスルー/外部API入口を目視で除外する。

--- a/tools/codegraph/README.md
+++ b/tools/codegraph/README.md
@@ -1,0 +1,67 @@
+# CodeGraph asm 拡張プラグイン
+
+ソース索引ツール CodeGraph(`@colbymchenry/codegraph`)は tree-sitter ベースで、
+標準では `.asm` を解析できない(シンボルが一切抽出されない)。本ディレクトリは、
+このプロジェクトの MC6800 アセンブリを索引できるようにする **カスタム抽出器** と、
+その適用手順を保全したもの。
+
+呼び出し構造・クロス参照の俯瞰(「構造地図」)用途に使う。**条件アセンブリや
+マクロは評価しない**ため、構成別の重複/デッドコード判定には使わない
+(そちらは `tools/lst_analyze.py` の `.lst` ベース解析を使う)。
+
+## 構成物
+
+- `asm-extractor.js` — 行単位の正規表現でラベル/定数/呼出/参照を抽出する抽出器。
+  抽出ルールはファイル冒頭のコメント参照。
+
+## 適用手順(ローカル dist へのパッチ)
+
+CodeGraph 本体は配布済みのコンパイル済み成果物で、拡張子→言語マップは
+ハードコードのため、設定では拡張子を足せない。インストール先の `dist/` を
+直接パッチする(本体アップグレードで消えるので、その都度再適用する)。
+
+インストール先の例: `~/.codegraph/versions/<ver>/lib/dist/extraction/`
+
+1. 本ファイルの `asm-extractor.js` を `extraction/` 直下にコピーする。
+
+2. `extraction/grammars.js` の `EXTENSION_MAP` に追記する:
+   ```js
+   '.inc': 'assembly', // このプロジェクトの .inc はアセンブラ include(既定は 'php')
+   '.asm': 'assembly',
+   '.s': 'assembly',
+   ```
+
+3. `extraction/tree-sitter.js` の冒頭 require 群に追記する:
+   ```js
+   const asm_extractor_1 = require("./asm-extractor");
+   ```
+
+4. 同ファイルの `extractFromSource()` のディスパッチに分岐を追加する
+   (`pascal`(.dfm)分岐の手前あたり):
+   ```js
+   else if (detectedLanguage === 'assembly') {
+       const extractor = new asm_extractor_1.AsmExtractor(filePath, source);
+       result = extractor.extract();
+   }
+   ```
+
+5. フル再索引する(増分索引はソース無変更だと抽出器変更を拾わないため):
+   ```sh
+   codegraph init .        # もしくは codegraph index -f .
+   ```
+
+## 確認
+
+```sh
+codegraph callers PIA_PRB      # PIA_PRB を読み書きする asm ルーチン + emu(クロス言語)
+codegraph callers SD_SPI_XFER  # 呼び出し元ルーチン
+codegraph node   SD_PIA_INIT   # ソース + 呼出経路
+```
+
+## 既知の限界
+
+- 条件アセンブリ・マクロ非評価(和集合を索引する)。構成別判断には不向き。
+- 全ラベルを `function`/`label` として扱うため、分岐のみで到達する局所ラベルは
+  「未呼出」に見える(デッドコード判定には使わない)。
+- 末尾コロンのないラベル(古典 Motorola 表記)は未対応。本プロジェクトの
+  `src/*.asm` は全てコロン付きのため実害なし。

--- a/tools/codegraph/asm-extractor.js
+++ b/tools/codegraph/asm-extractor.js
@@ -1,0 +1,238 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.AsmExtractor = void 0;
+const tree_sitter_helpers_1 = require("./tree-sitter-helpers");
+/**
+ * 6800/6502/Z80 系レトロアセンブリ(.asm/.s/.inc)用のカスタム抽出器。
+ *
+ * 多様な手書きアセンブラ方言に合う tree-sitter 文法が無いため、行単位の
+ * 正規表現で解析する。アセンブリのシンボル意味論は単純:
+ *
+ *   LABEL:                 → NodeKind `function`(入口)/ `label`(局所)
+ *   NAME equ <expr>        → NodeKind `constant`(signature = 式)
+ *   jsr / bsr TARGET       → `calls` エッジ
+ *   jmp TARGET             → `references` エッジ(末尾ジャンプ/エラー経路)
+ *   <データ命令> ... SYMBOL → オペランドのシンボルごとに `references` エッジ
+ *   fcb/fdb SYMBOL         → `references` エッジ(データ表/ベクタ)
+ *   NAME equ A-B           → NAME から A,B への `references`(定数依存)
+ *   include "file"         → 取り込みファイル basename への `references`
+ *
+ * オペランドのシンボルは過剰に拾ってよい。解決器は実在ノードに一致する参照
+ * だけを残し、残りを黙って捨てるため、余分なトークン($FFやレジスタ名)は
+ * 無害。これにより `callers PIA_PRB` / `impact SD_PORTB_SHADOW` が機能し、
+ * エミュレータ(Python)とファームウェア(asm)が同じレジスタ名を共有する
+ * 関係でクロス言語参照も自動的に張られる。
+ *
+ * 条件分岐(beq/bne/bra/...)はルーチン内制御フローなので、コールグラフを
+ * 汚さないよう意図的に無視する。
+ */
+const LABEL_RE = /^([A-Za-z_.][A-Za-z0-9_.$]*):/;
+const EQU_RE = /^([A-Za-z_.][A-Za-z0-9_.$]*)\s+equ\s+(.*)$/i;
+const SYMBOL_RE = /[A-Za-z_.][A-Za-z0-9_.$]*/g;
+// フロー終端: 直後のラベルは新しいルーチンの入口とみなす。
+const TERMINATOR_RE = /^\s*(rts|rti|jmp|bra)\b/i;
+const CALL_OPS = new Set(['jsr', 'bsr']);
+const BRANCH_OPS = new Set([
+    'beq', 'bne', 'bra', 'bcc', 'bcs', 'bhi', 'bls', 'bge', 'blt', 'bgt', 'ble',
+    'bmi', 'bpl', 'bvs', 'bvc', 'brn', 'lbra', 'lbeq', 'lbne',
+]);
+const DATA_OPS = new Set(['fcb', 'fdb', 'fcc', 'fqb', 'dc', 'db', 'dw']);
+// シンボルに見えるがレジスタ/条件コードのトークン。未解決参照を減らすため除外。
+const REGISTERS = new Set(['a', 'b', 'x', 'y', 's', 'u', 'd', 'cc', 'pc', 'sp']);
+class AsmExtractor {
+    filePath;
+    source;
+    nodes = [];
+    edges = [];
+    unresolvedReferences = [];
+    errors = [];
+    constructor(filePath, source) {
+        this.filePath = filePath;
+        this.source = source;
+    }
+    extract() {
+        const startTime = Date.now();
+        try {
+            const fileNode = this.createFileNode();
+            this.parse(fileNode.id);
+        }
+        catch (error) {
+            this.errors.push({
+                message: `ASM extraction error: ${error instanceof Error ? error.message : String(error)}`,
+                severity: 'error',
+                code: 'parse_error',
+            });
+        }
+        return {
+            nodes: this.nodes,
+            edges: this.edges,
+            unresolvedReferences: this.unresolvedReferences,
+            errors: this.errors,
+            durationMs: Date.now() - startTime,
+        };
+    }
+    createFileNode() {
+        const lines = this.source.split('\n');
+        const id = (0, tree_sitter_helpers_1.generateNodeId)(this.filePath, 'file', this.filePath, 1);
+        const fileNode = {
+            id,
+            kind: 'file',
+            name: this.filePath.split('/').pop() || this.filePath,
+            qualifiedName: this.filePath,
+            filePath: this.filePath,
+            language: 'assembly',
+            startLine: 1,
+            endLine: lines.length,
+            startColumn: 0,
+            endColumn: lines[lines.length - 1]?.length || 0,
+            updatedAt: Date.now(),
+        };
+        this.nodes.push(fileNode);
+        return fileNode;
+    }
+    /** 行末の `;` コメントを除去(asm のオペランドに `;` は出ない)。 */
+    stripComment(line) {
+        const idx = line.indexOf(';');
+        return idx < 0 ? line : line.slice(0, idx);
+    }
+    addNode(name, kind, lineNum, line, signature) {
+        const nodeId = (0, tree_sitter_helpers_1.generateNodeId)(this.filePath, kind, name, lineNum);
+        const node = {
+            id: nodeId,
+            kind,
+            name,
+            qualifiedName: `${this.filePath}#${name}`,
+            filePath: this.filePath,
+            language: 'assembly',
+            startLine: lineNum,
+            endLine: lineNum,
+            startColumn: 0,
+            endColumn: line.length,
+            updatedAt: Date.now(),
+        };
+        if (signature)
+            node.signature = signature;
+        this.nodes.push(node);
+        return node;
+    }
+    addRef(fromNodeId, name, kind, lineNum) {
+        this.unresolvedReferences.push({
+            fromNodeId,
+            referenceName: name,
+            referenceKind: kind,
+            line: lineNum,
+            column: 0,
+        });
+    }
+    /** オペランド式の中のシンボルらしいトークンごとに `references` を張る。 */
+    emitOperandRefs(fromNodeId, operand, lineNum, skipFirst) {
+        // 数値リテラルを落とし、$FF→"FF" のような桁文字が漏れないようにする。
+        const cleaned = operand
+            .replace(/\$[0-9A-Fa-f]+/g, ' ')
+            .replace(/%[01]+/g, ' ')
+            .replace(/'./g, ' ');
+        let first = true;
+        const seen = new Set();
+        let m;
+        SYMBOL_RE.lastIndex = 0;
+        while ((m = SYMBOL_RE.exec(cleaned)) !== null) {
+            const tok = m[0];
+            if (skipFirst && first) {
+                first = false;
+                continue;
+            }
+            first = false;
+            if (REGISTERS.has(tok.toLowerCase()))
+                continue;
+            if (seen.has(tok))
+                continue;
+            seen.add(tok);
+            this.addRef(fromNodeId, tok, 'references', lineNum);
+        }
+    }
+    parse(fileNodeId) {
+        const lines = this.source.split('\n');
+        let nearestLabel = null; // 直近のラベルノード(endLine 補正用)
+        let currentEntry = fileNodeId; // 直近の「入口」ラベル — 参照/呼出の帰属先
+        let prevCode = ''; // 直前の非空・非コメント行
+        for (let i = 0; i < lines.length; i++) {
+            const raw = lines[i];
+            const lineNum = i + 1;
+            const trimmedStart = raw.trimStart();
+            if (trimmedStart.startsWith(';') || trimmedStart.startsWith('*'))
+                continue;
+            const line = this.stripComment(raw);
+            if (line.trim() === '')
+                continue;
+            let rest = line;
+            // --- ラベル定義(行頭・末尾コロン) ---
+            const labelMatch = line.match(LABEL_RE);
+            if (labelMatch) {
+                const name = labelMatch[1];
+                // 入口判定: 最初のラベル、またはフロー終端の直後。
+                const isEntry = !nearestLabel || TERMINATOR_RE.test(prevCode);
+                const kind = isEntry ? 'function' : 'label';
+                if (nearestLabel)
+                    nearestLabel.endLine = lineNum - 1;
+                const node = this.addNode(name, kind, lineNum, line);
+                nearestLabel = node;
+                this.edges.push({ source: fileNodeId, target: node.id, kind: 'contains' });
+                if (isEntry)
+                    currentEntry = node.id;
+                rest = line.slice(labelMatch[0].length);
+            }
+            else {
+                // --- `NAME equ <expr>` 定数 ---
+                const equMatch = line.match(EQU_RE);
+                if (equMatch) {
+                    const name = equMatch[1];
+                    const expr = equMatch[2].trim();
+                    const node = this.addNode(name, 'constant', lineNum, line, `equ ${expr}`);
+                    this.edges.push({ source: fileNodeId, target: node.id, kind: 'contains' });
+                    // 右辺シンボル → 定数依存グラフ。
+                    this.emitOperandRefs(node.id, expr, lineNum, false);
+                    prevCode = line;
+                    continue;
+                }
+            }
+            prevCode = line;
+            const trimmed = rest.trim();
+            if (trimmed === '')
+                continue;
+            // --- include ディレクティブ ---
+            const incMatch = trimmed.match(/^include\s+["']([^"']+)["']/i);
+            if (incMatch) {
+                const base = incMatch[1].split('/').pop() || incMatch[1];
+                this.addRef(fileNodeId, base, 'references', lineNum);
+                continue;
+            }
+            // ニーモニック + オペランドに分割。
+            const opMatch = trimmed.match(/^([A-Za-z_.][A-Za-z0-9_.$]*)\s*(.*)$/);
+            if (!opMatch)
+                continue;
+            const mnem = opMatch[1].toLowerCase();
+            const operand = opMatch[2];
+            if (CALL_OPS.has(mnem)) {
+                // jsr/bsr → 呼出先(最初のオペランドシンボル)への calls エッジ。
+                const t = operand.match(SYMBOL_RE);
+                if (t && t.length)
+                    this.addRef(currentEntry, t[0], 'calls', lineNum);
+            }
+            else if (mnem === 'jmp') {
+                const t = operand.match(SYMBOL_RE);
+                if (t && t.length)
+                    this.addRef(currentEntry, t[0], 'references', lineNum);
+            }
+            else if (BRANCH_OPS.has(mnem)) {
+                // 局所制御フロー — 意図的に無視。
+            }
+            else {
+                // データ/算術命令: オペランドの全シンボルをデータ参照とする。
+                this.emitOperandRefs(currentEntry, operand, lineNum, false);
+            }
+        }
+        if (nearestLabel)
+            nearestLabel.endLine = lines.length;
+    }
+}
+exports.AsmExtractor = AsmExtractor;

--- a/tools/lst_analyze.py
+++ b/tools/lst_analyze.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""構成正確な無駄削減解析 — ASL のアセンブルリスト(.lst)ベース。
+
+ソース索引(構造地図)は生ソースの和集合しか見ない(条件アセンブリ/マクロを
+評価しない)。一方 ASL の .lst 末尾シンボルテーブルは「その構成で実際に
+アセンブルされた結果」を持ち、未使用シンボルを `*` で印字する。これを
+構成正確な無駄削減判断の土台にする。
+
+flag: 'C' = コード(ラベル) / '-' = 値(equ 等)
+
+使い方:
+    python3 tools/lst_analyze.py [構成名]   # 既定 sbcio-sdfs
+"""
+import re
+import sqlite3
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CELL = re.compile(r"^\s*(\*?)\s*([A-Za-z_.][A-Za-z0-9_.$]*)\s*:\s+(.+?)\s+([C-])\s*$")
+
+
+def our_symbols():
+    """ソース索引DB(あれば)から自前 asm シンボル名集合を得る(組込み除去用)。
+
+    DBが無い場合は空集合を返し、全シンボルを対象にする。"""
+    db = ROOT / ".codegraph" / "codegraph.db"
+    if not db.exists():
+        return set()
+    con = sqlite3.connect(db)
+    try:
+        rows = con.execute(
+            "SELECT DISTINCT name FROM nodes WHERE language='assembly' "
+            "AND file_path NOT LIKE 'third_party/%'"
+        ).fetchall()
+    except sqlite3.Error:
+        return set()
+    finally:
+        con.close()
+    return {r[0] for r in rows}
+
+
+def parse_symbol_table(lst_path):
+    """{name: (value, flag, unused_bool)} を返す。"""
+    p = Path(lst_path)
+    if not p.exists():
+        return {}
+    text = p.read_text(errors="replace").splitlines()
+    start = next((i for i, l in enumerate(text) if "Symbol Table" in l), None)
+    if start is None:
+        return {}
+    syms = {}
+    for line in text[start + 1:]:
+        for cell in line.split("|"):
+            m = CELL.match(cell)
+            if not m:
+                continue
+            star, name, value, flag = m.groups()
+            syms[name] = (value.strip(), flag, star == "*")
+    return syms
+
+
+def in_scope(name, ours):
+    """自前シンボル集合が空(DBなし)なら全対象、あれば交差で組込みを除去。"""
+    return (not ours) or (name in ours)
+
+
+def report(lst_path, label, ours):
+    syms = parse_symbol_table(lst_path)
+    if not syms:
+        print(f"\n{'='*70}\n■ {label}  ({Path(lst_path).name})  — リストなし(スキップ)")
+        return {}
+    mine = {n: v for n, v in syms.items() if in_scope(n, ours)}
+    dead_code = sorted(n for n, (_, f, u) in mine.items() if u and f == "C")
+    dead_const = sorted(n for n, (_, f, u) in mine.items() if u and f == "-")
+    print(f"\n{'='*70}\n■ {label}  ({Path(lst_path).name})")
+    print(f"  対象シンボル {len(mine)} 個 / 全 {len(syms)} 個")
+    print(f"\n  ▼ 未使用コード(※フォールスルー/外部API入口を含む。要目視) {len(dead_code)} 件")
+    for n in dead_code:
+        print(f"      {n}  @{mine[n][0]}")
+    print(f"\n  ▼ 未使用定数(デッド equ 候補) {len(dead_const)} 件")
+    for n in dead_const:
+        print(f"      {n} = {mine[n][0]}")
+    return syms
+
+
+def dup_report(rom, sdfs, ours):
+    """main↔SDFS_ 対が、各バイナリで実際に live(コード・使用中)か。"""
+    print(f"\n{'='*70}\n■ 重複対の構成正確チェック(ROM vs SDFSモジュール)")
+    universe = set(rom) | set(sdfs) | ours
+    pairs = sorted(n for n in universe
+                   if not n.startswith("SDFS_") and f"SDFS_{n}" in universe)
+    both_live = []
+    for base in pairs:
+        r = rom.get(base)
+        s = sdfs.get(f"SDFS_{base}")
+        r_live = r and r[1] == "C" and not r[2]
+        s_live = s and s[1] == "C" and not s[2]
+        if r_live and s_live:
+            both_live.append(base)
+    print(f"  ソース上の対: {len(pairs)} 組")
+    print(f"  両バイナリに live(=実コード・使用中)で存在する真の重複: {len(both_live)} 組")
+    for b in both_live:
+        print(f"      {b}  (ROM @{rom[b][0]})  ↔  SDFS_{b}  (SDFS @{sdfs['SDFS_'+b][0]})")
+
+
+if __name__ == "__main__":
+    cfg = sys.argv[1] if len(sys.argv) > 1 else "sbcio-sdfs"
+    ours = our_symbols()
+    rom = report(ROOT / f"build/mc6800-monitor-{cfg}.lst", f"ROMモニタ [{cfg}]", ours)
+    sdfs = report(ROOT / f"build/SDFS-{cfg}.lst", f"SDFSモジュール [{cfg}]", ours)
+    report(ROOT / f"build/stage1-{cfg}.lst", f"stage1 [{cfg}]", ours)
+    if rom and sdfs:
+        dup_report(rom, sdfs, ours)


### PR DESCRIPTION
## 概要

親Issue #216(メモリマップ / SDFS常駐場所検討)の子Issue #219 として、SDFS常駐部のサイズ削減余地を調査し、検討資料と解析基盤を追加する。

## 調査結果

- ROMモニタ(`main.asm`)とSDFSモジュール(`sdfs68.asm`)で S-Record / Intel-HEX ローダが二重実装。構成正確(`.lst`)で **真の重複48ルーチン**。
- ソース上の `X`↔`SDFS_X` 76対のうち27対は ROM 側で条件除外(`MONITOR_FEATURE_FAT=0` 等)= **偽重複**。生ソース解析だけでは判別できず、`.lst` で切り分けた。
- ROM側ローダの公開API化でSDFS常駐部から数百バイト回収できる見込み(#216 の常駐サイズ評価に反映)。

## 追加・変更

- `docs/plans/issue-219_loader_dedup_asm_analysis.md` — 指摘表つき検討資料
- `tools/lst_analyze.py` — `.lst` ベースの構成別解析(未使用シンボル / 真の重複対)
- `tools/codegraph/` — asm拡張プラグインと適用手順の保全(構造地図用途)
- `AGENTS.md` — 親子Issue(sub-issue / GraphQL)と生成AI痕跡禁止の運用ルールを追記
- `docs/plans/issue-216_bank_memory_sdfs_resident.md` — 子Issue #219 への相互リンク

## 対応Issue

Refs #216
Refs #219

## 補足

本PRは検討・資料整備であり、ローダAPI化の実装は含まない(#219 で削減方式を選択後に別PR)。マージは人手で行う。
