### PR TITLE
refactor: SDFS/68 FAT 重複コードを削除、stage1 API 経由に統一 (#248)

### DIFF
--- a/src/sdfs68.asm
+++ b/src/sdfs68.asm
@@ -5,7 +5,7 @@
 SDFS_FORMAT_VERSION equ 1
 SDFS_HDR_SIZE   equ 16
 SDFS_S1_VERSION equ 1
-SDFS_S1_COUNT   equ 6
+SDFS_S1_COUNT   equ 12
 SDFS_COM_LOAD_BASE equ $0100
 SDFS_COM_MAX_SIZE equ USER_RAM_END-SDFS_COM_LOAD_BASE+1
 SDFS_COM_MAX_HI equ SDFS_COM_MAX_SIZE/256
@@ -170,7 +170,7 @@ SDFS_K_LOAD_FILE:
         bcs     SDFS_CMD_LOAD_FAIL
         jsr     SDFS_RESOLVE_FILE_SAVED
         bcs     SDFS_CMD_LOAD_FAIL
-        jsr     SDFS_STREAM_OPEN
+        jsr     SDFS_API_STREAM_OPEN
         bcs     SDFS_CMD_LOAD_FAIL
 SDFS_LOAD_LOOP:
         jsr     SDFS_READ_LOADER_RECORD
@@ -314,7 +314,7 @@ SDFS_CMD_COM:
         bcs     SDFS_CMD_COM_FAIL
         jsr     SDFS_COM_CHECK_SIZE
         bcs     SDFS_CMD_COM_FAIL
-        jsr     SDFS_STREAM_OPEN
+        jsr     SDFS_API_STREAM_OPEN
         bcs     SDFS_CMD_COM_FAIL
         jsr     SDFS_COM_LOAD_RAW
         bcs     SDFS_CMD_COM_FAIL
@@ -354,9 +354,9 @@ SDFS_COM_LOAD_RAW:
         ldx     #SDFS_COM_LOAD_BASE
         stx     FAT_READ_PTR
 SDFS_COM_LOAD_LOOP:
-        jsr     SDFS_BYTES_REMAIN
+        jsr     SDFS_API_STREAM_BYTES_REMAIN
         bcc     SDFS_COM_LOAD_DONE
-        jsr     SDFS_STREAM_GETC
+        jsr     SDFS_API_STREAM_GETC
         bcs     SDFS_COM_LOAD_FAIL
         ldx     FAT_READ_PTR
         staa    0,x
@@ -404,7 +404,7 @@ SDFS_K_DIR_PATH:
         jsr     SDFS_RESOLVE_DIR_SAVED
         bcs     SDFS_K_DIR_FAIL
 SDFS_K_DIR_CLUSTER_LOOP:
-        jsr     SDFS_CLUSTER_TO_SD_LBA
+        jsr     SDFS_API_CLUSTER_TO_SD_LBA
         ldx     #SD_SECTOR_BUF
         jsr     SDFS_API_READ_SECTOR
         bcs     SDFS_K_DIR_FAIL
@@ -425,9 +425,9 @@ SDFS_K_DIR_NEXT_ENTRY:
         jsr     SDFS_K_ADVANCE_ENTRY_PTR
         dec     FAT_DIR_COUNT
         bne     SDFS_K_DIR_ENTRY_LOOP
-        jsr     SDFS_NEXT_CLUSTER
+        jsr     SDFS_API_NEXT_CLUSTER
         bcs     SDFS_K_DIR_DONE
-        jsr     SDFS_COPY_NEXT_TO_CUR
+        jsr     SDFS_API_COPY_NEXT_TO_CUR
         bra     SDFS_K_DIR_CLUSTER_LOOP
 SDFS_K_DIR_DONE:
         clc
@@ -601,7 +601,7 @@ SDFS_PATH_SKIP_TRAILING_FAIL:
         rts
 
 SDFS_FIND_IN_CUR:
-        jsr     SDFS_CLUSTER_TO_SD_LBA
+        jsr     SDFS_API_CLUSTER_TO_SD_LBA
         ldx     #SD_SECTOR_BUF
         jsr     SDFS_API_READ_SECTOR
         bcs     SDFS_FIND_IN_CUR_FAIL
@@ -628,9 +628,9 @@ SDFS_FIND_IN_CUR_NEXT_ENTRY:
         jsr     SDFS_K_ADVANCE_ENTRY_PTR
         dec     FAT_DIR_COUNT
         bne     SDFS_FIND_IN_CUR_ENTRY_LOOP
-        jsr     SDFS_NEXT_CLUSTER
+        jsr     SDFS_API_NEXT_CLUSTER
         bcs     SDFS_FIND_IN_CUR_FAIL
-        jsr     SDFS_COPY_NEXT_TO_CUR
+        jsr     SDFS_API_COPY_NEXT_TO_CUR
         bra     SDFS_FIND_IN_CUR
 SDFS_FIND_IN_CUR_MATCH:
         jsr     SDFS_STORE_FILE_ENTRY
@@ -912,6 +912,30 @@ SDFS_API_LOAD_FILE_83:
 
 SDFS_API_GET_ERROR:
         jsr     S1_BASE+31
+        rts
+
+SDFS_API_STREAM_OPEN:
+        jsr     S1_BASE+34
+        rts
+
+SDFS_API_STREAM_GETC:
+        jsr     S1_BASE+37
+        rts
+
+SDFS_API_STREAM_BYTES_REMAIN:
+        jsr     S1_BASE+40
+        rts
+
+SDFS_API_CLUSTER_TO_SD_LBA:
+        jsr     S1_BASE+43
+        rts
+
+SDFS_API_NEXT_CLUSTER:
+        jsr     S1_BASE+46
+        rts
+
+SDFS_API_COPY_NEXT_TO_CUR:
+        jsr     S1_BASE+49
         rts
 
 SDFS_READ_LINE:
@@ -1296,265 +1320,6 @@ SDFS_PARSE_HEX16_FAIL:
         sec
         rts
 
-SDFS_STREAM_OPEN:
-        ldaa    FAT_FILE_CLUS0
-        staa    FAT_CUR_CLUS0
-        ldaa    FAT_FILE_CLUS1
-        staa    FAT_CUR_CLUS1
-        ldaa    FAT_FILE_CLUS2
-        staa    FAT_CUR_CLUS2
-        ldaa    FAT_FILE_CLUS3
-        staa    FAT_CUR_CLUS3
-        ldaa    FAT_FILE_SIZE0
-        staa    FAT_BYTES_REM0
-        ldaa    FAT_FILE_SIZE1
-        staa    FAT_BYTES_REM1
-        ldaa    FAT_FILE_SIZE2
-        staa    FAT_BYTES_REM2
-        ldaa    FAT_FILE_SIZE3
-        staa    FAT_BYTES_REM3
-        clr     FAT_COPY_COUNT
-        clr     FAT_COPY_COUNT+1
-        clr     FAT_SECTOR_IN_CLUS
-        ldx     #SD_SECTOR_BUF
-        stx     FAT_ENTRY_PTR
-        clc
-        rts
-
-SDFS_STREAM_GETC:
-        jsr     SDFS_BYTES_REMAIN
-        bcs     SDFS_STREAM_HAS_REMAIN
-        sec
-        rts
-SDFS_STREAM_HAS_REMAIN:
-        ldaa    FAT_COPY_COUNT
-        oraa    FAT_COPY_COUNT+1
-        bne     SDFS_STREAM_HAVE_SECTOR
-        jsr     SDFS_STREAM_LOAD_SECTOR
-        bcc     SDFS_STREAM_HAVE_SECTOR
-        sec
-        rts
-SDFS_STREAM_HAVE_SECTOR:
-        ldx     FAT_ENTRY_PTR
-        ldaa    0,x
-        inx
-        stx     FAT_ENTRY_PTR
-        psha
-        ldx     FAT_COPY_COUNT
-        dex
-        stx     FAT_COPY_COUNT
-        jsr     SDFS_DEC_BYTES_REM_ONE
-        ldaa    FAT_COPY_COUNT
-        oraa    FAT_COPY_COUNT+1
-        bne     SDFS_STREAM_RETURN_BYTE
-        jsr     SDFS_BYTES_REMAIN
-        bcc     SDFS_STREAM_RETURN_BYTE
-        jsr     SDFS_ADVANCE_FILE_SECTOR
-        bcc     SDFS_STREAM_RETURN_BYTE
-        pula
-        sec
-        rts
-SDFS_STREAM_RETURN_BYTE:
-        pula
-        clc
-        rts
-
-SDFS_STREAM_LOAD_SECTOR:
-        jsr     SDFS_SECTOR_TO_SD_LBA
-        ldx     #SD_SECTOR_BUF
-        jsr     SDFS_API_READ_SECTOR
-        bcc     SDFS_STREAM_LOAD_OK
-        sec
-        rts
-SDFS_STREAM_LOAD_OK:
-        jsr     SDFS_PREP_COPY_COUNT
-        ldx     #SD_SECTOR_BUF
-        stx     FAT_ENTRY_PTR
-        clc
-        rts
-
-SDFS_SECTOR_TO_SD_LBA:
-        jsr     SDFS_CLUSTER_TO_SD_LBA
-        ldab    FAT_SECTOR_IN_CLUS
-        beq     SDFS_SECTOR_TO_SD_LBA_DONE
-SDFS_SECTOR_TO_SD_LBA_LOOP:
-        jsr     SDFS_INC_SD_LBA
-        decb
-        bne     SDFS_SECTOR_TO_SD_LBA_LOOP
-SDFS_SECTOR_TO_SD_LBA_DONE:
-        rts
-
-SDFS_CLUSTER_TO_SD_LBA:
-        ldaa    FAT_DATA_LBA0
-        staa    SD_LBA0
-        ldaa    FAT_DATA_LBA1
-        staa    SD_LBA1
-        ldaa    FAT_DATA_LBA2
-        staa    SD_LBA2
-        ldaa    FAT_DATA_LBA3
-        staa    SD_LBA3
-        ldaa    FAT_CUR_CLUS3
-        suba    #$02
-        staa    FAT_TMP
-SDFS_CLUSTER_ADD_LOOP:
-        ldaa    FAT_TMP
-        beq     SDFS_CLUSTER_ADD_DONE
-        ldab    FAT_SEC_PER_CLUS
-SDFS_CLUSTER_ADD_SECTOR_LOOP:
-        jsr     SDFS_INC_SD_LBA
-        decb
-        bne     SDFS_CLUSTER_ADD_SECTOR_LOOP
-        dec     FAT_TMP
-        bra     SDFS_CLUSTER_ADD_LOOP
-SDFS_CLUSTER_ADD_DONE:
-        rts
-
-SDFS_INC_SD_LBA:
-        inc     SD_LBA3
-        bne     SDFS_INC_SD_LBA_DONE
-        inc     SD_LBA2
-        bne     SDFS_INC_SD_LBA_DONE
-        inc     SD_LBA1
-        bne     SDFS_INC_SD_LBA_DONE
-        inc     SD_LBA0
-SDFS_INC_SD_LBA_DONE:
-        rts
-
-SDFS_ADVANCE_FILE_SECTOR:
-        inc     FAT_SECTOR_IN_CLUS
-        ldaa    FAT_SECTOR_IN_CLUS
-        cmpa    FAT_SEC_PER_CLUS
-        blo     SDFS_ADVANCE_SAME_CLUSTER
-        clr     FAT_SECTOR_IN_CLUS
-        jsr     SDFS_NEXT_CLUSTER
-        bcc     SDFS_ADVANCE_NEXT_CLUSTER
-        sec
-        rts
-SDFS_ADVANCE_NEXT_CLUSTER:
-        jsr     SDFS_COPY_NEXT_TO_CUR
-SDFS_ADVANCE_SAME_CLUSTER:
-        clc
-        rts
-
-SDFS_NEXT_CLUSTER:
-        ldaa    FAT_FAT_LBA0
-        staa    SD_LBA0
-        ldaa    FAT_FAT_LBA1
-        staa    SD_LBA1
-        ldaa    FAT_FAT_LBA2
-        staa    SD_LBA2
-        ldaa    FAT_FAT_LBA3
-        staa    SD_LBA3
-        ldx     #SD_SECTOR_BUF
-        jsr     SDFS_API_READ_SECTOR
-        bcc     SDFS_NEXT_OFFSET_PREP
-        sec
-        rts
-SDFS_NEXT_OFFSET_PREP:
-        ldaa    FAT_CUR_CLUS3
-        asla
-        asla
-        tab
-        ldx     #SD_SECTOR_BUF
-SDFS_NEXT_OFFSET_LOOP:
-        tstb
-        beq     SDFS_NEXT_READ
-        inx
-        decb
-        bra     SDFS_NEXT_OFFSET_LOOP
-SDFS_NEXT_READ:
-        ldaa    3,x
-        anda    #$0F
-        staa    FAT_NEXT_CLUS0
-        ldaa    2,x
-        staa    FAT_NEXT_CLUS1
-        ldaa    1,x
-        staa    FAT_NEXT_CLUS2
-        ldaa    0,x
-        staa    FAT_NEXT_CLUS3
-        ldaa    FAT_NEXT_CLUS0
-        cmpa    #$0F
-        bne     SDFS_NEXT_NOT_EOC
-        ldaa    FAT_NEXT_CLUS1
-        cmpa    #$FF
-        bne     SDFS_NEXT_NOT_EOC
-        ldaa    FAT_NEXT_CLUS2
-        cmpa    #$FF
-        bne     SDFS_NEXT_NOT_EOC
-        ldaa    FAT_NEXT_CLUS3
-        cmpa    #$F8
-        blo     SDFS_NEXT_NOT_EOC
-        sec
-        rts
-SDFS_NEXT_NOT_EOC:
-        clc
-        rts
-
-SDFS_COPY_NEXT_TO_CUR:
-        ldaa    FAT_NEXT_CLUS0
-        staa    FAT_CUR_CLUS0
-        ldaa    FAT_NEXT_CLUS1
-        staa    FAT_CUR_CLUS1
-        ldaa    FAT_NEXT_CLUS2
-        staa    FAT_CUR_CLUS2
-        ldaa    FAT_NEXT_CLUS3
-        staa    FAT_CUR_CLUS3
-        rts
-
-SDFS_BYTES_REMAIN:
-        ldaa    FAT_BYTES_REM0
-        oraa    FAT_BYTES_REM1
-        oraa    FAT_BYTES_REM2
-        oraa    FAT_BYTES_REM3
-        bne     SDFS_BYTES_REMAIN_YES
-        clc
-        rts
-SDFS_BYTES_REMAIN_YES:
-        sec
-        rts
-
-SDFS_PREP_COPY_COUNT:
-        ldaa    FAT_BYTES_REM0
-        oraa    FAT_BYTES_REM1
-        bne     SDFS_PREP_COPY_512
-        ldaa    FAT_BYTES_REM2
-        cmpa    #$02
-        bhs     SDFS_PREP_COPY_512
-        staa    FAT_COPY_COUNT
-        ldaa    FAT_BYTES_REM3
-        staa    FAT_COPY_COUNT+1
-        rts
-SDFS_PREP_COPY_512:
-        ldaa    #$02
-        staa    FAT_COPY_COUNT
-        clr     FAT_COPY_COUNT+1
-        rts
-
-SDFS_DEC_BYTES_REM_ONE:
-        ldaa    FAT_BYTES_REM3
-        bne     SDFS_DEC_REM_LO
-        ldaa    #$FF
-        staa    FAT_BYTES_REM3
-        ldaa    FAT_BYTES_REM2
-        bne     SDFS_DEC_REM_B2
-        ldaa    #$FF
-        staa    FAT_BYTES_REM2
-        ldaa    FAT_BYTES_REM1
-        bne     SDFS_DEC_REM_B1
-        ldaa    #$FF
-        staa    FAT_BYTES_REM1
-        dec     FAT_BYTES_REM0
-        rts
-SDFS_DEC_REM_B1:
-        dec     FAT_BYTES_REM1
-        rts
-SDFS_DEC_REM_B2:
-        dec     FAT_BYTES_REM2
-        rts
-SDFS_DEC_REM_LO:
-        dec     FAT_BYTES_REM3
-        rts
-
 SDFS_READ_LOADER_RECORD:
         jsr     SDFS_READ_RECORD_HEAD
         bcs     SDFS_READ_LOADER_RECORD_FAIL
@@ -1586,7 +1351,7 @@ SDFS_READ_LOADER_RECORD_FAIL:
         rts
 
 SDFS_READ_RECORD_HEAD:
-        jsr     SDFS_STREAM_GETC
+        jsr     SDFS_API_STREAM_GETC
         bcs     SDFS_READ_RECORD_HEAD_FAIL
         cmpa    #CHR_LF
         beq     SDFS_READ_RECORD_HEAD
@@ -1602,7 +1367,7 @@ SDFS_READ_RECORD_HEAD_FAIL:
         rts
 
 SDFS_READ_RECORD_TRAILER:
-        jsr     SDFS_STREAM_GETC
+        jsr     SDFS_API_STREAM_GETC
         bcs     SDFS_READ_RECORD_TRAILER_OK
         cmpa    #CHR_LF
         beq     SDFS_READ_RECORD_TRAILER_OK
@@ -1617,7 +1382,7 @@ SDFS_READ_RECORD_TRAILER_OK:
 
 SDFS_READ_HEXBYTE_INPUT:
         pshb
-        jsr     SDFS_STREAM_GETC
+        jsr     SDFS_API_STREAM_GETC
         bcs     SDFS_READ_HEXBYTE_INPUT_FAIL
         jsr     SDFS_HEX_TO_NIBBLE
         bcs     SDFS_READ_HEXBYTE_INPUT_FAIL
@@ -1626,7 +1391,7 @@ SDFS_READ_HEXBYTE_INPUT:
         lsla
         lsla
         tab
-        jsr     SDFS_STREAM_GETC
+        jsr     SDFS_API_STREAM_GETC
         bcs     SDFS_READ_HEXBYTE_INPUT_FAIL
         jsr     SDFS_HEX_TO_NIBBLE
         bcs     SDFS_READ_HEXBYTE_INPUT_FAIL
@@ -1647,7 +1412,7 @@ SDFS_READ_SREC_RECORD:
 SDFS_READ_SREC_HEAD_OK:
         ldaa    #1
         staa    LOADER_STAGE
-        jsr     SDFS_STREAM_GETC
+        jsr     SDFS_API_STREAM_GETC
         bcs     SDFS_READ_SREC_FAIL_NEAR0
         staa    LOADER_TYPE
         cmpa    #'0'

--- a/src/stage1.asm
+++ b/src/stage1.asm
@@ -3,7 +3,7 @@
         include "../include/hardware.inc"
 
 S1_API_VERSION  equ 1
-S1_API_COUNT    equ 9
+S1_API_COUNT    equ 12
 S1_FLAG_NONE    equ 0
 S1_ERR_NONE     equ 0
 S1_ERR_UNIMPL   equ 1
@@ -38,6 +38,9 @@ S1_JUMP_TABLE:
         jmp     S1_STREAM_OPEN
         jmp     S1_STREAM_GETC
         jmp     S1_STREAM_BYTES_REMAIN
+        jmp     S1_CLUSTER_TO_SD_LBA
+        jmp     S1_NEXT_CLUSTER
+        jmp     S1_COPY_NEXT_TO_CUR
 
 S1_INIT:
         clr     FAT_ERROR
@@ -170,6 +173,15 @@ S1_STREAM_GETC:
 
 S1_STREAM_BYTES_REMAIN:
         jmp     FAT_BYTES_REMAIN
+
+S1_CLUSTER_TO_SD_LBA:
+        jmp     FAT_CLUSTER_TO_SD_LBA
+
+S1_NEXT_CLUSTER:
+        jmp     FAT32_NEXT_CLUSTER
+
+S1_COPY_NEXT_TO_CUR:
+        jmp     FAT_COPY_NEXT_TO_CUR
 
 S1_SDFS_NAME:
         fcc     "SDFS    BIN"

--- a/tests/test_sdfs68_build.py
+++ b/tests/test_sdfs68_build.py
@@ -161,6 +161,12 @@ def test_sdfs_api_wrappers_target_stage1_jump_table() -> None:
         "SDFS_API_FIND_83",
         "SDFS_API_LOAD_FILE_83",
         "SDFS_API_GET_ERROR",
+        "SDFS_API_STREAM_OPEN",
+        "SDFS_API_STREAM_GETC",
+        "SDFS_API_STREAM_BYTES_REMAIN",
+        "SDFS_API_CLUSTER_TO_SD_LBA",
+        "SDFS_API_NEXT_CLUSTER",
+        "SDFS_API_COPY_NEXT_TO_CUR",
     )
     wrappers = {
         "SDFS_API_INIT": 16,
@@ -169,6 +175,12 @@ def test_sdfs_api_wrappers_target_stage1_jump_table() -> None:
         "SDFS_API_FIND_83": 25,
         "SDFS_API_LOAD_FILE_83": 28,
         "SDFS_API_GET_ERROR": 31,
+        "SDFS_API_STREAM_OPEN": 34,
+        "SDFS_API_STREAM_GETC": 37,
+        "SDFS_API_STREAM_BYTES_REMAIN": 40,
+        "SDFS_API_CLUSTER_TO_SD_LBA": 43,
+        "SDFS_API_NEXT_CLUSTER": 46,
+        "SDFS_API_COPY_NEXT_TO_CUR": 49,
     }
     for name, offset in wrappers.items():
         index = symbols[name] - symbols["SDFS_LOAD_BASE"]

--- a/tests/test_stage1_build.py
+++ b/tests/test_stage1_build.py
@@ -112,6 +112,9 @@ def test_stage1_profiles_build_and_match_layout() -> None:
             "S1_STREAM_OPEN",
             "S1_STREAM_GETC",
             "S1_STREAM_BYTES_REMAIN",
+            "S1_CLUSTER_TO_SD_LBA",
+            "S1_NEXT_CLUSTER",
+            "S1_COPY_NEXT_TO_CUR",
             "S1_BOOT_SDFS",
             "S1_END",
         )
@@ -134,6 +137,9 @@ def test_stage1_profiles_build_and_match_layout() -> None:
         _assert_jump(data, 34, symbols["S1_STREAM_OPEN"])
         _assert_jump(data, 37, symbols["S1_STREAM_GETC"])
         _assert_jump(data, 40, symbols["S1_STREAM_BYTES_REMAIN"])
+        _assert_jump(data, 43, symbols["S1_CLUSTER_TO_SD_LBA"])
+        _assert_jump(data, 46, symbols["S1_NEXT_CLUSTER"])
+        _assert_jump(data, 49, symbols["S1_COPY_NEXT_TO_CUR"])
     print("[PASS] test_stage1_profiles_build_and_match_layout")
 
 
@@ -310,7 +316,7 @@ def test_stage1_boot_sdfs_rejects_invalid_headers() -> None:
 def _assert_stage1_header(data: bytes, boot_entry: int) -> None:
     assert data[0:7] == b"S1API68"
     assert data[7] == 1, "API version mismatch"
-    assert data[8] == 9, "API count mismatch"
+    assert data[8] == 12, "API count mismatch"
     assert data[9] == 0, "flags mismatch"
     actual_boot_entry = (data[10] << 8) | data[11]
     assert actual_boot_entry == boot_entry, "boot entry mismatch"


### PR DESCRIPTION
## Summary

- **stage1 側**: S1_API_COUNT を 9 → 12 に拡張、jump table に \`S1_CLUSTER_TO_SD_LBA\` / \`S1_NEXT_CLUSTER\` / \`S1_COPY_NEXT_TO_CUR\` の 3 slot を追加(既存 \`FAT_CLUSTER_TO_SD_LBA\` / \`FAT32_NEXT_CLUSTER\` / \`FAT_COPY_NEXT_TO_CUR\` を露出するだけ)
- **SDFS/68 側**: 新 API wrapper 6 個追加、SDFS/68 に自前で持っていた FAT ナビゲーション 12 関数を削除、呼び出し元を新 API 経由に置換

## 削除した重複関数(SDFS/68 側、-258 行)

- \`SDFS_STREAM_OPEN\` / \`SDFS_STREAM_GETC\` / \`SDFS_STREAM_LOAD_SECTOR\`
- \`SDFS_SECTOR_TO_SD_LBA\` / \`SDFS_CLUSTER_TO_SD_LBA\`
- \`SDFS_INC_SD_LBA\` / \`SDFS_ADVANCE_FILE_SECTOR\`
- \`SDFS_NEXT_CLUSTER\` / \`SDFS_COPY_NEXT_TO_CUR\`
- \`SDFS_BYTES_REMAIN\` / \`SDFS_PREP_COPY_COUNT\` / \`SDFS_DEC_BYTES_REM_ONE\`

## 副次効果

**#243 の cluster ≥ 64 バグ修正が SDFS/68 側にも波及**。SDFS/68 が独自 FAT chain 追跡コードを持っていた頃は、stage1 の修正 (#247) が SDFS/68 の \`.COM\` load や DIR には効かなかった。dedup 後はすべて stage1 の \`FAT32_NEXT_CLUSTER\` (16-bit cluster 対応済) 一本に集約されるため、cluster >= 64 が同じ 1 箇所で正しく動く。

## サイズ影響

| profile | 変更前 | 変更後 | 差分 |
|---|---|---|---|
| stage1 | 2600 B | 2618 B | +18 B(jump slot 3 個追加)|
| SDFS/68 (k6802_vdg) | 3614 B | 3144 B | **-470 B** |
| SDFS/68 (sbcio_vdg) | 3614 B | 3144 B | -470 B |
| SDFS/68 (sbcio-sdfs) | 3614 B | 3144 B | -470 B |

SDFS/68 は余り 126 → 696 B に大幅回復、機能追加余地確保。

## テスト

- \`test_stage1_build.py\`: 14/14 pass(S1_API_COUNT 期待値と新 slot 3 個の assertion 追加)
- \`test_sdfs68_build.py\`: 25/25 pass(SDFS_API_* wrapper テストに新 6 個追加)
- \`test_smoke.py\`: 37/37 pass
- \`test_sd_fixture.py\`: 10/10 pass
- \`test_mk_sdfs_image.py\`: 7/7 pass
- Emu 手動 verify: fresh SD で BOOT + DBS.COM READY 到達

## Base

このブランチは Step 2 branch (\`codex/issue-247-stage1-streaming-and-cluster-fix\`) から派生。#250, #251 の commit も含まれる。両 merge 後に main へ rebase する。

## Refs

Refs #245 #248