### PR TITLE
feat: SDFS/68 v3 system image生成を追加する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,7 @@ SDFS3_TARGET := SDFS3$(TARGET_SUFFIX)
 SDFS3_OBJ := $(OUTDIR)/$(SDFS3_TARGET).p
 SDFS3_LST := $(OUTDIR)/$(SDFS3_TARGET).lst
 SDFS3_BIN := $(OUTDIR)/$(SDFS3_TARGET).BIN
+SDFS3SYS_BIN := $(OUTDIR)/SDFS3SYS$(TARGET_SUFFIX).BIN
 SDFS_TOOLS_DIR := sdfs_tools
 SDFS_TOOL_HELLO_S_SRC := $(SDFS_TOOLS_DIR)/HELLO_S.ASM
 SDFS_TOOL_HELLO_COM_SRC := $(SDFS_TOOLS_DIR)/HELLO_COM.ASM
@@ -256,7 +257,7 @@ endif
 
 ASL_INCLUDE := $(CURDIR)/$(OUTDIR)$(ASL_PATHSEP)$(CURDIR)/include$(ASL_PATHSEP)$(CURDIR)/src
 
-.PHONY: all clean bin test check-rom-size srec ihex stage1 sdfs sdfs3 sdfs-tools sdfs-tools-srec sdfs-tools-com check-stage1-config rombin rombin-27c64 rombin-27c128 rombin-27c256 rombin-28c256 rombin-w27c512 program verify readback program-27c64 program-27c128 program-27c256 program-28c256 program-w27c512 program-upd28c256 FORCE
+.PHONY: all clean bin test check-rom-size srec ihex stage1 sdfs sdfs3 sdfs3sys sdfs-tools sdfs-tools-srec sdfs-tools-com check-stage1-config rombin rombin-27c64 rombin-27c128 rombin-27c256 rombin-28c256 rombin-w27c512 program verify readback program-27c64 program-27c128 program-27c256 program-28c256 program-w27c512 program-upd28c256 FORCE
 
 all: check-rom-size srec ihex
 
@@ -297,6 +298,8 @@ sdfs: check-stage1-config $(SDFS_BIN)
 
 sdfs3: check-stage1-config $(SDFS3_BIN)
 
+sdfs3sys: check-stage1-config $(SDFS3SYS_BIN)
+
 check-stage1-config:
 	"$(PYTHON)" -c "import sys; sd='$(FEATURE_SD)'; board='$(BOARD_IO)'; memory='$(MEMORY_CONFIG)'; ok = sd == '1' and board == 'sbcio' and memory in ('ram64_c000_work', 'ram64_a000_work', 'ram64_4000_work'); sys.exit(0 if ok else 1)" || (echo "stage1 target requires FEATURE_SD=1 BOARD_IO=sbcio and MEMORY_CONFIG=ram64_c000_work, ram64_a000_work or ram64_4000_work" && exit 1)
 
@@ -317,6 +320,11 @@ $(SDFS3_OBJ): FORCE $(SDFS3_TOPSRC) include/hardware.inc $(CONFIG_INC) | $(OUTDI
 
 $(SDFS3_BIN): $(SDFS3_OBJ)
 	"$(P2BIN)" $(SDFS3_OBJ) $(SDFS3_BIN) -q
+
+$(SDFS3_LST): $(SDFS3_OBJ)
+
+$(SDFS3SYS_BIN): $(SDFS3_BIN) $(SDFS3_LST) tools/mk_sdfs3sys.py
+	"$(PYTHON)" tools/mk_sdfs3sys.py --input "$(SDFS3_BIN)" --listing "$(SDFS3_LST)" --output "$(SDFS3SYS_BIN)"
 
 sdfs-tools: sdfs-tools-srec sdfs-tools-com
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,6 +67,7 @@ ROM常駐FATを確認したい場合は、profileではなく直接構成軸で 
 - [plans/sdfs68_v3/issue-275_resident_detect.md](plans/sdfs68_v3/issue-275_resident_detect.md): SDFS/68 v3 ROM側resident header検出
 - [plans/sdfs68_v3/issue-279_memtop_caps.md](plans/sdfs68_v3/issue-279_memtop_caps.md): SDFS/68 v3 GET_MEMTOP / GET_CAPS API
 - [plans/sdfs68_v3/issue-276_cmd_gateway.md](plans/sdfs68_v3/issue-276_cmd_gateway.md): SDFS/68 v3 ROM CMD gateway
+- [plans/sdfs68_v3/issue-278_sdfs3sys_image.md](plans/sdfs68_v3/issue-278_sdfs3sys_image.md): SDFS/68 v3 SDFS3SYS system image生成
 - [plans/issue-141_sdfs68_load.md](plans/issue-141_sdfs68_load.md): SDFS/68 LOAD正式化
 - [plans/issue-149_sdfs68_run_addr.md](plans/issue-149_sdfs68_run_addr.md): SDFS/68 RUN addr
 - [plans/issue-150_sdfs68_run_file.md](plans/issue-150_sdfs68_run_file.md): SDFS/68 RUN filename

--- a/docs/plans/sdfs68_v3/README.md
+++ b/docs/plans/sdfs68_v3/README.md
@@ -31,3 +31,4 @@ v3 は、現行の `BOOT -> stage1 -> SDFS.BIN -> SDFS> ` 方式を単純に拡�
 | #275 | [issue-275_resident_detect.md](issue-275_resident_detect.md) | ROM側resident header検出 |
 | #279 | [issue-279_memtop_caps.md](issue-279_memtop_caps.md) | GET_MEMTOP / GET_CAPS API |
 | #276 | [issue-276_cmd_gateway.md](issue-276_cmd_gateway.md) | ROM CMD gateway |
+| #278 | [issue-278_sdfs3sys_image.md](issue-278_sdfs3sys_image.md) | SDFS3SYS system image生成 |

--- a/docs/plans/sdfs68_v3/issue-278_sdfs3sys_image.md
+++ b/docs/plans/sdfs68_v3/issue-278_sdfs3sys_image.md
@@ -1,0 +1,66 @@
+# Issue #278 SDFS/68 v3 SDFS3SYS system image生成
+
+## 背景
+
+#257では、v3 residentを固定LBA system imageから1発ロードする案を採用候補にした。
+#271以降で `SDFS3API` resident stub、ROM側resident検出、`CMD <tail>` gatewayが入ったため、次はPC側/ビルド側でresident binaryをROM loaderが扱えるsystem image形式へ包む必要がある。
+
+このIssueでは、ROMから固定LBAを読む実装には入らず、`SDFS3SYS` header付きimageの生成と検査に絞る。
+
+## 採用方針
+
+- v3用toolは `tools/mk_sdfs3sys.py` として既存v2の `tools/mk_sdfs_image.py` から分ける。
+- `make sdfs3sys` で `build/SDFS3SYS*.BIN` を生成する。
+- headerは #257 の初期案どおり32 bytes固定で始める。
+- 16bit値はMC6800側で扱いやすいbig-endianにする。
+- `load_address` は listing の `SDFS_LOAD_BASE` を使う。
+- payloadが listing の `SDFS_LOAD_BASE..SDFS_LOAD_LIMIT` を超える場合は生成時に拒否する。
+- `entry_offset` は現stubで安全に呼べる `SDFS3_GET_INFO - SDFS_LOAD_BASE` とする。
+- `api_table_offset` はresident API jump table位置である `SDFS3_JUMP_TABLE - SDFS_LOAD_BASE` とする。
+- ROM側resident検出で使う `SDFS3API` headerは、現stubではpayload先頭の `SDFS_LOAD_BASE` に置く前提とする。
+- checksumはchecksum欄 `$18-$19` だけを0として、header+payload全体の16bit加算で計算する。
+- 初期最大image sizeは #257 の16KB級方針に合わせて16KBとする。
+
+## Header
+
+| Offset | Size | 項目 | 初期値 |
+| ---: | ---: | --- | --- |
+| `$00` | 8 | magic | `SDFS3SYS` |
+| `$08` | 1 | header version | `1` |
+| `$09` | 1 | ABI major | `1` |
+| `$0A` | 1 | ABI minor | `0` |
+| `$0B` | 1 | flags | bit0: checksum16あり |
+| `$0C` | 2 | load address | `SDFS_LOAD_BASE` |
+| `$0E` | 2 | image size | header + payload bytes |
+| `$10` | 2 | entry offset | `SDFS3_GET_INFO - SDFS_LOAD_BASE` |
+| `$12` | 2 | API table offset | `SDFS3_JUMP_TABLE - SDFS_LOAD_BASE` |
+| `$14` | 2 | work min | `0` |
+| `$16` | 2 | bank window hint | `0` |
+| `$18` | 2 | checksum | checksum欄を0として計算した16bit加算 |
+| `$1A` | 2 | header size | `32` |
+| `$1C` | 4 | reserved | `0` |
+
+## 検証方針
+
+- `tests/test_sdfs68_v3_build.py` で `sbcio_4000` と `k6802_4000` の `make sdfs3sys` を実行する。
+- headerのload address、image size、entry offset、API table offset、checksum、payload境界を確認する。
+- payloadが `SDFS_LOAD_LIMIT` を超える場合に生成を拒否することを確認する。
+- bad magicとbad checksumを `parse_sdfs3sys_header` が拒否することを確認する。
+- listingに必要symbolがないCLI失敗を確認する。
+- 既存v2 image生成経路を壊していないことを `make test` で確認する。
+
+## 対象外
+
+- ROMから固定LBAを読む実装。
+- system領域slot A/B更新。
+- active marker形式。
+- FAT write。
+- residentの `DIR` / `TYPE` / `LOAD` / `RUN` 実装。
+
+## 関連
+
+- #278: 対応Issue。
+- #272: v3 phase 1 実装epic。
+- #257: 固定LBA system image形式と1発ロード方式。
+- #258: system領域更新方式。
+- #271: resident API stub とビルド基盤。

--- a/docs/usage/build_commands.md
+++ b/docs/usage/build_commands.md
@@ -105,8 +105,10 @@ ROM_CODE_LIMIT=0 make bin
 | SDFS/68本体 | `MONITOR_PROFILE=sbcio_vdg make sdfs` | `build/SDFS-sbcio-vdg.BIN` |
 | SDFS/68 stage1 (16k) | `MONITOR_PROFILE=sbcio_4000 make stage1` | `build/stage1-sbcio-4000.bin` |
 | SDFS/68本体 (16k) | `MONITOR_PROFILE=sbcio_4000 make sdfs` | `build/SDFS-sbcio-4000.BIN` |
+| SDFS/68 v3 resident system image (16k) | `MONITOR_PROFILE=sbcio_4000 make sdfs3sys` | `build/SDFS3SYS-sbcio-4000.BIN` |
 | SDFS/68 stage1 (k6802-16k) | `MONITOR_PROFILE=k6802_4000 make stage1` | `build/stage1-k6802-4000.bin` |
 | SDFS/68本体 (k6802-16k) | `MONITOR_PROFILE=k6802_4000 make sdfs` | `build/SDFS-k6802-4000.BIN` |
+| SDFS/68 v3 resident system image (k6802-16k) | `MONITOR_PROFILE=k6802_4000 make sdfs3sys` | `build/SDFS3SYS-k6802-4000.BIN` |
 
 成果物の所属は次の通り。
 
@@ -115,13 +117,15 @@ ROM_CODE_LIMIT=0 make bin
 | `make bin` / `make rombin` | ROMモニタ | EPROM/EEPROMへ焼く本体。低レベル操作と `BOOT` 入口を持つ |
 | `make stage1` | system SD fixed boot area | ROM `BOOT` から読まれる第1段loader |
 | `make sdfs` | system SD FAT root | `SDFS.BIN` として置く第2段DOS本体 |
+| `make sdfs3sys` | system SD fixed system area | v3 residentを `SDFS3SYS` headerで包んだ固定LBA system image |
 | `tools/mk_sdfs_image.py` | ホストPC上の補助ツール | stage1、`SDFS.BIN`、利用者ファイルをまとめた system SD image を作る |
+| `tools/mk_sdfs3sys.py` | ホストPC上の補助ツール | v3 resident binaryに `SDFS3SYS` headerを付ける |
 
 ## SDFS/68 stage1
 
 `stage1` ターゲットは SDFS/68 の固定LBA boot areaへ置くstage1 loaderを単体生成する。
 生成可否はprofile名ではなく構成軸で決まる。
-`FEATURE_SD=1`、`BOARD_IO=sbcio`、stage1対応RAM配置である `MEMORY_CONFIG=ram64_c000_work` または `ram64_a000_work` の組み合わせで有効になる。
+`FEATURE_SD=1`、`BOARD_IO=sbcio`、stage1対応RAM配置である `MEMORY_CONFIG=ram64_c000_work`、`ram64_a000_work`、`ram64_4000_work` の組み合わせで有効になる。
 `base` profileや `FEATURE_SD=0` の構成では生成しない。
 
 ```sh
@@ -167,6 +171,10 @@ SDFS/68本体の初期ロード領域はそれぞれ `$D000-$DEFF`、`$B000-$BEF
 
 `sdfs` ターゲットは FAT root の `SDFS.BIN` として配置するSDFS/68本体を生成する。
 出力はsuffix付きの `build/SDFS-sbcio-vdg.BIN`、`build/SDFS-k6802-vdg.BIN`、`build/SDFS-sbcio-sdfs.BIN` などで、SDイメージ作成時に root の8.3名 `SDFS.BIN` として格納する。
+
+`sdfs3sys` ターゲットは v3 resident binaryを `SDFS3SYS` header付きsystem imageへ包む。
+出力はsuffix付きの `build/SDFS3SYS-sbcio-4000.BIN`、`build/SDFS3SYS-k6802-4000.BIN` などで、後続の固定LBA loaderが読むsystem領域へ配置する。
+このtargetは `make sdfs3` を前提にし、resident listingからload address、load limit、entry offset、resident API table offsetを取得する。
 
 ROM profileでは `FEATURE_SD` と `FEATURE_FAT` を分ける。
 `FEATURE_SD=1` はraw SD sector readと `BOOT` の前提、`FEATURE_FAT=1` はROM常駐の `DIR` / `LF` を含める設定である。

--- a/tests/test_sdfs68_v3_build.py
+++ b/tests/test_sdfs68_v3_build.py
@@ -11,7 +11,17 @@ from pathlib import Path
 
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "tools"))
 EMU_PATH = PROJECT_ROOT / "emu" / "sbc6800_emu.py"
+
+from mk_sdfs3sys import (  # noqa: E402
+    FLAG_CHECKSUM16,
+    HEADER_SIZE,
+    MAGIC,
+    build_sdfs3sys_image,
+    checksum16,
+    parse_sdfs3sys_header,
+)
 
 
 EXPECTED = {
@@ -151,6 +161,118 @@ def test_sdfs3_memtop_and_caps_match_calling_convention() -> None:
             ]
         )
     print("[PASS] test_sdfs3_memtop_and_caps_match_calling_convention")
+
+
+def test_sdfs3sys_profiles_build_and_match_header() -> None:
+    for profile, expected in EXPECTED.items():
+        _run_make(profile, "sdfs3sys")
+        suffix = expected["suffix"]
+        sys_path = PROJECT_ROOT / "build" / f"SDFS3SYS{suffix}.BIN"
+        bin_path = PROJECT_ROOT / "build" / f"SDFS3{suffix}.BIN"
+        lst_path = PROJECT_ROOT / "build" / f"SDFS3{suffix}.lst"
+        image = sys_path.read_bytes()
+        payload = bin_path.read_bytes()
+        symbols = _load_symbols(
+            lst_path,
+            "SDFS_LOAD_BASE",
+            "SDFS_LOAD_LIMIT",
+            "SDFS3_JUMP_TABLE",
+            "SDFS3_GET_INFO",
+        )
+        header = parse_sdfs3sys_header(image)
+        assert image[0:8] == MAGIC
+        assert header.header_version == 1
+        assert header.abi_major == 1
+        assert header.abi_minor == 0
+        assert header.flags == FLAG_CHECKSUM16
+        assert header.load_address == expected["SDFS_LOAD_BASE"]
+        assert header.load_address == symbols["SDFS_LOAD_BASE"]
+        assert len(payload) <= symbols["SDFS_LOAD_LIMIT"] - symbols["SDFS_LOAD_BASE"] + 1
+        assert header.image_size == HEADER_SIZE + len(payload)
+        assert header.entry_offset == symbols["SDFS3_GET_INFO"] - symbols["SDFS_LOAD_BASE"]
+        assert header.api_table_offset == symbols["SDFS3_JUMP_TABLE"] - symbols["SDFS_LOAD_BASE"]
+        assert header.work_min == 0
+        assert header.bank_window_hint == 0
+        assert header.header_size == HEADER_SIZE
+        assert header.checksum == checksum16(image)
+        assert image[HEADER_SIZE:] == payload
+    print("[PASS] test_sdfs3sys_profiles_build_and_match_header")
+
+
+def test_sdfs3sys_rejects_bad_header_and_checksum() -> None:
+    payload = b"SDFS3API" + bytes(range(64))
+    image = build_sdfs3sys_image(
+        resident_data=payload,
+        load_address=0x5000,
+        load_limit=0x7EFF,
+        entry_address=0x5018,
+        api_table_address=0x5018,
+    )
+    bad_magic = bytearray(image)
+    bad_magic[0] = ord("X")
+    try:
+        parse_sdfs3sys_header(bytes(bad_magic))
+    except ValueError as exc:
+        assert "magic" in str(exc)
+    else:
+        raise AssertionError("bad SDFS3SYS magic should be rejected")
+
+    bad_checksum = bytearray(image)
+    bad_checksum[-1] ^= 0x01
+    try:
+        parse_sdfs3sys_header(bytes(bad_checksum))
+    except ValueError as exc:
+        assert "checksum" in str(exc)
+    else:
+        raise AssertionError("bad SDFS3SYS checksum should be rejected")
+    print("[PASS] test_sdfs3sys_rejects_bad_header_and_checksum")
+
+
+def test_sdfs3sys_rejects_payload_outside_load_range() -> None:
+    try:
+        build_sdfs3sys_image(
+            resident_data=b"X" * 2,
+            load_address=0x5000,
+            load_limit=0x5000,
+            entry_address=0x5000,
+            api_table_address=0x5000,
+        )
+    except ValueError as exc:
+        assert "load range" in str(exc)
+    else:
+        raise AssertionError("payload outside SDFS load range should be rejected")
+    print("[PASS] test_sdfs3sys_rejects_payload_outside_load_range")
+
+
+def test_sdfs3sys_cli_reports_bad_input() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        payload = root / "SDFS3.BIN"
+        listing = root / "SDFS3.lst"
+        output = root / "SDFS3SYS.BIN"
+        payload.write_bytes(b"SDFS3API")
+        listing.write_text("", encoding="ascii")
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(PROJECT_ROOT / "tools" / "mk_sdfs3sys.py"),
+                "--input",
+                str(payload),
+                "--listing",
+                str(listing),
+                "--output",
+                str(output),
+            ],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=10,
+        )
+        assert result.returncode == 2
+        assert "mk-sdfs3sys:" in result.stderr
+        assert not output.exists()
+    print("[PASS] test_sdfs3sys_cli_reports_bad_input")
 
 
 def test_sdfs3_rejects_base_profile() -> None:
@@ -473,6 +595,10 @@ def main() -> None:
         test_sdfs3_profiles_build_and_match_header,
         test_sdfs3_get_info_matches_calling_convention,
         test_sdfs3_memtop_and_caps_match_calling_convention,
+        test_sdfs3sys_profiles_build_and_match_header,
+        test_sdfs3sys_rejects_bad_header_and_checksum,
+        test_sdfs3sys_rejects_payload_outside_load_range,
+        test_sdfs3sys_cli_reports_bad_input,
         test_rom_detects_sdfs3_api_header,
         test_rom_cmd_gateway_calls_resident_dispatch,
     ]

--- a/tools/mk_sdfs3sys.py
+++ b/tools/mk_sdfs3sys.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Create and validate a SDFS/68 v3 fixed-LBA system image."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+MAGIC = b"SDFS3SYS"
+HEADER_VERSION = 1
+HEADER_SIZE = 32
+FLAG_CHECKSUM16 = 0x01
+MAX_IMAGE_SIZE = 16 * 1024
+CHECKSUM_OFFSET = 0x18
+
+
+@dataclass(frozen=True)
+class Sdfs3SysHeader:
+    header_version: int
+    abi_major: int
+    abi_minor: int
+    flags: int
+    load_address: int
+    image_size: int
+    entry_offset: int
+    api_table_offset: int
+    work_min: int
+    bank_window_hint: int
+    checksum: int
+    header_size: int
+
+
+def build_sdfs3sys_image(
+    *,
+    resident_data: bytes,
+    load_address: int,
+    load_limit: int | None,
+    entry_address: int,
+    api_table_address: int,
+    abi_major: int = 1,
+    abi_minor: int = 0,
+    flags: int = FLAG_CHECKSUM16,
+    work_min: int = 0,
+    bank_window_hint: int = 0,
+) -> bytes:
+    if not resident_data:
+        raise ValueError("resident payload must not be empty")
+    if load_limit is not None and load_address + len(resident_data) - 1 > load_limit:
+        raise ValueError("resident payload exceeds SDFS load range")
+    image_size = HEADER_SIZE + len(resident_data)
+    if image_size > MAX_IMAGE_SIZE:
+        raise ValueError(f"SDFS3SYS image exceeds {MAX_IMAGE_SIZE} bytes")
+    entry_offset = _offset_from_load(load_address, entry_address, "entry")
+    api_table_offset = _offset_from_load(load_address, api_table_address, "API table")
+    header = bytearray(HEADER_SIZE)
+    header[0:8] = MAGIC
+    header[0x08] = _byte(HEADER_VERSION, "header version")
+    header[0x09] = _byte(abi_major, "ABI major")
+    header[0x0A] = _byte(abi_minor, "ABI minor")
+    header[0x0B] = _byte(flags, "flags")
+    _put_u16be(header, 0x0C, load_address)
+    _put_u16be(header, 0x0E, image_size)
+    _put_u16be(header, 0x10, entry_offset)
+    _put_u16be(header, 0x12, api_table_offset)
+    _put_u16be(header, 0x14, work_min)
+    _put_u16be(header, 0x16, bank_window_hint)
+    _put_u16be(header, CHECKSUM_OFFSET, 0)
+    _put_u16be(header, 0x1A, HEADER_SIZE)
+    image = bytes(header) + resident_data
+    checksum = checksum16(image)
+    mutable = bytearray(image)
+    _put_u16be(mutable, CHECKSUM_OFFSET, checksum)
+    return bytes(mutable)
+
+
+def parse_sdfs3sys_header(image: bytes) -> Sdfs3SysHeader:
+    if len(image) < HEADER_SIZE:
+        raise ValueError("SDFS3SYS image is shorter than the fixed header")
+    if image[0:8] != MAGIC:
+        raise ValueError("SDFS3SYS magic mismatch")
+    header = Sdfs3SysHeader(
+        header_version=image[0x08],
+        abi_major=image[0x09],
+        abi_minor=image[0x0A],
+        flags=image[0x0B],
+        load_address=_u16be(image, 0x0C),
+        image_size=_u16be(image, 0x0E),
+        entry_offset=_u16be(image, 0x10),
+        api_table_offset=_u16be(image, 0x12),
+        work_min=_u16be(image, 0x14),
+        bank_window_hint=_u16be(image, 0x16),
+        checksum=_u16be(image, CHECKSUM_OFFSET),
+        header_size=_u16be(image, 0x1A),
+    )
+    if header.header_version != HEADER_VERSION:
+        raise ValueError("unsupported SDFS3SYS header version")
+    if header.header_size < HEADER_SIZE:
+        raise ValueError("SDFS3SYS header size is too small")
+    if header.image_size != len(image):
+        raise ValueError("SDFS3SYS image size mismatch")
+    if header.image_size > MAX_IMAGE_SIZE:
+        raise ValueError(f"SDFS3SYS image exceeds {MAX_IMAGE_SIZE} bytes")
+    if header.entry_offset >= len(image) - HEADER_SIZE:
+        raise ValueError("SDFS3SYS entry offset points outside payload")
+    if header.api_table_offset >= len(image) - HEADER_SIZE:
+        raise ValueError("SDFS3SYS API header offset points outside payload")
+    if header.flags & FLAG_CHECKSUM16:
+        actual = checksum16(image)
+        if actual != header.checksum:
+            raise ValueError("SDFS3SYS checksum mismatch")
+    return header
+
+
+def checksum16(image: bytes) -> int:
+    data = bytearray(image)
+    if len(data) > CHECKSUM_OFFSET + 1:
+        data[CHECKSUM_OFFSET] = 0
+        data[CHECKSUM_OFFSET + 1] = 0
+    return sum(data) & 0xFFFF
+
+
+def load_symbols(path: Path, *names: str) -> dict[str, int]:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    result: dict[str, int] = {}
+    for name in names:
+        patterns = [
+            re.compile(rf":\s*=\$([0-9A-Fa-f]{{1,4}})\s+{re.escape(name)}\s+equ\b"),
+            re.compile(rf"/([0-9A-Fa-f]{{1,4}})\s+:\s+.*\b{re.escape(name)}:\s*$"),
+            re.compile(rf"\b{re.escape(name)}\s+:\s+([0-9A-Fa-f]{{1,4}})\b"),
+        ]
+        for pattern in patterns:
+            match = pattern.search(text)
+            if match:
+                result[name] = int(match.group(1), 16)
+                break
+        if name not in result:
+            raise ValueError(f"missing symbol in listing: {name}")
+    return result
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Create a SDFS/68 v3 SDFS3SYS image from a resident binary.",
+    )
+    parser.add_argument("--input", required=True, type=Path, help="SDFS3 resident binary")
+    parser.add_argument("--listing", required=True, type=Path, help="SDFS3 resident listing")
+    parser.add_argument("--output", required=True, type=Path, help="output SDFS3SYS image")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        symbols = load_symbols(
+            args.listing,
+            "SDFS_LOAD_BASE",
+            "SDFS_LOAD_LIMIT",
+            "SDFS3_GET_INFO",
+            "SDFS3_JUMP_TABLE",
+        )
+        image = build_sdfs3sys_image(
+            resident_data=args.input.read_bytes(),
+            load_address=symbols["SDFS_LOAD_BASE"],
+            load_limit=symbols["SDFS_LOAD_LIMIT"],
+            entry_address=symbols["SDFS3_GET_INFO"],
+            api_table_address=symbols["SDFS3_JUMP_TABLE"],
+        )
+        parse_sdfs3sys_header(image)
+        args.output.write_bytes(image)
+    except OSError as exc:
+        print(f"mk-sdfs3sys: {exc}", file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        print(f"mk-sdfs3sys: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+def _offset_from_load(load_address: int, address: int, label: str) -> int:
+    if address < load_address:
+        raise ValueError(f"{label} address is below load address")
+    return _u16(address - load_address, f"{label} offset")
+
+
+def _byte(value: int, label: str) -> int:
+    if value < 0 or value > 0xFF:
+        raise ValueError(f"{label} does not fit in 8 bits")
+    return value
+
+
+def _u16(value: int, label: str) -> int:
+    if value < 0 or value > 0xFFFF:
+        raise ValueError(f"{label} does not fit in 16 bits")
+    return value
+
+
+def _put_u16be(data: bytearray, offset: int, value: int) -> None:
+    value = _u16(value, "u16 value")
+    data[offset] = (value >> 8) & 0xFF
+    data[offset + 1] = value & 0xFF
+
+
+def _u16be(data: bytes, offset: int) -> int:
+    return (data[offset] << 8) | data[offset + 1]
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 概要
- v3 resident binaryを `SDFS3SYS` header付きsystem imageへ包む `tools/mk_sdfs3sys.py` を追加
- `make sdfs3sys` targetを追加し、`build/SDFS3SYS*.BIN` を生成できるようにした
- headerは `SDFS3SYS` magic、version、load address、image size、entry offset、API table offset、checksum、header sizeを持つ32byte形式にした
- checksumはchecksum欄を0としてheader+payload全体の16bit加算で計算し、bad magic/bad checksumを検出する
- listingから `SDFS_LOAD_BASE`、`SDFS_LOAD_LIMIT`、`SDFS3_GET_INFO`、`SDFS3_JUMP_TABLE` を取得し、payloadがload rangeを超える場合は生成時に拒否する
- build手順と #278 の実装メモを更新

## 確認内容
- `python3 tests/test_sdfs68_v3_build.py`
- `make -j2 sdfs3sys MONITOR_PROFILE=sbcio_4000`
- `make test`
- `git diff --check`
- `git diff --numstat` と `git diff --ignore-all-space --numstat` が一致することを確認

## レビュー指摘への対応
- `api_table_offset` を `SDFS3_JUMP_TABLE - SDFS_LOAD_BASE` に修正
- `SDFS_LOAD_LIMIT` を使ったpayload範囲検査を追加
- `SDFS3_LST` の副生成物依存を明示ruleで補強

Closes #278
Refs #272 #254 #257 #258 #271