### PR TITLE
test: cluster >= 64 の統合テスト追加 + docs 更新 (#249)

### DIFF
--- a/docs/design/sdfs68_com_abi.md
+++ b/docs/design/sdfs68_com_abi.md
@@ -157,9 +157,15 @@ SDFS/68 は初期実装では `.COM` が低RAM内のどの領域を使うかま�
 
 ## SDFS/68本体サイズ
 
-2026-06-11 時点の V1.3 実装では、`make sdfs MONITOR_PROFILE=sbcio_vdg` の `SDFS.BIN` は 3614 byte である。
+2026-07-15 の #245 FAT dedup refactor で、SDFS/68 が独自に持っていた FAT chain 追跡コード (`SDFS_STREAM_OPEN` / `SDFS_STREAM_GETC` / `SDFS_NEXT_CLUSTER` / `SDFS_CLUSTER_TO_SD_LBA` 他 12 関数) を削除し、stage1 API 経由に統一した。
 
-`SDFS_LOAD_BASE` から `SDFS_LOAD_LIMIT` までの枠は 3840 byte なので、現時点の余裕は 226 byte である。
+- `make sdfs MONITOR_PROFILE=sbcio_vdg` の `SDFS.BIN` は 3614 byte → **3144 byte** (`SDFS_LOAD_LIMIT` 枠 3840 byte 中、余り 226 byte → **696 byte**)。
+- stage1 側 API を 6 → 12 slot に拡張 (streaming 3 + cluster プリミティブ 3 追加、S1_API_VERSION は 1 据置)。
+- 同時に `FAT32_NEXT_CLUSTER` を cluster >= 64 対応済に修正 (#243)。SDFS/68 側から共用するため修正は 1 箇所に集約。
+
+参考: [stage1 API 仕様](stage1_api.md)。
+
+以前(V1.3 = 2026-06-11 時点)は 3614 byte で、`SDFS_LOAD_BASE` から `SDFS_LOAD_LIMIT` までの枠 3840 byte 中の余裕は 226 byte だった。
 `.COM` 対応は SDFS/68 本体を肥大化させすぎないよう、実装を次に限定する。
 
 - 先頭トークン `.COM` 判定。

--- a/docs/plans/issue-219_loader_dedup_asm_analysis.md
+++ b/docs/plans/issue-219_loader_dedup_asm_analysis.md
@@ -102,6 +102,16 @@ SDFS本体(非ローダ)から呼ばれる再利用入口は **9個**: `READ_LOA
 - 案1採用で SDFS常駐部から約730バイト(モジュールコードの約2割)を解放できる見込み。#216 の候補B/Cでの常駐サイズ評価に反映する。
 - 削減後の正確なバイト数は、API化の実装後に `tools/lst_analyze.py` と `make` のサイズ確認で再計測する。
 
+## 別軸の dedup: stage1 ↔ SDFS/68 の FAT ヘルパ(2026-07 #245)
+
+本書の指摘は ROM ↔ SDFS の loader 系重複が中心だが、これとは別に **stage1 ↔ SDFS/68** で FAT chain 追跡ヘルパが二重実装されていた。#245 でこちらを先に解消した。
+
+- 削除対象(SDFS/68 側): `SDFS_STREAM_OPEN` / `SDFS_STREAM_GETC` / `SDFS_STREAM_LOAD_SECTOR` / `SDFS_SECTOR_TO_SD_LBA` / `SDFS_CLUSTER_TO_SD_LBA` / `SDFS_INC_SD_LBA` / `SDFS_ADVANCE_FILE_SECTOR` / `SDFS_NEXT_CLUSTER` / `SDFS_COPY_NEXT_TO_CUR` / `SDFS_BYTES_REMAIN` / `SDFS_PREP_COPY_COUNT` / `SDFS_DEC_BYTES_REM_ONE`(計 12 関数)。
+- 追加した stage1 API: `S1_STREAM_OPEN` / `S1_STREAM_GETC` / `S1_STREAM_BYTES_REMAIN` / `S1_CLUSTER_TO_SD_LBA` / `S1_NEXT_CLUSTER` / `S1_COPY_NEXT_TO_CUR`(6 slot、`S1_API_COUNT` 6 → 12)。既存 `FAT32_*` / `FAT_*` 実装を jump table に露出したのみで stage1 バイナリ増加は 18 byte。
+- 副次効果として #243 の cluster >= 64 バグ修正が SDFS/68 側にも自動波及した。
+- 効果測定: `SDFS.BIN` (k6802_vdg / sbcio_vdg / sbcio-sdfs) が 3614 → **3144 byte**(-470 byte)。`SDFS_LOAD_LIMIT` 枠 3840 中の余裕は 226 → **696 byte**。
+- ROM ↔ SDFS の loader 系 dedup(本書本題)は未着手のまま残っている。730 byte 見込みの回収は依然として有効。
+
 ## 整備した解析基盤(保全)
 
 - `tools/lst_analyze.py`: ASL の `.lst` シンボルテーブルをパースし、構成別に「未使用シンボル(`*`)」「ROM↔SDFS の真の重複対」「案1の回収見積りバイト数」を出力する。構成名を引数で指定(既定 `sbcio-sdfs`)。

--- a/tests/sd_fixtures.py
+++ b/tests/sd_fixtures.py
@@ -209,3 +209,82 @@ def _write_file_data(image: bytearray, layout: Fat32Layout, clusters: tuple[int,
 
 def _padded(prefix: bytes, fill: int) -> bytes:
     return prefix + bytes([fill]) * (SECTOR_SIZE - len(prefix))
+
+
+HIGH_CLUSTER_TOTAL_VOLUME_SECTORS = 256
+HIGH_CLUSTER_TARGET_1 = 100
+HIGH_CLUSTER_TARGET_2 = 101
+HIGH_CLUSTER_PAYLOAD_1_PREFIX = b"HIGH-CLUSTER-100"
+HIGH_CLUSTER_PAYLOAD_2_PREFIX = b"HIGH-CLUSTER-101"
+
+
+def high_cluster_layout(with_mbr: bool) -> Fat32Layout:
+    return _layout_for_image(
+        with_mbr=with_mbr,
+        partition_start_lba=PARTITION_START_LBA,
+        total_volume_sectors=HIGH_CLUSTER_TOTAL_VOLUME_SECTORS,
+        reserved_sectors=RESERVED_SECTORS,
+        fat_count=FAT_COUNT,
+        fat_size_sectors=FAT_SIZE_SECTORS,
+        sectors_per_cluster=1,
+        root_cluster=ROOT_CLUSTER,
+    )
+
+
+def build_high_cluster_image(with_mbr: bool = True) -> bytes:
+    """FAT chain at cluster >= 64 to exercise FAT32_NEXT_CLUSTER fix (#243).
+
+    The image places a 2-cluster file "HIGH.BIN" whose first cluster is 100
+    and whose second cluster is 101. Reading it via S1_STREAM_GETC forces
+    the loader to compute a byte offset > 255 in the FAT sector, which was
+    silently wrapped by the old implementation.
+    """
+    volume_start = PARTITION_START_LBA if with_mbr else 0
+    total_sectors = volume_start + HIGH_CLUSTER_TOTAL_VOLUME_SECTORS
+    image = bytearray(total_sectors * SECTOR_SIZE)
+    layout = high_cluster_layout(with_mbr=with_mbr)
+
+    if with_mbr:
+        _write_mbr(image, volume_start, HIGH_CLUSTER_TOTAL_VOLUME_SECTORS)
+
+    _write_vbr_common(
+        image,
+        volume_start,
+        total_volume_sectors=HIGH_CLUSTER_TOTAL_VOLUME_SECTORS,
+        reserved_sectors=RESERVED_SECTORS,
+        fat_count=FAT_COUNT,
+        fat_size_sectors=FAT_SIZE_SECTORS,
+        sectors_per_cluster=1,
+        root_cluster=ROOT_CLUSTER,
+    )
+    _write_fsinfo(image, volume_start + 1)
+
+    # FAT: entries 0 and 1 are the standard reserved values;
+    # cluster 100 -> cluster 101; cluster 101 -> EOC; ROOT_CLUSTER is EOC.
+    fat = bytearray(SECTOR_SIZE)
+    entries = {
+        0: 0x0FFFFFF8,
+        1: EOC,
+        ROOT_CLUSTER: EOC,
+        HIGH_CLUSTER_TARGET_1: HIGH_CLUSTER_TARGET_2,
+        HIGH_CLUSTER_TARGET_2: EOC,
+    }
+    for cluster, value in entries.items():
+        offset = cluster * 4
+        fat[offset:offset + 4] = value.to_bytes(4, "little")
+    for copy_index in range(FAT_COUNT):
+        _write_sector(image, layout.fat_lba + copy_index * FAT_SIZE_SECTORS, fat)
+
+    # Root dir: single entry HIGH.BIN pointing at cluster 100, size = 2 sectors.
+    root = bytearray(SECTOR_SIZE)
+    root[0:32] = root_entry(
+        b"HIGH    BIN", 0x20, HIGH_CLUSTER_TARGET_1, SECTOR_SIZE * 2
+    )
+    root[32] = 0x00
+    _write_sector(image, layout.root_dir_lba, root)
+
+    # File data: distinct payloads per cluster
+    _write_cluster(image, layout, HIGH_CLUSTER_TARGET_1, _padded(HIGH_CLUSTER_PAYLOAD_1_PREFIX, 0xAA))
+    _write_cluster(image, layout, HIGH_CLUSTER_TARGET_2, _padded(HIGH_CLUSTER_PAYLOAD_2_PREFIX, 0x55))
+
+    return bytes(image)

--- a/tests/test_stage1_build.py
+++ b/tests/test_stage1_build.py
@@ -20,6 +20,7 @@ from sd_fixtures import (  # noqa: E402
     MULTI_CLUSTER_2_PREFIX,
     TEST_S_CONTENT,
     build_fat32_image,
+    build_high_cluster_image,
     layout_for_image,
 )
 from fat32_image import Fat32File, build_fat32_image_from_files  # noqa: E402
@@ -263,6 +264,90 @@ def test_stage1_load_file_83_service_loads_multisector_files() -> None:
     assert result == 0x42, f"S1_LOAD_FILE_83 failed to load BIGSREC.S: {result:02X}"
     assert bytes(data[:len(BIG_S_CONTENT)]) == BIG_S_CONTENT
     print("[PASS] test_stage1_load_file_83_service_loads_multisector_files")
+
+
+def test_stage1_next_cluster_handles_cluster_ge_64() -> None:
+    """FAT32_NEXT_CLUSTER (#243 fix) must handle clusters where the byte
+    offset within the FAT sector exceeds 255 (i.e., cluster * 4 > 255,
+    meaning cluster >= 64). This exercises the 16-bit offset path.
+    """
+    profile = "sbcio_vdg"
+    _run_make(profile)
+    _run_make(profile, target="bin")
+    expected = EXPECTED[profile]
+    suffix = expected["suffix"]
+    stage1_data = (PROJECT_ROOT / "build" / f"stage1{suffix}.bin").read_bytes()
+    symbols = _load_symbols(
+        PROJECT_ROOT / "build" / f"stage1{suffix}.lst",
+        "S1_BASE",
+        "SDFS_LOAD_BASE",
+        "FAT_CUR_CLUS0",
+        "FAT_CUR_CLUS3",
+        "FAT_NEXT_CLUS3",
+    )
+    result_addr = symbols["SDFS_LOAD_BASE"]
+    harness_addr = 0x0100
+    # Slots (V2 stage1):
+    #   S1_INIT              = S1_BASE + 16
+    #   S1_MOUNT             = S1_BASE + 22
+    #   S1_NEXT_CLUSTER      = S1_BASE + 46
+    harness = [
+        # jsr S1_INIT
+        0xBD, ((symbols["S1_BASE"] + 16) >> 8) & 0xFF, (symbols["S1_BASE"] + 16) & 0xFF,
+        # bcs err (relative +$1B forward to error branch)
+        0x25, 0x22,
+        # jsr S1_MOUNT
+        0xBD, ((symbols["S1_BASE"] + 22) >> 8) & 0xFF, (symbols["S1_BASE"] + 22) & 0xFF,
+        0x25, 0x1D,
+        # clr FAT_CUR_CLUS0
+        0x7F, (symbols["FAT_CUR_CLUS0"] >> 8) & 0xFF, symbols["FAT_CUR_CLUS0"] & 0xFF,
+        # clr FAT_CUR_CLUS0+1
+        0x7F, ((symbols["FAT_CUR_CLUS0"] + 1) >> 8) & 0xFF, (symbols["FAT_CUR_CLUS0"] + 1) & 0xFF,
+        # clr FAT_CUR_CLUS0+2
+        0x7F, ((symbols["FAT_CUR_CLUS0"] + 2) >> 8) & 0xFF, (symbols["FAT_CUR_CLUS0"] + 2) & 0xFF,
+        # ldaa #100
+        0x86, 0x64,
+        # staa FAT_CUR_CLUS3
+        0xB7, (symbols["FAT_CUR_CLUS3"] >> 8) & 0xFF, symbols["FAT_CUR_CLUS3"] & 0xFF,
+        # jsr S1_NEXT_CLUSTER
+        0xBD, ((symbols["S1_BASE"] + 46) >> 8) & 0xFF, (symbols["S1_BASE"] + 46) & 0xFF,
+        0x25, 0x08,
+        # ldaa FAT_NEXT_CLUS3 (should be 101 after fix)
+        0xB6, (symbols["FAT_NEXT_CLUS3"] >> 8) & 0xFF, symbols["FAT_NEXT_CLUS3"] & 0xFF,
+        # staa result_addr
+        0xB7, (result_addr >> 8) & 0xFF, result_addr & 0xFF,
+        0x3F,
+        # error path: store $E1 and halt
+        0x86, 0xE1,
+        0xB7, (result_addr >> 8) & 0xFF, result_addr & 0xFF,
+        0x3F,
+    ]
+    sd_image = build_high_cluster_image(with_mbr=True)
+    input_text = (
+        f"M{symbols['S1_BASE']:04X}\r"
+        f"{_hex_bytes(list(stage1_data))}\r.\r"
+        f"M{harness_addr:04X}\r"
+        f"{_hex_bytes(harness)}\r.\r"
+        f"G{harness_addr:04X}\r"
+        f"D{result_addr:04X}-{result_addr:04X}\r"
+        "\r"
+    )
+    stdout, stderr, rc = _run_emu_with_sd(
+        rom_path=PROJECT_ROOT / "build" / "mc6800-monitor-sbcio-vdg.bin",
+        input_text=input_text,
+        sd_image=sd_image,
+    )
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    line = _dump_line(stdout, result_addr)
+    match = re.search(rf"{result_addr:04X}\s+([0-9A-Fa-f]{{2}})", line)
+    if not match:
+        raise AssertionError(f"missing next-cluster result byte: {line!r}\nstdout={stdout!r}")
+    value = int(match.group(1), 16)
+    assert value == 101, (
+        f"S1_NEXT_CLUSTER for cluster 100 returned {value:02X}, expected 65 (=101) "
+        f"— cluster >= 64 fix (#243) regressed. stdout={stdout!r}"
+    )
+    print("[PASS] test_stage1_next_cluster_handles_cluster_ge_64")
 
 
 def test_stage1_load_file_83_service_rejects_unsupported_files() -> None:
@@ -720,6 +805,7 @@ def main() -> None:
         test_stage1_find_83_service_rejects_missing_name,
         test_stage1_load_file_83_service_loads_one_sector_file,
         test_stage1_load_file_83_service_loads_multisector_files,
+        test_stage1_next_cluster_handles_cluster_ge_64,
         test_stage1_load_file_83_service_rejects_unsupported_files,
         test_stage1_boot_sdfs_jumps_to_valid_entry,
         test_stage1_boot_sdfs_loads_multisector_entry,


### PR DESCRIPTION
## Summary

- \`tests/sd_fixtures.py\`: \`build_high_cluster_image()\` を追加。cluster 100 -> 101 -> EOC の 2-cluster チェーンを持つ 256 sector 画像を作る fixture
- \`tests/test_stage1_build.py\`: \`test_stage1_next_cluster_handles_cluster_ge_64\` を追加。#243 の cluster >= 64 バグ修正を **直接検証** するテスト
- \`docs/design/sdfs68_com_abi.md\`: #245 refactor 後のサイズ変化と stage1 API 経由化を追記
- \`docs/plans/issue-219_loader_dedup_asm_analysis.md\`: stage1 ↔ SDFS/68 の FAT ヘルパ dedup の実施結果を追記

## テストの検証点

\`test_stage1_next_cluster_handles_cluster_ge_64\` は以下を検査:

1. 高 cluster fixture(FAT[100]=101, FAT[101]=EOC)をエミュレータの SD として渡す
2. ハーネス: \`S1_MOUNT\` → \`FAT_CUR_CLUS = 100\` セット → \`S1_NEXT_CLUSTER\` 呼び出し → \`FAT_NEXT_CLUS3\` を dump
3. 期待値: **101** (\`\$65\`) が返る

旧バグコード(\`(cluster_lo * 4) mod 256\` で 8bit wrap する版)なら、cluster 100 の byte offset を 144 と計算 → cluster 36 の FAT entry(= 0)を誤読 → \`FAT_NEXT_CLUS3 = 0\` を返して assertion fail。

つまりこのテストは #243 のリグレッションを catch する。

## テスト結果

- test_stage1_build: **15/15 pass** (新規 1 test 追加)
- test_sdfs68_build: 25/25 pass
- test_smoke: 37/37 pass
- test_sd_fixture: 10/10 pass
- test_mk_sdfs_image: 7/7 pass

## Refs

Closes #249
Refs #245