### PR TITLE
feat: SDFS/68 v3 resident stubを追加する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,11 @@ SDFS_TARGET := SDFS$(TARGET_SUFFIX)
 SDFS_OBJ := $(OUTDIR)/$(SDFS_TARGET).p
 SDFS_LST := $(OUTDIR)/$(SDFS_TARGET).lst
 SDFS_BIN := $(OUTDIR)/$(SDFS_TARGET).BIN
+SDFS3_TOPSRC := src/sdfs68_v3/resident_stub.asm
+SDFS3_TARGET := SDFS3$(TARGET_SUFFIX)
+SDFS3_OBJ := $(OUTDIR)/$(SDFS3_TARGET).p
+SDFS3_LST := $(OUTDIR)/$(SDFS3_TARGET).lst
+SDFS3_BIN := $(OUTDIR)/$(SDFS3_TARGET).BIN
 SDFS_TOOLS_DIR := sdfs_tools
 SDFS_TOOL_HELLO_S_SRC := $(SDFS_TOOLS_DIR)/HELLO_S.ASM
 SDFS_TOOL_HELLO_COM_SRC := $(SDFS_TOOLS_DIR)/HELLO_COM.ASM
@@ -251,7 +256,7 @@ endif
 
 ASL_INCLUDE := $(CURDIR)/$(OUTDIR)$(ASL_PATHSEP)$(CURDIR)/include$(ASL_PATHSEP)$(CURDIR)/src
 
-.PHONY: all clean bin test check-rom-size srec ihex stage1 sdfs sdfs-tools sdfs-tools-srec sdfs-tools-com check-stage1-config rombin rombin-27c64 rombin-27c128 rombin-27c256 rombin-28c256 rombin-w27c512 program verify readback program-27c64 program-27c128 program-27c256 program-28c256 program-w27c512 program-upd28c256 FORCE
+.PHONY: all clean bin test check-rom-size srec ihex stage1 sdfs sdfs3 sdfs-tools sdfs-tools-srec sdfs-tools-com check-stage1-config rombin rombin-27c64 rombin-27c128 rombin-27c256 rombin-28c256 rombin-w27c512 program verify readback program-27c64 program-27c128 program-27c256 program-28c256 program-w27c512 program-upd28c256 FORCE
 
 all: check-rom-size srec ihex
 
@@ -282,12 +287,15 @@ test:
 	REQUIRE_BUILD_ROM=1 MONITOR_PROFILE=sbcio MONITOR_ROM_PATH=$(OUTDIR)/mc6800-monitor-sbcio.bin MONITOR_LST_PATH=$(OUTDIR)/mc6800-monitor-sbcio.lst "$(PYTHON)" tests/test_smoke.py
 	REQUIRE_BUILD_ROM=1 MONITOR_PROFILE=sbcio MONITOR_ROM_PATH=$(OUTDIR)/mc6800-monitor-sbcio.bin MONITOR_LST_PATH=$(OUTDIR)/mc6800-monitor-sbcio.lst "$(PYTHON)" tests/test_sd_fixture.py
 	"$(PYTHON)" tests/test_sdfs68_build.py
+	"$(PYTHON)" tests/test_sdfs68_v3_build.py
 	"$(PYTHON)" tests/test_stage1_build.py
 	"$(PYTHON)" tests/test_mk_sdfs_image.py
 
 stage1: check-stage1-config $(STAGE1_BIN)
 
 sdfs: check-stage1-config $(SDFS_BIN)
+
+sdfs3: check-stage1-config $(SDFS3_BIN)
 
 check-stage1-config:
 	"$(PYTHON)" -c "import sys; sd='$(FEATURE_SD)'; board='$(BOARD_IO)'; memory='$(MEMORY_CONFIG)'; ok = sd == '1' and board == 'sbcio' and memory in ('ram64_c000_work', 'ram64_a000_work', 'ram64_4000_work'); sys.exit(0 if ok else 1)" || (echo "stage1 target requires FEATURE_SD=1 BOARD_IO=sbcio and MEMORY_CONFIG=ram64_c000_work, ram64_a000_work or ram64_4000_work" && exit 1)
@@ -303,6 +311,12 @@ $(SDFS_OBJ): FORCE $(SDFS_TOPSRC) include/hardware.inc $(CONFIG_INC) | $(OUTDIR)
 
 $(SDFS_BIN): $(SDFS_OBJ)
 	"$(P2BIN)" $(SDFS_OBJ) $(SDFS_BIN) -q
+
+$(SDFS3_OBJ): FORCE $(SDFS3_TOPSRC) include/hardware.inc $(CONFIG_INC) | $(OUTDIR)
+	"$(ASL)" -q -L -olist $(SDFS3_LST) -o $(SDFS3_OBJ) -i $(ASL_INCLUDE_ARG) $(SDFS3_TOPSRC)
+
+$(SDFS3_BIN): $(SDFS3_OBJ)
+	"$(P2BIN)" $(SDFS3_OBJ) $(SDFS3_BIN) -q
 
 sdfs-tools: sdfs-tools-srec sdfs-tools-com
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,6 +63,7 @@ ROM常駐FATを確認したい場合は、profileではなく直接構成軸で 
 - [plans/sdfs68_v3/issue-259_resident_api.md](plans/sdfs68_v3/issue-259_resident_api.md): SDFS/68 v3 resident API最小セット
 - [plans/sdfs68_v3/issue-260_memory_bankram.md](plans/sdfs68_v3/issue-260_memory_bankram.md): SDFS/68 v3 メモリマップとBank RAM利用方針
 - [plans/sdfs68_v3/issue-261_basic_save_load.md](plans/sdfs68_v3/issue-261_basic_save_load.md): SDFS/68 v3 BASIC SAVE/LOAD連携方式
+- [plans/sdfs68_v3/issue-271_resident_stub.md](plans/sdfs68_v3/issue-271_resident_stub.md): SDFS/68 v3 resident API stub とビルド基盤
 - [plans/issue-141_sdfs68_load.md](plans/issue-141_sdfs68_load.md): SDFS/68 LOAD正式化
 - [plans/issue-149_sdfs68_run_addr.md](plans/issue-149_sdfs68_run_addr.md): SDFS/68 RUN addr
 - [plans/issue-150_sdfs68_run_file.md](plans/issue-150_sdfs68_run_file.md): SDFS/68 RUN filename

--- a/docs/plans/sdfs68_v3/README.md
+++ b/docs/plans/sdfs68_v3/README.md
@@ -22,3 +22,9 @@ v3 は、現行の `BOOT -> stage1 -> SDFS.BIN -> SDFS> ` 方式を単純に拡�
 - v3設計文書はこのディレクトリに置く。
 - 実装Issueは、#256から#261の設計が固まってから分割する。
 - v2系の既存文書、テスト、`SDFS.BIN`、stage1は、v3検討中も旧系統として壊さない。
+
+## 実装Issue
+
+| Issue | 文書 | 内容 |
+| --- | --- | --- |
+| #271 | [issue-271_resident_stub.md](issue-271_resident_stub.md) | resident API stub とビルド基盤 |

--- a/docs/plans/sdfs68_v3/issue-271_resident_stub.md
+++ b/docs/plans/sdfs68_v3/issue-271_resident_stub.md
@@ -1,0 +1,59 @@
+# Issue #271 SDFS/68 v3 resident API stub とビルド基盤
+
+## 背景
+
+#255-#261 で SDFS/68 v3 の設計判断を整理した。
+実装の最初のPRでは、既存v2の `src/sdfs68.asm`、stage1、`SDFS.BIN` 生成経路を壊さず、v3 residentを別成果物としてビルドできる足場を作る。
+
+## 採用方針
+
+- v3 residentのソースは `src/sdfs68_v3/` に分ける。
+- 既存の `make sdfs` はv2用として変更しない。
+- v3 residentは `make sdfs3` で `build/SDFS3*.BIN` を生成する。
+- 最初のstubは `SDFS3API` headerと最小jump tableのみを持つ。
+- API slotは #259 のslot番号に合わせ、slot 0-6をjump tableに置く。
+- `GET_INFO`、`GET_ERROR` 以外は未実装エラーを返すだけにし、ROM dispatchやFAT処理は後続Issueへ分ける。
+
+## 初期stubのheader
+
+`SDFS3API` headerは #259 のresident header案に合わせ、次を持つ。
+
+| Offset | 項目 | 初期値 |
+| ---: | --- | --- |
+| `$00` | magic | `SDFS3API` |
+| `$08` | api major | `1` |
+| `$09` | api minor | `0` |
+| `$0A` | api count | `7` |
+| `$0B` | flags | `0` |
+| `$0C` | jump table address | `SDFS3_JUMP_TABLE` |
+| `$0E` | work base | `SDFS_LOAD_BASE` |
+| `$10` | work end | `SDFS3_END-1` |
+| `$12` | memtop | `USER_RAM_END` |
+| `$14` | scratch min | `0` |
+| `$16` | reserved | `0` |
+
+## 検証方針
+
+- `tests/test_sdfs68_v3_build.py` で `make sdfs3` を実行する。
+- `sbcio_4000` と `k6802_4000` で `SDFS3*.BIN` が生成されることを確認する。
+- listingから `SDFS_LOAD_BASE`、`SDFS_LOAD_LIMIT`、`USER_RAM_END`、API symbolを取得し、binary headerとjump tableが #259 のslot番号と一致することを確認する。
+- `GET_INFO` が `A=api_major`、`B=flags`、`X=resident API header address`、carry clearを返す命令列であることを確認する。
+- `base` profileでは `sdfs3` が失敗することを確認する。
+- コード変更なのでPR前に `make test` を実行する。
+
+## 対象外
+
+- ROMモニタからv3 residentを検出/呼び出す実装。
+- `CMD <tail>` gatewayのROM側実装。
+- 固定LBA `SDFS3SYS` loader実装。
+- FAT/SD処理との接続。
+- BASIC SAVE/LOAD実装。
+- FAT write実装。
+
+## 関連
+
+- #271: 対応Issue。
+- #272: v3 phase 1 実装epic。
+- #254: v3全体親Issue。
+- #259: resident API最小セット。
+- #260: メモリマップとBank RAM利用方針。

--- a/src/sdfs68_v3/resident_stub.asm
+++ b/src/sdfs68_v3/resident_stub.asm
@@ -1,0 +1,78 @@
+        cpu     6800
+
+        include "hardware.inc"
+
+SDFS3_API_MAJOR    equ 1
+SDFS3_API_MINOR    equ 0
+SDFS3_API_COUNT    equ 7
+SDFS3_API_HDR_SIZE equ $18
+SDFS3_FLAG_NONE    equ 0
+SDFS3_ERR_NONE     equ 0
+SDFS3_ERR_NOT_IMPL equ 1
+
+        if S1_SUPPORTED = 0
+        error   "SDFS/68 v3 resident is not supported for this memory configuration"
+        endif
+
+        org     SDFS_LOAD_BASE
+
+SDFS3_API_HEADER:
+        fcc     "SDFS3API"
+        fcb     SDFS3_API_MAJOR
+        fcb     SDFS3_API_MINOR
+        fcb     SDFS3_API_COUNT
+        fcb     SDFS3_FLAG_NONE
+        fdb     SDFS3_JUMP_TABLE
+        fdb     SDFS_LOAD_BASE
+        fdb     SDFS3_END-1
+        fdb     USER_RAM_END
+        fdb     0
+        fdb     0
+
+SDFS3_JUMP_TABLE:
+        fdb     SDFS3_GET_INFO
+        fdb     SDFS3_CMD_DISPATCH
+        fdb     SDFS3_LOAD_PATH
+        fdb     SDFS3_READ_STREAM_OPEN
+        fdb     SDFS3_READ_STREAM_GETC
+        fdb     SDFS3_READ_STREAM_CLOSE
+        fdb     SDFS3_GET_ERROR
+
+SDFS3_GET_INFO:
+        ldaa    #SDFS3_API_MAJOR
+        ldab    #SDFS3_FLAG_NONE
+        ldx     #SDFS3_API_HEADER
+        clc
+        rts
+
+SDFS3_CMD_DISPATCH:
+        jmp     SDFS3_NOT_IMPLEMENTED
+
+SDFS3_LOAD_PATH:
+        jmp     SDFS3_NOT_IMPLEMENTED
+
+SDFS3_READ_STREAM_OPEN:
+        jmp     SDFS3_NOT_IMPLEMENTED
+
+SDFS3_READ_STREAM_GETC:
+        jmp     SDFS3_NOT_IMPLEMENTED
+
+SDFS3_READ_STREAM_CLOSE:
+        jmp     SDFS3_NOT_IMPLEMENTED
+
+SDFS3_NOT_IMPLEMENTED:
+        ldaa    #SDFS3_ERR_NOT_IMPL
+        staa    SDFS3_LAST_ERROR
+        sec
+        rts
+
+SDFS3_GET_ERROR:
+        ldaa    SDFS3_LAST_ERROR
+        clc
+        rts
+
+SDFS3_LAST_ERROR:
+        fcb     SDFS3_ERR_NONE
+
+SDFS3_END:
+        end

--- a/tests/test_sdfs68_v3_build.py
+++ b/tests/test_sdfs68_v3_build.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""SDFS/68 v3 resident stub build tests."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+EXPECTED = {
+    "sbcio_4000": {
+        "suffix": "-sbcio-4000",
+        "SDFS_LOAD_BASE": 0x5000,
+        "SDFS_LOAD_LIMIT": 0x7EFF,
+        "USER_RAM_END": 0x3FFF,
+    },
+    "k6802_4000": {
+        "suffix": "-k6802-4000",
+        "SDFS_LOAD_BASE": 0x5000,
+        "SDFS_LOAD_LIMIT": 0x7EFF,
+        "USER_RAM_END": 0x3FFF,
+    },
+}
+
+
+def test_sdfs3_profiles_build_and_match_header() -> None:
+    for profile, expected in EXPECTED.items():
+        _run_make(profile, "sdfs3")
+        suffix = expected["suffix"]
+        bin_path = PROJECT_ROOT / "build" / f"SDFS3{suffix}.BIN"
+        lst_path = PROJECT_ROOT / "build" / f"SDFS3{suffix}.lst"
+        data = bin_path.read_bytes()
+        symbols = _load_symbols(
+            lst_path,
+            "SDFS_LOAD_BASE",
+            "SDFS_LOAD_LIMIT",
+            "USER_RAM_END",
+            "SDFS3_API_HEADER",
+            "SDFS3_JUMP_TABLE",
+            "SDFS3_GET_INFO",
+            "SDFS3_CMD_DISPATCH",
+            "SDFS3_LOAD_PATH",
+            "SDFS3_READ_STREAM_OPEN",
+            "SDFS3_READ_STREAM_GETC",
+            "SDFS3_READ_STREAM_CLOSE",
+            "SDFS3_GET_ERROR",
+            "SDFS3_END",
+        )
+        assert symbols["SDFS_LOAD_BASE"] == expected["SDFS_LOAD_BASE"]
+        assert symbols["SDFS_LOAD_LIMIT"] == expected["SDFS_LOAD_LIMIT"]
+        assert symbols["USER_RAM_END"] == expected["USER_RAM_END"]
+        assert symbols["SDFS3_API_HEADER"] == symbols["SDFS_LOAD_BASE"]
+        assert len(data) <= symbols["SDFS_LOAD_LIMIT"] - symbols["SDFS_LOAD_BASE"] + 1
+        assert len(data) == symbols["SDFS3_END"] - symbols["SDFS_LOAD_BASE"]
+        assert data[0:8] == b"SDFS3API"
+        assert data[8] == 1, "SDFS3 api major mismatch"
+        assert data[9] == 0, "SDFS3 api minor mismatch"
+        assert data[10] == 7, "SDFS3 api count mismatch"
+        assert data[11] == 0, "SDFS3 flags should be zero in stub"
+        assert _word(data, 0x0C) == symbols["SDFS3_JUMP_TABLE"]
+        assert _word(data, 0x0E) == symbols["SDFS_LOAD_BASE"]
+        assert _word(data, 0x10) == symbols["SDFS3_END"] - 1
+        assert _word(data, 0x12) == expected["USER_RAM_END"]
+        assert _word(data, 0x14) == 0
+        assert _word(data, 0x16) == 0
+        jump_table = symbols["SDFS3_JUMP_TABLE"] - symbols["SDFS_LOAD_BASE"]
+        assert _word(data, jump_table) == symbols["SDFS3_GET_INFO"]
+        assert _word(data, jump_table + 2) == symbols["SDFS3_CMD_DISPATCH"]
+        assert _word(data, jump_table + 4) == symbols["SDFS3_LOAD_PATH"]
+        assert _word(data, jump_table + 6) == symbols["SDFS3_READ_STREAM_OPEN"]
+        assert _word(data, jump_table + 8) == symbols["SDFS3_READ_STREAM_GETC"]
+        assert _word(data, jump_table + 10) == symbols["SDFS3_READ_STREAM_CLOSE"]
+        assert _word(data, jump_table + 12) == symbols["SDFS3_GET_ERROR"]
+        get_error = symbols["SDFS3_GET_ERROR"] - symbols["SDFS_LOAD_BASE"]
+        assert data[get_error + 3 : get_error + 5] == bytes([0x0C, 0x39])
+    print("[PASS] test_sdfs3_profiles_build_and_match_header")
+
+
+def test_sdfs3_get_info_matches_calling_convention() -> None:
+    profile = "sbcio_4000"
+    expected = EXPECTED[profile]
+    _run_make(profile, "sdfs3")
+    suffix = expected["suffix"]
+    data = (PROJECT_ROOT / "build" / f"SDFS3{suffix}.BIN").read_bytes()
+    symbols = _load_symbols(
+        PROJECT_ROOT / "build" / f"SDFS3{suffix}.lst",
+        "SDFS_LOAD_BASE",
+        "SDFS3_GET_INFO",
+        "SDFS3_API_HEADER",
+    )
+    get_info = symbols["SDFS3_GET_INFO"] - symbols["SDFS_LOAD_BASE"]
+    header = symbols["SDFS3_API_HEADER"]
+    assert data[get_info : get_info + 8] == bytes(
+        [
+            0x86,
+            0x01,
+            0xC6,
+            0x00,
+            0xCE,
+            (header >> 8) & 0xFF,
+            header & 0xFF,
+            0x0C,
+        ]
+    )
+    assert data[get_info + 8] == 0x39
+    print("[PASS] test_sdfs3_get_info_matches_calling_convention")
+
+
+def test_sdfs3_rejects_base_profile() -> None:
+    result = _run_make("base", "sdfs3", expect_success=False)
+    assert result.returncode != 0
+    assert "FEATURE_SD=1" in result.stdout or "FEATURE_SD=1" in result.stderr
+    print("[PASS] test_sdfs3_rejects_base_profile")
+
+
+def _word(data: bytes, offset: int) -> int:
+    return (data[offset] << 8) | data[offset + 1]
+
+
+def _run_make(
+    profile: str,
+    target: str,
+    expect_success: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["make", target, f"MONITOR_PROFILE={profile}"],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=15,
+    )
+    if expect_success and result.returncode != 0:
+        raise AssertionError(
+            f"make {target} failed for {profile}: stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+    return result
+
+
+def _load_symbols(path: Path, *names: str) -> dict[str, int]:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    result: dict[str, int] = {}
+    for name in names:
+        patterns = [
+            re.compile(rf":\s*=\$([0-9A-Fa-f]{{1,4}})\s+{re.escape(name)}\s+equ\b"),
+            re.compile(rf"/([0-9A-Fa-f]{{1,4}})\s+:\s+.*\b{re.escape(name)}:\s*$"),
+            re.compile(rf"\b{re.escape(name)}\s+:\s+([0-9A-Fa-f]{{1,4}})\b"),
+        ]
+        for pattern in patterns:
+            match = pattern.search(text)
+            if match:
+                result[name] = int(match.group(1), 16)
+                break
+        if name not in result:
+            raise AssertionError(f"missing symbol in listing: {name}")
+    return result
+
+
+def main() -> None:
+    print("=" * 50)
+    print("SDFS/68 v3 build tests")
+    print("=" * 50)
+    tests = [
+        test_sdfs3_rejects_base_profile,
+        test_sdfs3_profiles_build_and_match_header,
+        test_sdfs3_get_info_matches_calling_convention,
+    ]
+    passed = 0
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            passed += 1
+        except AssertionError as exc:
+            print(f"[FAIL] {test.__name__}: {exc}")
+            failed += 1
+        except Exception as exc:
+            print(f"[ERROR] {test.__name__}: {exc}")
+            failed += 1
+    print()
+    print(f"Result: {passed} passed, {failed} failed")
+    sys.exit(0 if failed == 0 else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 概要
- v3 resident用ソースを `src/sdfs68_v3/` に分離
- `make sdfs3` で `SDFS3*.BIN` を生成するビルドtargetを追加
- `SDFS3API` headerとslot 0-6のjump table stubを追加
- v3 resident stubのheader、jump table、`GET_INFO` / `GET_ERROR` 呼び出し規約を検証するテストを追加
- #271の計画文書と目次を更新

## 確認内容
- `python3 tests/test_sdfs68_v3_build.py`
- `python3 tests/test_sdfs68_build.py`
- `make test`
- `git diff --cached --check`
- `git diff --cached --numstat` と `git diff --cached --ignore-all-space --numstat` の一致を確認

## 補足
- 途中でビルド系テストを並列実行して `build/monitor_config.inc` が競合し、既存SDFSテストが一時失敗した。以後は順次実行し、`python3 tests/test_sdfs68_build.py` と `make test` の通過を確認済み。
- ROM dispatch、固定LBA loader、FAT/SD接続は後続Issueへ分割する。

Closes #271
Refs #272
Refs #254
Refs #259
Refs #260