### PR TITLE
feat: SDFS/68 v3 memtop caps APIを追加する

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -65,6 +65,7 @@ ROM常駐FATを確認したい場合は、profileではなく直接構成軸で 
 - [plans/sdfs68_v3/issue-261_basic_save_load.md](plans/sdfs68_v3/issue-261_basic_save_load.md): SDFS/68 v3 BASIC SAVE/LOAD連携方式
 - [plans/sdfs68_v3/issue-271_resident_stub.md](plans/sdfs68_v3/issue-271_resident_stub.md): SDFS/68 v3 resident API stub とビルド基盤
 - [plans/sdfs68_v3/issue-275_resident_detect.md](plans/sdfs68_v3/issue-275_resident_detect.md): SDFS/68 v3 ROM側resident header検出
+- [plans/sdfs68_v3/issue-279_memtop_caps.md](plans/sdfs68_v3/issue-279_memtop_caps.md): SDFS/68 v3 GET_MEMTOP / GET_CAPS API
 - [plans/issue-141_sdfs68_load.md](plans/issue-141_sdfs68_load.md): SDFS/68 LOAD正式化
 - [plans/issue-149_sdfs68_run_addr.md](plans/issue-149_sdfs68_run_addr.md): SDFS/68 RUN addr
 - [plans/issue-150_sdfs68_run_file.md](plans/issue-150_sdfs68_run_file.md): SDFS/68 RUN filename

--- a/docs/plans/sdfs68_v3/README.md
+++ b/docs/plans/sdfs68_v3/README.md
@@ -29,3 +29,4 @@ v3 は、現行の `BOOT -> stage1 -> SDFS.BIN -> SDFS> ` 方式を単純に拡�
 | --- | --- | --- |
 | #271 | [issue-271_resident_stub.md](issue-271_resident_stub.md) | resident API stub とビルド基盤 |
 | #275 | [issue-275_resident_detect.md](issue-275_resident_detect.md) | ROM側resident header検出 |
+| #279 | [issue-279_memtop_caps.md](issue-279_memtop_caps.md) | GET_MEMTOP / GET_CAPS API |

--- a/docs/plans/sdfs68_v3/issue-279_memtop_caps.md
+++ b/docs/plans/sdfs68_v3/issue-279_memtop_caps.md
@@ -1,0 +1,43 @@
+# Issue #279 SDFS/68 v3 GET_MEMTOP / GET_CAPS API
+
+## 背景
+
+#271でv3 resident stubの `SDFS3API` headerとslot 0-6のjump tableを追加した。
+#259/#261では、ROMやBASIC adapterがresident常駐後の安全なRAM上限とcapabilityを問い合わせられることが必要と判断している。
+
+このIssueでは、後続のROM gatewayやBASIC adapterが参照できるように、`GET_MEMTOP` と `GET_CAPS` をresident APIとして実体化する。
+
+## 採用方針
+
+- API slotは #259 の設計どおり、slot 7を `SDFS3_GET_MEMTOP`、slot 8を `SDFS3_GET_CAPS` にする。
+- `SDFS3_API_COUNT` は `9` に更新する。
+- ROM側の `SDFS3_FIND_API` も、slot 7/8を安全に使えるように `api_count>=9` を受け入れ条件にする。
+- `SDFS3_GET_MEMTOP` は初期実装として `X=USER_RAM_END`、carry clearで返す。
+- `SDFS3_GET_CAPS` は初期実装として `A=0`、`B=0`、`X=SDFS3_API_HEADER`、carry clearで返す。
+- header flagsは当面 `0` のままにする。
+- Bank RAM、FAT write、BASIC補助はcapability上も未対応として明示する。
+
+## 検証方針
+
+- `tests/test_sdfs68_v3_build.py` で `sbcio_4000` と `k6802_4000` のv3 residentを確認する。
+- headerの `api_count=9` とjump table slot 7/8のsymbol対応を確認する。
+- ROM側検出テストで `api_count=7` と `api_count=8` を拒否することを確認する。
+- `GET_MEMTOP` が `USER_RAM_END` を返す命令列であることを確認する。
+- `GET_CAPS` がcapabilityなし、かつheader addressを返す命令列であることを確認する。
+- コード変更なので `make test` を実行する。
+
+## 対象外
+
+- Bank RAM実制御。
+- FAT write capability有効化。
+- BASIC SAVE/LOAD adapter実装。
+- ROM `CMD <tail>` gateway実装。
+- `GET_CAPS` のbit定義拡張。
+
+## 関連
+
+- #279: 対応Issue。
+- #272: v3 phase 1 実装epic。
+- #259: resident API最小セット。
+- #260: メモリマップとBank RAM利用方針。
+- #261: BASIC SAVE/LOAD連携方式。

--- a/src/main.asm
+++ b/src/main.asm
@@ -1730,7 +1730,7 @@ BOOT_FAIL_A:
         rts
 
 SDFS3_API_MAJOR    equ 1
-SDFS3_API_MIN_COUNT equ 7
+SDFS3_API_MIN_COUNT equ 9
 
 SDFS3_FIND_API:
         ldx     #SDFS_LOAD_BASE

--- a/src/sdfs68_v3/resident_stub.asm
+++ b/src/sdfs68_v3/resident_stub.asm
@@ -4,9 +4,10 @@
 
 SDFS3_API_MAJOR    equ 1
 SDFS3_API_MINOR    equ 0
-SDFS3_API_COUNT    equ 7
+SDFS3_API_COUNT    equ 9
 SDFS3_API_HDR_SIZE equ $18
 SDFS3_FLAG_NONE    equ 0
+SDFS3_CAPS_NONE    equ 0
 SDFS3_ERR_NONE     equ 0
 SDFS3_ERR_NOT_IMPL equ 1
 
@@ -37,6 +38,8 @@ SDFS3_JUMP_TABLE:
         fdb     SDFS3_READ_STREAM_GETC
         fdb     SDFS3_READ_STREAM_CLOSE
         fdb     SDFS3_GET_ERROR
+        fdb     SDFS3_GET_MEMTOP
+        fdb     SDFS3_GET_CAPS
 
 SDFS3_GET_INFO:
         ldaa    #SDFS3_API_MAJOR
@@ -68,6 +71,18 @@ SDFS3_NOT_IMPLEMENTED:
 
 SDFS3_GET_ERROR:
         ldaa    SDFS3_LAST_ERROR
+        clc
+        rts
+
+SDFS3_GET_MEMTOP:
+        ldx     #USER_RAM_END
+        clc
+        rts
+
+SDFS3_GET_CAPS:
+        ldaa    #SDFS3_CAPS_NONE
+        ldab    #SDFS3_CAPS_NONE
+        ldx     #SDFS3_API_HEADER
         clc
         rts
 

--- a/tests/test_sdfs68_v3_build.py
+++ b/tests/test_sdfs68_v3_build.py
@@ -51,6 +51,8 @@ def test_sdfs3_profiles_build_and_match_header() -> None:
             "SDFS3_READ_STREAM_GETC",
             "SDFS3_READ_STREAM_CLOSE",
             "SDFS3_GET_ERROR",
+            "SDFS3_GET_MEMTOP",
+            "SDFS3_GET_CAPS",
             "SDFS3_END",
         )
         assert symbols["SDFS_LOAD_BASE"] == expected["SDFS_LOAD_BASE"]
@@ -62,7 +64,7 @@ def test_sdfs3_profiles_build_and_match_header() -> None:
         assert data[0:8] == b"SDFS3API"
         assert data[8] == 1, "SDFS3 api major mismatch"
         assert data[9] == 0, "SDFS3 api minor mismatch"
-        assert data[10] == 7, "SDFS3 api count mismatch"
+        assert data[10] == 9, "SDFS3 api count mismatch"
         assert data[11] == 0, "SDFS3 flags should be zero in stub"
         assert _word(data, 0x0C) == symbols["SDFS3_JUMP_TABLE"]
         assert _word(data, 0x0E) == symbols["SDFS_LOAD_BASE"]
@@ -78,6 +80,8 @@ def test_sdfs3_profiles_build_and_match_header() -> None:
         assert _word(data, jump_table + 8) == symbols["SDFS3_READ_STREAM_GETC"]
         assert _word(data, jump_table + 10) == symbols["SDFS3_READ_STREAM_CLOSE"]
         assert _word(data, jump_table + 12) == symbols["SDFS3_GET_ERROR"]
+        assert _word(data, jump_table + 14) == symbols["SDFS3_GET_MEMTOP"]
+        assert _word(data, jump_table + 16) == symbols["SDFS3_GET_CAPS"]
         get_error = symbols["SDFS3_GET_ERROR"] - symbols["SDFS_LOAD_BASE"]
         assert data[get_error + 3 : get_error + 5] == bytes([0x0C, 0x39])
     print("[PASS] test_sdfs3_profiles_build_and_match_header")
@@ -111,6 +115,42 @@ def test_sdfs3_get_info_matches_calling_convention() -> None:
     )
     assert data[get_info + 8] == 0x39
     print("[PASS] test_sdfs3_get_info_matches_calling_convention")
+
+
+def test_sdfs3_memtop_and_caps_match_calling_convention() -> None:
+    for profile, expected in EXPECTED.items():
+        _run_make(profile, "sdfs3")
+        suffix = expected["suffix"]
+        data = (PROJECT_ROOT / "build" / f"SDFS3{suffix}.BIN").read_bytes()
+        symbols = _load_symbols(
+            PROJECT_ROOT / "build" / f"SDFS3{suffix}.lst",
+            "SDFS_LOAD_BASE",
+            "SDFS3_API_HEADER",
+            "SDFS3_GET_MEMTOP",
+            "SDFS3_GET_CAPS",
+        )
+        get_memtop = symbols["SDFS3_GET_MEMTOP"] - symbols["SDFS_LOAD_BASE"]
+        memtop = expected["USER_RAM_END"]
+        assert data[get_memtop : get_memtop + 5] == bytes(
+            [0xCE, (memtop >> 8) & 0xFF, memtop & 0xFF, 0x0C, 0x39]
+        )
+
+        get_caps = symbols["SDFS3_GET_CAPS"] - symbols["SDFS_LOAD_BASE"]
+        header = symbols["SDFS3_API_HEADER"]
+        assert data[get_caps : get_caps + 9] == bytes(
+            [
+                0x86,
+                0x00,
+                0xC6,
+                0x00,
+                0xCE,
+                (header >> 8) & 0xFF,
+                header & 0xFF,
+                0x0C,
+                0x39,
+            ]
+        )
+    print("[PASS] test_sdfs3_memtop_and_caps_match_calling_convention")
 
 
 def test_sdfs3_rejects_base_profile() -> None:
@@ -163,7 +203,8 @@ def test_rom_detects_sdfs3_api_header() -> None:
         ("valid", _sdfs3_header(symbols["SDFS_LOAD_BASE"]), 0x42),
         ("bad magic", b"XDFS3API" + _sdfs3_header(symbols["SDFS_LOAD_BASE"])[8:], 0xE1),
         ("bad major", _mutated_header(symbols["SDFS_LOAD_BASE"], 8, 0x02), 0xE1),
-        ("short api count", _mutated_header(symbols["SDFS_LOAD_BASE"], 10, 0x06), 0xE1),
+        ("legacy api count 7", _mutated_header(symbols["SDFS_LOAD_BASE"], 10, 0x07), 0xE1),
+        ("short api count 8", _mutated_header(symbols["SDFS_LOAD_BASE"], 10, 0x08), 0xE1),
     ]
     for label, header, expected_status in cases:
         stdout, stderr, rc = _run_emu(
@@ -204,7 +245,7 @@ def _sdfs3_header(load_base: int) -> bytes:
             *b"SDFS3API",
             0x01,
             0x00,
-            0x07,
+            0x09,
             0x00,
             (load_base >> 8) & 0xFF,
             load_base & 0xFF,
@@ -323,6 +364,7 @@ def main() -> None:
         test_sdfs3_rejects_base_profile,
         test_sdfs3_profiles_build_and_match_header,
         test_sdfs3_get_info_matches_calling_convention,
+        test_sdfs3_memtop_and_caps_match_calling_convention,
         test_rom_detects_sdfs3_api_header,
     ]
     passed = 0


### PR DESCRIPTION
## 概要
- v3 resident APIの `api_count` を9へ更新し、slot 7/8に `SDFS3_GET_MEMTOP` と `SDFS3_GET_CAPS` を追加
- `GET_MEMTOP` は初期値として `X=USER_RAM_END`、carry clearを返す
- `GET_CAPS` はbankなし/writeなし/BASIC補助なしの最小capabilityとして `A=0`、`B=0`、`X=SDFS3_API_HEADER`、carry clearを返す
- ROM側の `SDFS3_FIND_API` も `api_count>=9` を要求するよう更新し、古いslot不足headerを拒否するテストを追加
- #279 の実装判断を `docs/plans/sdfs68_v3/` に追加

## 確認内容
- `python3 tests/test_sdfs68_v3_build.py`
- `make test`
- `git diff --check`
- `git diff --numstat src/main.asm` と `git diff --ignore-all-space --numstat src/main.asm` が一致することを確認

## レビュー指摘への対応
- `api_count=7/8` をROM側検出で受け入れるとslot 7/8利用時に危険なため、最小受入数を9へ更新し、拒否テストを追加

Closes #279
Refs #272 #254 #259 #260 #261 #275