### PR TITLE
ci: ドキュメントのみの変更でCIをスキップする

### DIFF
--- a/.github/workflows/windows-emu.yml
+++ b/.github/workflows/windows-emu.yml
@@ -5,7 +5,20 @@ on:
     branches:
       - main
       - "codex/**"
+      - "feature/**"
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - "**/*.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/pull_request_template.md"
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - "**/*.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/pull_request_template.md"
 
 jobs:
   smoke:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ GitHub Project の「Linked pull requests」列でPRを取りこぼさず追跡�
 ## テスト実行
 
 - コード変更後と PR 作成前は、**必ず全テストを実行する**。正規手順は `make test`(ビルド前提込みで全テストを実行)。
+- ドキュメントのみの変更では `make test` を省略してよい。その場合は PR 本文に「ドキュメントのみのためテスト省略」と明記する。
 - 手順の詳細は `docs/development/workflow.md` の「テスト方針」を参照。
 - テストは pytest ではなくスクリプト直実行。エミュテストは先に base profile をビルドしないと環境失敗する(`make test` が自動で満たす)。
 

--- a/docs/development/project_context.md
+++ b/docs/development/project_context.md
@@ -44,6 +44,7 @@ python tests/test_smoke.py
 ```
 
 `REQUIRE_BUILD_ROM=1` を付けると、fixture ではなく最新ソースから生成した `build/mc6800-monitor.bin` を要求する。PR 前の確認ではこの経路を使う。
+ドキュメントのみの変更ではローカルの `make test` を省略してよい。GitHub Actions も docs / Markdown / Issue・PRテンプレートのみの変更では起動しない。
 
 新しい振る舞いを実装する場合は、既存 smoke test が通るだけでは不十分である。追加した機能に対応するテストを追加し、入力と期待結果を固定する。
 

--- a/docs/development/workflow.md
+++ b/docs/development/workflow.md
@@ -86,12 +86,13 @@ PR 作成前に、差分へ不要ファイルが入っていないことを確�
 ## テスト方針
 
 コード変更後と PR 作成前は、**必ず全テストを実行する**。一発で済む正規手順は `make test`。
+ドキュメントのみの変更では `make test` を省略してよい。その場合は PR 本文に「ドキュメントのみのためテスト省略」と明記する。
 
 ```sh
 make test
 ```
 
-`make test` は次をまとめて行う(CI `.github/workflows/windows-emu.yml` と同等)。
+`make test` は次をまとめて行う。CI `.github/workflows/windows-emu.yml` は Windows 上の smoke subset であり、`make test` 全体とは範囲が異なる。
 
 - 前提ROMを先にビルド: `make bin MONITOR_PROFILE=base` と `make bin MONITOR_PROFILE=sbcio`
 - エミュレータテスト(`REQUIRE_BUILD_ROM=1`、base と sbcio 両構成): `tests/test_smoke.py` / `tests/test_sd_fixture.py`
@@ -112,6 +113,7 @@ make test
 - 実機でしか確認できない内容は、手順と確認結果を `docs/testing/` または `docs/progress/` に残す。
 
 CI では `REQUIRE_BUILD_ROM=1` を使い、最新ソースから生成した `build/mc6800-monitor.bin` を検証する。fixture はローカル補助用であり、最新ソースの確認には使わない。
+CI もドキュメント、Markdown、Issue/PRテンプレートのみの変更では起動しない。
 
 ## レビュー運用
 

--- a/docs/testing/windows_emulator_ci.md
+++ b/docs/testing/windows_emulator_ci.md
@@ -9,9 +9,10 @@ Windows 上で次の 2 点を安定して確認する。
 
 この手順書は、ローカル確認と GitHub Actions の両方をまとめたもの。
 
-## GitHub Actions で 2 本の結果が出る理由
+## GitHub Actions の起動条件
 
-PR の checks に次の 2 本が見えるのは、workflow が `push` と `pull_request` の両方で動くため。
+workflow は `push` と `pull_request` の両方で動く。
+コード、テスト、ビルド設定、workflow 自体を変更したPRでは、checks に次の 2 本が見える。
 
 - `Windows Emulator Smoke / smoke (push)`
 - `Windows Emulator Smoke / smoke (pull_request)`
@@ -24,6 +25,7 @@ PR の checks に次の 2 本が見えるのは、workflow が `push` と `pull_
   - PR として `main` に対して評価したときの確認
 
 同じ workflow でも、トリガーが別なので 2 本表示される。
+ただし、docs、Markdown、Issue/PRテンプレートのみの変更では workflow は起動しない。
 
 ## CI の流れ
 
@@ -31,8 +33,8 @@ PR の checks に次の 2 本が見えるのは、workflow が `push` と `pull_
 
 1. Python をセットアップ
 2. `third_party/asl/asw-1.42-Beta.zip` を展開
-3. `asl.exe` と `p2bin.exe` で `build/mc6800-monitor.bin` を生成
-4. `REQUIRE_BUILD_ROM=1` を付けて `python tests/test_smoke.py` を実行
+3. `asl.exe` と `p2bin.exe` で base / sbcio の ROM を生成
+4. `REQUIRE_BUILD_ROM=1` を付けて base / sbcio の `tests/test_smoke.py` と `tests/test_sd_fixture.py` を実行
 
 このため、CI では fixture ではなく、毎回最新ソースから生成した ROM を使う。
 
@@ -121,4 +123,5 @@ python emu\sbc6800_emu.py build\mc6800-monitor.bin --input tests\fixtures\sample
 
 - CI の本命は `build/mc6800-monitor.bin` を使う経路
 - fixture フォールバックはローカル補助用
-- workflow が `push` と `pull_request` の両方を監視しているため、checks は 2 本見える
+- workflow が `push` と `pull_request` の両方を監視しているため、コード変更時のchecksは通常 2 本見える
+- docs、Markdown、Issue/PRテンプレートのみの変更では CI は起動しない


### PR DESCRIPTION
## 概要
- Windows Emulator Smoke に `paths-ignore` を追加し、docs / Markdown / Issue・PRテンプレートのみの変更ではCIを起動しないようにした
- `feature/**` ブランチへのpushでもCI対象になるようにした
- docs-only変更ではローカル `make test` を省略できる運用を文書化した
- Windows CI手順書を現在の実行内容とdocs-only skipに合わせて更新した

## 確認内容
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/windows-emu.yml"); puts "ok"'`
- `git diff --numstat` と `git diff --ignore-all-space --numstat` の一致を確認
- CI設定と文書のみの変更のため、`make test` は省略

## 対応Issue
Closes #264