### PR TITLE
feat: SDFS/68 v3 resident header検出を追加する

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -64,6 +64,7 @@ ROM常駐FATを確認したい場合は、profileではなく直接構成軸で 
 - [plans/sdfs68_v3/issue-260_memory_bankram.md](plans/sdfs68_v3/issue-260_memory_bankram.md): SDFS/68 v3 メモリマップとBank RAM利用方針
 - [plans/sdfs68_v3/issue-261_basic_save_load.md](plans/sdfs68_v3/issue-261_basic_save_load.md): SDFS/68 v3 BASIC SAVE/LOAD連携方式
 - [plans/sdfs68_v3/issue-271_resident_stub.md](plans/sdfs68_v3/issue-271_resident_stub.md): SDFS/68 v3 resident API stub とビルド基盤
+- [plans/sdfs68_v3/issue-275_resident_detect.md](plans/sdfs68_v3/issue-275_resident_detect.md): SDFS/68 v3 ROM側resident header検出
 - [plans/issue-141_sdfs68_load.md](plans/issue-141_sdfs68_load.md): SDFS/68 LOAD正式化
 - [plans/issue-149_sdfs68_run_addr.md](plans/issue-149_sdfs68_run_addr.md): SDFS/68 RUN addr
 - [plans/issue-150_sdfs68_run_file.md](plans/issue-150_sdfs68_run_file.md): SDFS/68 RUN filename

--- a/docs/plans/sdfs68_v3/README.md
+++ b/docs/plans/sdfs68_v3/README.md
@@ -28,3 +28,4 @@ v3 は、現行の `BOOT -> stage1 -> SDFS.BIN -> SDFS> ` 方式を単純に拡�
 | Issue | 文書 | 内容 |
 | --- | --- | --- |
 | #271 | [issue-271_resident_stub.md](issue-271_resident_stub.md) | resident API stub とビルド基盤 |
+| #275 | [issue-275_resident_detect.md](issue-275_resident_detect.md) | ROM側resident header検出 |

--- a/docs/plans/sdfs68_v3/issue-275_resident_detect.md
+++ b/docs/plans/sdfs68_v3/issue-275_resident_detect.md
@@ -1,0 +1,42 @@
+# Issue #275 SDFS/68 v3 ROM側resident header検出
+
+## 背景
+
+#271で `SDFS3API` headerを持つv3 resident stubを別成果物として生成できるようにした。
+次の段階として、ROMモニタ側がRAM上のresident API headerを検査できる必要がある。
+
+このIssueでは、ROMからresident APIを呼び出すところまでは進めず、header検出だけを実装する。
+`CMD <tail>` gatewayと `SDFS3_CMD_DISPATCH` 呼び出しは #276 へ分ける。
+
+## 採用方針
+
+- ROM側に `SDFS3_FIND_API` を追加する。
+- 初期検出位置は `SDFS_LOAD_BASE` とする。
+- 検査項目は `SDFS3API` magic、`api_major=1`、`api_count>=7` に絞る。
+- 成功時は `X=SDFS_LOAD_BASE`、carry clearで返す。
+- 失敗時はcarry setで返す。
+- 既存v2の `BOOT -> stage1 -> SDFS.BIN` 経路は変更しない。
+
+## 検証方針
+
+- `tests/test_sdfs68_v3_build.py` にROM側検出テストを追加する。
+- `sbcio_4000` ROMをビルドし、RAM上の `SDFS_LOAD_BASE` へテストheaderを書き込む。
+- 小さいRAMハーネスから `SDFS3_FIND_API` を `JSR` し、成功時に返る `X` と失敗時statusを確認する。
+- 正常header、bad magic、bad major、api count不足を確認する。
+- コード変更なので `make test` を実行する。
+
+## 対象外
+
+- `CMD <tail>` gateway実装。
+- resident `CMD_DISPATCH` 呼び出し。
+- 固定LBA `SDFS3SYS` loader実装。
+- FAT/SD処理との接続。
+- BASIC SAVE/LOAD実装。
+
+## 関連
+
+- #275: 対応Issue。
+- #272: v3 phase 1 実装epic。
+- #256: ROM command dispatch設計。
+- #259: resident API最小セット。
+- #260: メモリマップとBank RAM利用方針。

--- a/src/main.asm
+++ b/src/main.asm
@@ -1728,6 +1728,48 @@ BOOT_FAIL_A:
         staa    FAT_ERROR
         sec
         rts
+
+SDFS3_API_MAJOR    equ 1
+SDFS3_API_MIN_COUNT equ 7
+
+SDFS3_FIND_API:
+        ldx     #SDFS_LOAD_BASE
+        ldaa    0,x
+        cmpa    #'S'
+        bne     SDFS3_FIND_API_FAIL
+        ldaa    1,x
+        cmpa    #'D'
+        bne     SDFS3_FIND_API_FAIL
+        ldaa    2,x
+        cmpa    #'F'
+        bne     SDFS3_FIND_API_FAIL
+        ldaa    3,x
+        cmpa    #'S'
+        bne     SDFS3_FIND_API_FAIL
+        ldaa    4,x
+        cmpa    #'3'
+        bne     SDFS3_FIND_API_FAIL
+        ldaa    5,x
+        cmpa    #'A'
+        bne     SDFS3_FIND_API_FAIL
+        ldaa    6,x
+        cmpa    #'P'
+        bne     SDFS3_FIND_API_FAIL
+        ldaa    7,x
+        cmpa    #'I'
+        bne     SDFS3_FIND_API_FAIL
+        ldaa    8,x
+        cmpa    #SDFS3_API_MAJOR
+        bne     SDFS3_FIND_API_FAIL
+        ldaa    10,x
+        cmpa    #SDFS3_API_MIN_COUNT
+        blo     SDFS3_FIND_API_FAIL
+        ldx     #SDFS_LOAD_BASE
+        clc
+        rts
+SDFS3_FIND_API_FAIL:
+        sec
+        rts
  endif
  endif
  if MONITOR_FEATURE_FAT

--- a/tests/test_sdfs68_v3_build.py
+++ b/tests/test_sdfs68_v3_build.py
@@ -6,10 +6,12 @@ from __future__ import annotations
 import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
+EMU_PATH = PROJECT_ROOT / "emu" / "sbc6800_emu.py"
 
 
 EXPECTED = {
@@ -118,8 +120,159 @@ def test_sdfs3_rejects_base_profile() -> None:
     print("[PASS] test_sdfs3_rejects_base_profile")
 
 
+def test_rom_detects_sdfs3_api_header() -> None:
+    profile = "sbcio_4000"
+    expected = EXPECTED[profile]
+    _run_make(profile, "bin")
+    suffix = expected["suffix"]
+    symbols = _load_symbols(
+        PROJECT_ROOT / "build" / f"mc6800-monitor{suffix}.lst",
+        "SDFS3_FIND_API",
+        "SDFS_LOAD_BASE",
+    )
+    status_addr = 0x0200
+    result_addr = 0x0201
+    harness_addr = 0x0100
+    find_api = symbols["SDFS3_FIND_API"]
+    harness = bytes(
+        [
+            0xBD,
+            (find_api >> 8) & 0xFF,
+            find_api & 0xFF,
+            0x25,
+            0x09,
+            0xFF,
+            (result_addr >> 8) & 0xFF,
+            result_addr & 0xFF,
+            0x86,
+            0x42,
+            0xB7,
+            (status_addr >> 8) & 0xFF,
+            status_addr & 0xFF,
+            0x3F,
+            0x86,
+            0xE1,
+            0xB7,
+            (status_addr >> 8) & 0xFF,
+            status_addr & 0xFF,
+            0x3F,
+        ]
+    )
+
+    cases = [
+        ("valid", _sdfs3_header(symbols["SDFS_LOAD_BASE"]), 0x42),
+        ("bad magic", b"XDFS3API" + _sdfs3_header(symbols["SDFS_LOAD_BASE"])[8:], 0xE1),
+        ("bad major", _mutated_header(symbols["SDFS_LOAD_BASE"], 8, 0x02), 0xE1),
+        ("short api count", _mutated_header(symbols["SDFS_LOAD_BASE"], 10, 0x06), 0xE1),
+    ]
+    for label, header, expected_status in cases:
+        stdout, stderr, rc = _run_emu(
+            rom_path=PROJECT_ROOT / "build" / f"mc6800-monitor{suffix}.bin",
+            input_text=(
+                f"M{symbols['SDFS_LOAD_BASE']:04X}\r"
+                f"{_hex_bytes(header)}\r.\r"
+                f"M{harness_addr:04X}\r"
+                f"{_hex_bytes(harness)}\r.\r"
+                f"G{harness_addr:04X}\r"
+                f"D{status_addr:04X}-{result_addr + 1:04X}\r"
+                "\r"
+            ),
+            max_cycles=20_000_000,
+        )
+        assert rc == 0 and "[TIMEOUT]" not in stderr, (
+            f"emulator failed for {label}: rc={rc} stderr={stderr!r}"
+        )
+        values = _dump_bytes(stdout, status_addr)
+        assert values[0] == expected_status, (
+            f"{label} status mismatch: {values!r}\nstdout={stdout!r}"
+        )
+        if expected_status == 0x42:
+            assert values[1:3] == [
+                (symbols["SDFS_LOAD_BASE"] >> 8) & 0xFF,
+                symbols["SDFS_LOAD_BASE"] & 0xFF,
+            ], f"{label} returned header address mismatch: {values!r}"
+    print("[PASS] test_rom_detects_sdfs3_api_header")
+
+
 def _word(data: bytes, offset: int) -> int:
     return (data[offset] << 8) | data[offset + 1]
+
+
+def _sdfs3_header(load_base: int) -> bytes:
+    return bytes(
+        [
+            *b"SDFS3API",
+            0x01,
+            0x00,
+            0x07,
+            0x00,
+            (load_base >> 8) & 0xFF,
+            load_base & 0xFF,
+            (load_base >> 8) & 0xFF,
+            load_base & 0xFF,
+            (load_base >> 8) & 0xFF,
+            load_base & 0xFF,
+            0x3F,
+            0xFF,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+        ]
+    )
+
+
+def _mutated_header(load_base: int, offset: int, value: int) -> bytes:
+    data = bytearray(_sdfs3_header(load_base))
+    data[offset] = value
+    return bytes(data)
+
+
+def _hex_bytes(data: bytes) -> str:
+    return "\r".join(f"{value:02X}" for value in data)
+
+
+def _run_emu(
+    *,
+    rom_path: Path,
+    input_text: str,
+    max_cycles: int,
+) -> tuple[str, str, int]:
+    with tempfile.NamedTemporaryFile("w", encoding="ascii", delete=False) as f:
+        f.write(input_text)
+        input_path = Path(f.name)
+    try:
+        cmd = [
+            sys.executable,
+            str(EMU_PATH),
+            str(rom_path),
+            "--input",
+            str(input_path),
+            "--max-cycles",
+            str(max_cycles),
+            "--dump-memory",
+            "0200-0202",
+        ]
+        result = subprocess.run(
+            cmd,
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+        )
+    finally:
+        input_path.unlink(missing_ok=True)
+    return result.stdout, result.stderr, result.returncode
+
+
+def _dump_bytes(stdout: str, address: int) -> list[int]:
+    for line in stdout.splitlines():
+        if line.startswith(f"{address:04X} "):
+            parts = re.findall(r"\b[0-9A-Fa-f]{2}\b", line.split("  ", 1)[0])
+            return [int(part, 16) for part in parts]
+    raise AssertionError(f"missing dump line for {address:04X}: {stdout!r}")
 
 
 def _run_make(
@@ -170,6 +323,7 @@ def main() -> None:
         test_sdfs3_rejects_base_profile,
         test_sdfs3_profiles_build_and_match_header,
         test_sdfs3_get_info_matches_calling_convention,
+        test_rom_detects_sdfs3_api_header,
     ]
     passed = 0
     failed = 0


### PR DESCRIPTION
## 概要
- ROM側に `SDFS3_FIND_API` を追加し、`SDFS_LOAD_BASE` 上の v3 resident API header を検出できるようにした
- 検査条件を `SDFS3API` magic、`api_major=1`、`api_count>=7` に絞り、成功時は `X=SDFS_LOAD_BASE` + carry clear、失敗時は carry set で返す
- エミュレータ上のRAMハーネスで正常header、bad magic、bad major、api count不足を確認するテストを追加した
- #276 以降へ引き継ぐ設計メモを `docs/plans/sdfs68_v3/` に追加した

## 確認内容
- `python3 tests/test_sdfs68_v3_build.py`
- `make test`
- `git diff --check`
- `git diff --numstat src/main.asm` と `git diff --ignore-all-space --numstat src/main.asm` が一致することを確認

Closes #275
Refs #272 #254 #256 #259 #260 #271