### PR TITLE
fix: VDG_PUTCの表示スキップ時にVRAMを触らないよう早期return追加

### DIFF
--- a/src/main.asm
+++ b/src/main.asm
@@ -1387,6 +1387,16 @@ VDG_CLEAR_DONE:
         rts
 
 VDG_PUTC:
+        cmpa    #CHR_LF
+        beq     VDG_PUTC_ENTER
+        cmpa    #CHR_CR
+        beq     VDG_PUTC_ENTER
+        cmpa    #CHR_BS
+        beq     VDG_PUTC_ENTER
+        cmpa    #CHR_SPACE
+        bhs     VDG_PUTC_ENTER
+        rts
+VDG_PUTC_ENTER:
         psha
         pshb
         stx     VDG_SAVE_X
@@ -1401,8 +1411,6 @@ VDG_PUTC:
         beq     VDG_PUTC_BS
         cmpa    #CHR_DEL
         beq     VDG_PUTC_BS
-        cmpa    #CHR_SPACE
-        blo     VDG_PUTC_DONE
         clr     VDG_LAST_CR
         jsr     VDG_ASCII_TO_CHAR
         ldx     VDG_CURSOR


### PR DESCRIPTION
## Summary

- `VDG_PUTC` 冒頭に文字クラス早期フィルタを追加し、扱えない制御文字は VRAM に一切触らず即 `rts` で戻すよう修正
- フィルタ通過後は必ず表示可能文字となるため、旧 `cmpa #CHR_SPACE / blo VDG_PUTC_DONE` のデッドコードを削除

## 背景と機序

`k6802_vdg` (K6802-SBC + K68-VDG, VRAM `$C000-$DFFF`) profile で、SDFS/68 の入力プロンプト `SDFS> ` の待機中に VDG 画面へ継続的なノイズが乗る現象があった。
ROM モニタの `] ` 待機中には出ず、`DIR` などディスクアクセス中は止まる。

原因:

1. `MIKBUG_INEEE_IMPL` (`src/acia6850.asm:102-108`) は BASIC 互換入口として、受信バイトを LF 以外すべて `MIKBUG_OUTEEE_IMPL` → `VDG_PUTC` へ echo する。
2. `VDG_PUTC` (`src/main.asm:1389-1443`) は入口で無条件に `VDG_UNDRAW_CURSOR` を実行し、末尾で `VDG_DRAW_CURSOR` を実行する。表示スキップ対象の制御文字 (`$00-$07, $09, $0B, $0C, $0E-$1F`) でも、UNDRAW + DRAW のカーソル書換で VRAM を 3 アクセスしていた。
3. ACIA1/ACIA2 に何かスプリアスバイト (フレーミングエラー由来 NUL、ACIA2 未接続 floating 由来のゴミ等) が入るたび、`VDG_PUTC` が VRAM を叩き、K68-VDG のバス調停と競合してノイズが可視化する。

ROM の `READ_LINE_LOOP` (`src/main.asm:1759-1782`) は `CONSOLE_GETC` を直接呼び、`cmpa #CHR_SPACE / blo READ_LINE_LOOP` で echo する前に制御文字を捨てるためこの副作用を受けない。
`DIR` 実行中は CPU が `sdcard.asm` の SPI ビットバングと FAT ウォークに専念して `CONSOLE_GETC` を呼ばないため、受信バイトが echo されずノイズが止まる。

## 実機切り分け結果

`k6802_vdg` ROM 実機で `M` + `G` による 4 テスト:

- Test A: `$0100` / `$A000` に `20 FE` (`BRA *`) — どちらもクリーン。実行アドレスによる競合ではない。
- Test B: `$0100` から `B6 A0 00 20 FB` (`LDAA $A000; BRA *-3`) — クリーン。`$A000-$BFFF` へのデータアクセスも競合しない。
- Test C: `$0100` から `B6 C0 00 20 FB` (`LDAA $C000; BRA *-3`) — ノイズ発生。VRAM read は HS/FS 非同期で必ず競合する。
- Test D: `$0100` から `BD E0 78 20 FB` (`JSR MIKBUG_INCH; BRA *-3`) — SDFS/68 プロンプト待ちと同じノイズを再現。MIKBUG_INCH 経由の echo が真犯人。

## 変更内容

`src/main.asm` の `VDG_PUTC` のみ変更。

早期フィルタ (追加 +17 byte):

```
VDG_PUTC:
        cmpa    #CHR_LF
        beq     VDG_PUTC_ENTER
        cmpa    #CHR_CR
        beq     VDG_PUTC_ENTER
        cmpa    #CHR_BS
        beq     VDG_PUTC_ENTER
        cmpa    #CHR_SPACE
        bhs     VDG_PUTC_ENTER
        rts
VDG_PUTC_ENTER:
        psha
        ...
```

DEL (`$7F`) は `bhs #CHR_SPACE` の側で拾われるため、早期フィルタ側に明示 DEL 分岐は置いていない (DEL の本体処理は既存分岐で継続)。

デッドコード削除 (-4 byte):

```
-        cmpa    #CHR_SPACE
-        blo     VDG_PUTC_DONE
```

正味 +13 byte。ROM サイズ影響:

- `k6802_vdg`: 8075/8192 byte (変化なし ※境界に達していないため)
- `sbcio_vdg`: 8075/8192 byte
- `sbcio` / `base`: 8075/8192 byte (`FEATURE_VDG=0` のため実質不変)

## 影響範囲

- SDFS/68 プロンプト待ちのノイズ解消
- BASIC 移植 5 系列 (Uiterwyk / Dendai / Micro / Altair680 / BASIC-68) の入力待ちも同経路のため同時に副作用が消える
- 表示可能文字集合 (`$20-$7F` + CR/LF/BS/DEL) は不変
- `VDG_PUTC` は元々制御文字を VRAM に書けない実装なので、外部仕様の欠落はなし
- 任意バイトを VRAM に置きたい用途 (`diagnostics/VDGA000.S` 等) は元から VRAM 直接書きなので影響なし

## Test plan

- [x] `make test` (base + sbcio ビルド前提で全 smoke)
- [x] `MONITOR_PROFILE=k6802_vdg make bin` (8192 byte 以内)
- [x] `MONITOR_PROFILE=sbcio_vdg make bin` (8192 byte 以内)
- [x] `git diff --numstat` == `git diff --ignore-all-space --numstat` (改行コード保持)
- [ ] 実機 `k6802_vdg` ROM 焼き直しで SDFS/68 プロンプト待ちが無音化することを確認
- [ ] 実機で Test D (`$0100: BD E0 78 20 FB`; `G0100`) が無音化することを確認
- [ ] 実機で `DIR` / `LOAD` / `RUN` / `EXIT` が既存通り動作
- [ ] 実機で BASIC 系 (`RUN BASIC.S` 等) の入力待ちが無音であることを確認

## 別途課題

ACIA 側で実際にスプリアスバイトが発生している要因 (ACIA2 未接続 floating、フレーミングエラー、端末側の初期化バイト) の追跡は別 Issue で扱う。

Closes #241
