### PR TITLE
build,docs: テスト実行手順を make test に整備し運用ルールを明記

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,18 @@ GitHub Project の「Linked pull requests」列でPRを取りこぼさず追跡�
 - コミットに `Co-Authored-By` の生成AI署名を付けない。PR本文に「Generated with ...」等のフッタを付けない。
 - 道具名(解析ツール等)を手段として記載するのは痕跡ではないので可。
 
+## テスト実行
+
+- コード変更後と PR 作成前は、**必ず全テストを実行する**。正規手順は `make test`(ビルド前提込みで全テストを実行)。
+- 手順の詳細は `docs/development/workflow.md` の「テスト方針」を参照。
+- テストは pytest ではなくスクリプト直実行。エミュテストは先に base profile をビルドしないと環境失敗する(`make test` が自動で満たす)。
+
+## 改行コードを変更しない
+
+- ファイルの既存の改行コードを変更しない(正規化しない)。`src/main.asm` は CRLF、その他は LF。
+- 編集ツールは保存時に CRLF→LF 正規化することがあるため、CRLF ファイルはバイト保持の方法で編集する。
+- コミット前に `git diff --numstat` と `git diff --ignore-all-space --numstat` が一致することを確認する(乖離=改行コードが壊れた合図)。
+
 このリポジトリで Codex が作業する際のローカル運用ルールを定義する。
 
 ## 言語

--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ endif
 
 ASL_INCLUDE := $(CURDIR)/$(OUTDIR)$(ASL_PATHSEP)$(CURDIR)/include$(ASL_PATHSEP)$(CURDIR)/src
 
-.PHONY: all clean bin check-rom-size srec ihex stage1 sdfs sdfs-tools sdfs-tools-srec sdfs-tools-com check-stage1-config rombin rombin-27c64 rombin-27c128 rombin-27c256 rombin-28c256 rombin-w27c512 program verify readback program-27c64 program-27c128 program-27c256 program-28c256 program-w27c512 program-upd28c256 FORCE
+.PHONY: all clean bin test check-rom-size srec ihex stage1 sdfs sdfs-tools sdfs-tools-srec sdfs-tools-com check-stage1-config rombin rombin-27c64 rombin-27c128 rombin-27c256 rombin-28c256 rombin-w27c512 program verify readback program-27c64 program-27c128 program-27c256 program-28c256 program-w27c512 program-upd28c256 FORCE
 
 all: check-rom-size srec ihex
 
@@ -251,6 +251,19 @@ $(BIN): $(OBJ)
 
 check-rom-size: $(BIN)
 	"$(PYTHON)" -c "from pathlib import Path; import sys; p=Path('$(BIN)'); size=p.stat().st_size; limit=int('$(ROM_CODE_LIMIT)', 0); print(f'{p}: {size}/{limit} bytes'); sys.exit(0 if limit <= 0 or size <= limit else 1)"
+
+# 全テストをビルド前提込みで実行する(CI windows-emu.yml と同等)。
+# エミュテストは最新ビルドのROM/listを使うため base と sbcio を先にビルドする。
+test:
+	$(MAKE) bin MONITOR_PROFILE=base
+	$(MAKE) bin MONITOR_PROFILE=sbcio
+	REQUIRE_BUILD_ROM=1 "$(PYTHON)" tests/test_smoke.py
+	REQUIRE_BUILD_ROM=1 "$(PYTHON)" tests/test_sd_fixture.py
+	REQUIRE_BUILD_ROM=1 MONITOR_PROFILE=sbcio MONITOR_ROM_PATH=$(OUTDIR)/mc6800-monitor-sbcio.bin MONITOR_LST_PATH=$(OUTDIR)/mc6800-monitor-sbcio.lst "$(PYTHON)" tests/test_smoke.py
+	REQUIRE_BUILD_ROM=1 MONITOR_PROFILE=sbcio MONITOR_ROM_PATH=$(OUTDIR)/mc6800-monitor-sbcio.bin MONITOR_LST_PATH=$(OUTDIR)/mc6800-monitor-sbcio.lst "$(PYTHON)" tests/test_sd_fixture.py
+	"$(PYTHON)" tests/test_sdfs68_build.py
+	"$(PYTHON)" tests/test_stage1_build.py
+	"$(PYTHON)" tests/test_mk_sdfs_image.py
 
 stage1: check-stage1-config $(STAGE1_BIN)
 

--- a/docs/development/workflow.md
+++ b/docs/development/workflow.md
@@ -83,13 +83,24 @@ PR 作成前に、差分へ不要ファイルが入っていないことを確�
 
 ## テスト方針
 
-PR 作成前に、原則として次を実行する。
+コード変更後と PR 作成前は、**必ず全テストを実行する**。一発で済む正規手順は `make test`。
 
-```powershell
-make bin
-$env:REQUIRE_BUILD_ROM='1'
-python tests/test_smoke.py
+```sh
+make test
 ```
+
+`make test` は次をまとめて行う(CI `.github/workflows/windows-emu.yml` と同等)。
+
+- 前提ROMを先にビルド: `make bin MONITOR_PROFILE=base` と `make bin MONITOR_PROFILE=sbcio`
+- エミュレータテスト(`REQUIRE_BUILD_ROM=1`、base と sbcio 両構成): `tests/test_smoke.py` / `tests/test_sd_fixture.py`
+- ビルド系テスト: `tests/test_sdfs68_build.py` / `tests/test_stage1_build.py` / `tests/test_mk_sdfs_image.py`
+
+注意点:
+
+- テストは pytest ではなく**スクリプト直実行**(各 `tests/test_*.py` を `python3` で実行)。
+- エミュテストは最新ビルドのROM/listを使うため、**先に base profile をビルドしないと**「build output missing」で**環境失敗**する(回帰ではない)。`make test` はこれを自動で満たす。
+- 個別実行例: `REQUIRE_BUILD_ROM=1 python3 tests/test_smoke.py`(事前に `make bin` 必須)。
+- Windows は `make` を使わず CI と同じ PowerShell 手順(`$env:REQUIRE_BUILD_ROM='1'` など)でもよい。
 
 実装で既存 smoke test にない振る舞いを追加・変更した場合は、対応するテストを追加する。
 


### PR DESCRIPTION
## 概要

テスト実行手順が CI にしか整備されておらず、ローカルで全テストを正しく回す手順が分かりにくかった(base profile 未ビルドで環境失敗する罠もあった)。`make test` 一発で回せるよう整備し、運用ルールを明記する。

## 変更

- `Makefile`:`make test` を新設(`make bin`(base/sbcio)→ `REQUIRE_BUILD_ROM=1` でエミュテスト2構成 + ビルド系テスト。CI `windows-emu.yml` と同等)
- `docs/development/workflow.md`:「テスト方針」を `make test` 中心に充実(全テストファイル、base+sbcio前提、pytest不使用、環境失敗の罠)
- `AGENTS.md`:「テスト実行(必ず `make test`)」と「改行コードを変更しない」を追記

## 検証

- `make test` 実行:`test_smoke` 37/0(base・sbcio)、`test_sd_fixture` 10/0(base・sbcio)、`test_sdfs68_build` 25/0、`test_stage1_build` 14/0、`test_mk_sdfs_image` 7/0 — **全パス**
- 変更3ファイルとも改行コード無変更(`git diff --numstat` == `--ignore-all-space`)

## 対応Issue

Closes #228
