### PR TITLE
feat: stage1 streaming API + cluster >= 64 対応 (#243/#247)

### DIFF
--- a/emu/sbc6800_emu.py
+++ b/emu/sbc6800_emu.py
@@ -1117,9 +1117,27 @@ class MC6800:
             self.a = result & 0xFF
             self.update_nz(self.a)
 
+        elif opcode == 0x89:  # ADCA #imm
+            val = self.addr_imm8()
+            carry_in = 1 if self.cc_c else 0
+            result = self.a + val + carry_in
+            self.cc_c = result > 0xFF
+            self.cc_v = bool((~(self.a ^ val) & (self.a ^ result)) & 0x80)
+            self.a = result & 0xFF
+            self.update_nz(self.a)
+
         elif opcode == 0x80:  # SUBA #imm
             val = self.addr_imm8()
             result = self.a - val
+            self.cc_c = result < 0
+            self.cc_v = bool(((self.a ^ val) & (self.a ^ result)) & 0x80)
+            self.a = result & 0xFF
+            self.update_nz(self.a)
+
+        elif opcode == 0x82:  # SBCA #imm
+            val = self.addr_imm8()
+            carry_in = 1 if self.cc_c else 0
+            result = self.a - val - carry_in
             self.cc_c = result < 0
             self.cc_v = bool(((self.a ^ val) & (self.a ^ result)) & 0x80)
             self.a = result & 0xFF
@@ -1170,10 +1188,30 @@ class MC6800:
             self.a = result & 0xFF
             self.update_nz(self.a)
 
+        elif opcode == 0x99:  # ADCA direct
+            addr = self.addr_direct()
+            val = self.read(addr)
+            carry_in = 1 if self.cc_c else 0
+            result = self.a + val + carry_in
+            self.cc_c = result > 0xFF
+            self.cc_v = bool((~(self.a ^ val) & (self.a ^ result)) & 0x80)
+            self.a = result & 0xFF
+            self.update_nz(self.a)
+
         elif opcode == 0x90:  # SUBA direct
             addr = self.addr_direct()
             val = self.read(addr)
             result = self.a - val
+            self.cc_c = result < 0
+            self.cc_v = bool(((self.a ^ val) & (self.a ^ result)) & 0x80)
+            self.a = result & 0xFF
+            self.update_nz(self.a)
+
+        elif opcode == 0x92:  # SBCA direct
+            addr = self.addr_direct()
+            val = self.read(addr)
+            carry_in = 1 if self.cc_c else 0
+            result = self.a - val - carry_in
             self.cc_c = result < 0
             self.cc_v = bool(((self.a ^ val) & (self.a ^ result)) & 0x80)
             self.a = result & 0xFF
@@ -1228,10 +1266,30 @@ class MC6800:
             self.a = result & 0xFF
             self.update_nz(self.a)
 
+        elif opcode == 0xA9:  # ADCA indexed
+            addr = self.addr_indexed()
+            val = self.read(addr)
+            carry_in = 1 if self.cc_c else 0
+            result = self.a + val + carry_in
+            self.cc_c = result > 0xFF
+            self.cc_v = bool((~(self.a ^ val) & (self.a ^ result)) & 0x80)
+            self.a = result & 0xFF
+            self.update_nz(self.a)
+
         elif opcode == 0xA0:  # SUBA indexed
             addr = self.addr_indexed()
             val = self.read(addr)
             result = self.a - val
+            self.cc_c = result < 0
+            self.cc_v = bool(((self.a ^ val) & (self.a ^ result)) & 0x80)
+            self.a = result & 0xFF
+            self.update_nz(self.a)
+
+        elif opcode == 0xA2:  # SBCA indexed
+            addr = self.addr_indexed()
+            val = self.read(addr)
+            carry_in = 1 if self.cc_c else 0
+            result = self.a - val - carry_in
             self.cc_c = result < 0
             self.cc_v = bool(((self.a ^ val) & (self.a ^ result)) & 0x80)
             self.a = result & 0xFF
@@ -1286,10 +1344,30 @@ class MC6800:
             self.a = result & 0xFF
             self.update_nz(self.a)
 
+        elif opcode == 0xB9:  # ADCA extended
+            addr = self.addr_extended()
+            val = self.read(addr)
+            carry_in = 1 if self.cc_c else 0
+            result = self.a + val + carry_in
+            self.cc_c = result > 0xFF
+            self.cc_v = bool((~(self.a ^ val) & (self.a ^ result)) & 0x80)
+            self.a = result & 0xFF
+            self.update_nz(self.a)
+
         elif opcode == 0xB0:  # SUBA extended
             addr = self.addr_extended()
             val = self.read(addr)
             result = self.a - val
+            self.cc_c = result < 0
+            self.cc_v = bool(((self.a ^ val) & (self.a ^ result)) & 0x80)
+            self.a = result & 0xFF
+            self.update_nz(self.a)
+
+        elif opcode == 0xB2:  # SBCA extended
+            addr = self.addr_extended()
+            val = self.read(addr)
+            carry_in = 1 if self.cc_c else 0
+            result = self.a - val - carry_in
             self.cc_c = result < 0
             self.cc_v = bool(((self.a ^ val) & (self.a ^ result)) & 0x80)
             self.a = result & 0xFF
@@ -1342,9 +1420,27 @@ class MC6800:
             self.b = result & 0xFF
             self.update_nz(self.b)
 
+        elif opcode == 0xC9:  # ADCB #imm
+            val = self.addr_imm8()
+            carry_in = 1 if self.cc_c else 0
+            result = self.b + val + carry_in
+            self.cc_c = result > 0xFF
+            self.cc_v = bool((~(self.b ^ val) & (self.b ^ result)) & 0x80)
+            self.b = result & 0xFF
+            self.update_nz(self.b)
+
         elif opcode == 0xC0:  # SUBB #imm
             val = self.addr_imm8()
             result = self.b - val
+            self.cc_c = result < 0
+            self.cc_v = bool(((self.b ^ val) & (self.b ^ result)) & 0x80)
+            self.b = result & 0xFF
+            self.update_nz(self.b)
+
+        elif opcode == 0xC2:  # SBCB #imm
+            val = self.addr_imm8()
+            carry_in = 1 if self.cc_c else 0
+            result = self.b - val - carry_in
             self.cc_c = result < 0
             self.cc_v = bool(((self.b ^ val) & (self.b ^ result)) & 0x80)
             self.b = result & 0xFF
@@ -1616,6 +1712,36 @@ class MC6800:
             self.b = result & 0xFF
             self.update_nz(self.b)
 
+        elif opcode == 0xD9:  # ADCB direct
+            addr = self.addr_direct()
+            val = self.read(addr)
+            carry_in = 1 if self.cc_c else 0
+            result = self.b + val + carry_in
+            self.cc_c = result > 0xFF
+            self.cc_v = bool((~(self.b ^ val) & (self.b ^ result)) & 0x80)
+            self.b = result & 0xFF
+            self.update_nz(self.b)
+
+        elif opcode == 0xE9:  # ADCB indexed
+            addr = self.addr_indexed()
+            val = self.read(addr)
+            carry_in = 1 if self.cc_c else 0
+            result = self.b + val + carry_in
+            self.cc_c = result > 0xFF
+            self.cc_v = bool((~(self.b ^ val) & (self.b ^ result)) & 0x80)
+            self.b = result & 0xFF
+            self.update_nz(self.b)
+
+        elif opcode == 0xF9:  # ADCB extended
+            addr = self.addr_extended()
+            val = self.read(addr)
+            carry_in = 1 if self.cc_c else 0
+            result = self.b + val + carry_in
+            self.cc_c = result > 0xFF
+            self.cc_v = bool((~(self.b ^ val) & (self.b ^ result)) & 0x80)
+            self.b = result & 0xFF
+            self.update_nz(self.b)
+
         elif opcode == 0xD0:  # SUBB direct
             addr = self.addr_direct()
             val = self.read(addr)
@@ -1638,6 +1764,36 @@ class MC6800:
             addr = self.addr_extended()
             val = self.read(addr)
             result = self.b - val
+            self.cc_c = result < 0
+            self.cc_v = bool(((self.b ^ val) & (self.b ^ result)) & 0x80)
+            self.b = result & 0xFF
+            self.update_nz(self.b)
+
+        elif opcode == 0xD2:  # SBCB direct
+            addr = self.addr_direct()
+            val = self.read(addr)
+            carry_in = 1 if self.cc_c else 0
+            result = self.b - val - carry_in
+            self.cc_c = result < 0
+            self.cc_v = bool(((self.b ^ val) & (self.b ^ result)) & 0x80)
+            self.b = result & 0xFF
+            self.update_nz(self.b)
+
+        elif opcode == 0xE2:  # SBCB indexed
+            addr = self.addr_indexed()
+            val = self.read(addr)
+            carry_in = 1 if self.cc_c else 0
+            result = self.b - val - carry_in
+            self.cc_c = result < 0
+            self.cc_v = bool(((self.b ^ val) & (self.b ^ result)) & 0x80)
+            self.b = result & 0xFF
+            self.update_nz(self.b)
+
+        elif opcode == 0xF2:  # SBCB extended
+            addr = self.addr_extended()
+            val = self.read(addr)
+            carry_in = 1 if self.cc_c else 0
+            result = self.b - val - carry_in
             self.cc_c = result < 0
             self.cc_v = bool(((self.b ^ val) & (self.b ^ result)) & 0x80)
             self.b = result & 0xFF

--- a/src/fat32.asm
+++ b/src/fat32.asm
@@ -638,6 +638,12 @@ FAT_STORE_FILE_ENTRY:
         rts
 
 FAT_CLUSTER_TO_SD_LBA:
+        ldaa    FAT_CUR_CLUS0
+        oraa    FAT_CUR_CLUS1
+        beq     FAT_CLUS_TO_LBA_16
+        ldaa    #FAT_ERR_CHAIN
+        jmp     FAT_FAIL_A
+FAT_CLUS_TO_LBA_16:
         ldaa    FAT_DATA_LBA0
         staa    SD_LBA0
         ldaa    FAT_DATA_LBA1
@@ -648,16 +654,21 @@ FAT_CLUSTER_TO_SD_LBA:
         staa    SD_LBA3
         ldaa    FAT_CUR_CLUS3
         suba    #$02
+        staa    FAT_DIR_COUNT
+        ldaa    FAT_CUR_CLUS2
+        sbca    #0
         staa    FAT_TMP
 FAT_CLUSTER_ADD_LOOP:
-        ldaa    FAT_TMP
+        ldx     FAT_TMP
         beq     FAT_CLUSTER_ADD_DONE
         ldab    FAT_SEC_PER_CLUS
 FAT_CLUSTER_ADD_SECTOR_LOOP:
         jsr     FAT_INC_SD_LBA
         decb
         bne     FAT_CLUSTER_ADD_SECTOR_LOOP
-        dec     FAT_TMP
+        ldx     FAT_TMP
+        dex
+        stx     FAT_TMP
         bra     FAT_CLUSTER_ADD_LOOP
 FAT_CLUSTER_ADD_DONE:
         rts
@@ -687,14 +698,32 @@ FAT_INC_SD_LBA_DONE:
         rts
 
 FAT32_NEXT_CLUSTER:
-        ldaa    FAT_FAT_LBA0
-        staa    SD_LBA0
-        ldaa    FAT_FAT_LBA1
-        staa    SD_LBA1
-        ldaa    FAT_FAT_LBA2
-        staa    SD_LBA2
+        ldaa    FAT_CUR_CLUS0
+        oraa    FAT_CUR_CLUS1
+        beq     FAT_NEXT_CLUS_OK
+        ldaa    #FAT_ERR_CHAIN
+        jmp     FAT_FAIL_A
+FAT_NEXT_CLUS_OK:
+        ldaa    FAT_CUR_CLUS3
+        rola
+        ldaa    FAT_CUR_CLUS2
+        rola
+        staa    FAT_DIR_COUNT
+        ldaa    #0
+        adca    #0
+        staa    FAT_TMP
         ldaa    FAT_FAT_LBA3
+        adda    FAT_DIR_COUNT
         staa    SD_LBA3
+        ldaa    FAT_FAT_LBA2
+        adca    FAT_TMP
+        staa    SD_LBA2
+        ldaa    FAT_FAT_LBA1
+        adca    #0
+        staa    SD_LBA1
+        ldaa    FAT_FAT_LBA0
+        adca    #0
+        staa    SD_LBA0
         ldx     #SD_SECTOR_BUF
         jsr     SD_READ_SECTOR
         bcc     FAT_NEXT_OFFSET_PREP
@@ -702,14 +731,15 @@ FAT32_NEXT_CLUSTER:
         jmp     FAT_FAIL_A
 
 FAT_NEXT_OFFSET_PREP:
-        ldaa    FAT_CUR_CLUS3
-        asla
-        asla
-        tab
         ldx     #SD_SECTOR_BUF
+        ldab    FAT_CUR_CLUS3
+        andb    #$7F
 FAT_NEXT_OFFSET_LOOP:
         tstb
         beq     FAT_NEXT_READ
+        inx
+        inx
+        inx
         inx
         decb
         bra     FAT_NEXT_OFFSET_LOOP

--- a/src/stage1.asm
+++ b/src/stage1.asm
@@ -3,7 +3,7 @@
         include "../include/hardware.inc"
 
 S1_API_VERSION  equ 1
-S1_API_COUNT    equ 6
+S1_API_COUNT    equ 9
 S1_FLAG_NONE    equ 0
 S1_ERR_NONE     equ 0
 S1_ERR_UNIMPL   equ 1
@@ -35,6 +35,9 @@ S1_JUMP_TABLE:
         jmp     S1_FIND_83
         jmp     S1_LOAD_FILE_83
         jmp     S1_GET_ERROR
+        jmp     S1_STREAM_OPEN
+        jmp     S1_STREAM_GETC
+        jmp     S1_STREAM_BYTES_REMAIN
 
 S1_INIT:
         clr     FAT_ERROR
@@ -158,6 +161,15 @@ S1_GET_ERROR:
 S1_GET_ERROR_DONE:
         clc
         rts
+
+S1_STREAM_OPEN:
+        jmp     FAT32_STREAM_OPEN
+
+S1_STREAM_GETC:
+        jmp     FAT32_STREAM_GETC
+
+S1_STREAM_BYTES_REMAIN:
+        jmp     FAT_BYTES_REMAIN
 
 S1_SDFS_NAME:
         fcc     "SDFS    BIN"

--- a/tests/test_stage1_build.py
+++ b/tests/test_stage1_build.py
@@ -109,6 +109,9 @@ def test_stage1_profiles_build_and_match_layout() -> None:
             "S1_FIND_83",
             "S1_LOAD_FILE_83",
             "S1_GET_ERROR",
+            "S1_STREAM_OPEN",
+            "S1_STREAM_GETC",
+            "S1_STREAM_BYTES_REMAIN",
             "S1_BOOT_SDFS",
             "S1_END",
         )
@@ -128,6 +131,9 @@ def test_stage1_profiles_build_and_match_layout() -> None:
         _assert_jump(data, 25, symbols["S1_FIND_83"])
         _assert_jump(data, 28, symbols["S1_LOAD_FILE_83"])
         _assert_jump(data, 31, symbols["S1_GET_ERROR"])
+        _assert_jump(data, 34, symbols["S1_STREAM_OPEN"])
+        _assert_jump(data, 37, symbols["S1_STREAM_GETC"])
+        _assert_jump(data, 40, symbols["S1_STREAM_BYTES_REMAIN"])
     print("[PASS] test_stage1_profiles_build_and_match_layout")
 
 
@@ -304,7 +310,7 @@ def test_stage1_boot_sdfs_rejects_invalid_headers() -> None:
 def _assert_stage1_header(data: bytes, boot_entry: int) -> None:
     assert data[0:7] == b"S1API68"
     assert data[7] == 1, "API version mismatch"
-    assert data[8] == 6, "API count mismatch"
+    assert data[8] == 9, "API count mismatch"
     assert data[9] == 0, "flags mismatch"
     actual_boot_entry = (data[10] << 8) | data[11]
     assert actual_boot_entry == boot_entry, "boot entry mismatch"


### PR DESCRIPTION
## Summary

- \`src/stage1.asm\`: streaming primitives 3 API を jump table に追加、S1_API_COUNT を 6 → 9(非破壊拡張、VERSION 据置)
- \`src/fat32.asm\`: \`FAT32_NEXT_CLUSTER\` を cluster ≥ 64 対応 & 16-bit cluster 対応、\`FAT_CLUSTER_TO_SD_LBA\` も 16-bit cluster 対応
- \`emu/sbc6800_emu.py\`: ADCA/SBCA/ADCB/SBCB を全 addressing mode で追加
- \`tests/test_stage1_build.py\`: S1_API_COUNT 期待値と新 jump slot の assertion 追加

## 修正した bug

**#243** — \`FAT32_NEXT_CLUSTER\` が cluster >= 64 で誤動作。以下 2 点:
1. FAT sector を常に FAT_FAT_LBA 固定で読んでいた → \`FAT_FAT_LBA + (cluster >> 7)\` に
2. sector 内 byte offset を \`cluster_lo * 4\` (8bit wrap) で計算 → \`(cluster & 0x7F) * 4\` の 9-bit 値に

\`FAT_CLUSTER_TO_SD_LBA\` も同種修正。両関数とも cluster > 65535 は FAT_ERR_CHAIN で reject。

## サイズ影響

stage1: 2514 B → 2600 B(+86 B、余り 472 B)。全 profile OK。

## エミュ opcode 追加

MC6800 標準命令 ADCA/SBCA/ADCB/SBCB を全 4 addressing mode 分追加(16 opcode)。プロジェクト原則「未実装 opcode は emu 側実装」に従う。

## テスト

- stage1 build: 14/14 pass
- smoke: 37/37 pass
- sd_fixture: 10/10 pass
- sdfs68 build: 25/25 pass
- emu 手動: fresh SD BOOT + DBS.COM READY 到達

高 cluster fixture テストは Step 4 (#249) 統合テストで追加予定。

## 注意

このブランチは #246 (#250) の設計 doc branch の上に派生している。#250 が merge されるまで、この PR の diff には設計 doc も含まれる。#250 merge 後に main へ rebase して doc 差分を除去する。

## Refs

Closes #243
Refs #245 #247