### PR TITLE
SDFS/68 v3: resident CMD_DISPATCH parserを追加

### DIFF
--- a/docs/plans/sdfs68_v3/issue-281_cmd_dispatch_parser.md
+++ b/docs/plans/sdfs68_v3/issue-281_cmd_dispatch_parser.md
@@ -1,0 +1,43 @@
+# Issue #281 SDFS/68 v3 resident CMD_DISPATCH tail parser
+
+## 背景
+
+#276 で ROM 側 `CMD <tail>` gateway から resident API slot 1 `SDFS3_CMD_DISPATCH` を呼び出せるようになった。
+#280 / #282 で read-only 系や loader 系の実処理へ接続する前に、resident 側で tail の先頭トークンを分類する必要がある。
+
+## 採用方針
+
+- `SDFS3_CMD_DISPATCH` は `X=tail pointer`、`B=tail length`、`A=0` の #259 規約を受ける。
+- 先頭空白を読み飛ばし、最初の空白までを command token として扱う。
+- token 判定は大文字小文字非依存にする。
+- `DIR`、`TYPE`、`LOAD`、`RUN`、`*.COM` を分類する。
+- このIssueでは FAT mount、directory walk、file read、loader 実処理には入らない。
+- 分類できた command は、後続Issueで差し替えやすい個別 stub label へ分ける。
+- stub は carry set で戻し、`SDFS3_LAST_ERROR` へ command 種別ごとの未実装エラーを保存する。
+- 空tail、空白のみ、未知commandは `SDFS3_ERR_BAD_CMD` で戻す。
+
+## 対象外
+
+- `DIR` / `TYPE` の実処理接続。
+- `LOAD` / `RUN` / `.COM` の実処理接続。
+- path parser、8.3変換、FAT処理。
+- ROM側の直接alias追加。
+- v2 `SDFS> ` shell の変更。
+
+## 検証方針
+
+- `tests/test_sdfs68_v3_build.py` に resident parser harness を追加する。
+- built resident をRAMへロードし、harness から `SDFS3_CMD_DISPATCH` を直接呼ぶ。
+- `DIR`、前後空白付き小文字 `dir`、`TYPE`、大小混在 `LOAD`、`RUN`、大文字/小文字 `.COM` が各分類へ入ることを、`GET_ERROR` の未実装エラーコードで確認する。
+- 空tail、空白のみ、未知commandが bad command になることを確認する。
+- 既存 v3 system image / ROM gateway harness が通ることを確認する。
+- 最終確認は `make test` を使う。Windows のローカル実行では `PYTHON=python` と相対 `ASL_INCLUDE_ARG` が必要になる場合がある。
+
+## 関連
+
+- #281: 対応Issue。
+- #272: v3 phase 1 実装epic。
+- #276: ROM CMD gateway。
+- #280: resident DIR / TYPE read-only接続。
+- #282: resident LOAD / RUN / .COM接続。
+- #259: resident API最小セット。

--- a/src/sdfs68_v3/resident_stub.asm
+++ b/src/sdfs68_v3/resident_stub.asm
@@ -10,6 +10,12 @@ SDFS3_FLAG_NONE    equ 0
 SDFS3_CAPS_NONE    equ 0
 SDFS3_ERR_NONE     equ 0
 SDFS3_ERR_NOT_IMPL equ 1
+SDFS3_ERR_BAD_CMD  equ 2
+SDFS3_ERR_DIR_IMPL equ $11
+SDFS3_ERR_TYPE_IMPL equ $12
+SDFS3_ERR_LOAD_IMPL equ $13
+SDFS3_ERR_RUN_IMPL equ $14
+SDFS3_ERR_COM_IMPL equ $15
 
         if S1_SUPPORTED = 0
         error   "SDFS/68 v3 resident is not supported for this memory configuration"
@@ -49,7 +55,76 @@ SDFS3_GET_INFO:
         rts
 
 SDFS3_CMD_DISPATCH:
-        jmp     SDFS3_NOT_IMPLEMENTED
+        stx     SDFS3_PARSE_PTR
+        stab    SDFS3_PARSE_LEN
+SDFS3_CMD_SKIP_SPACE:
+        tst     SDFS3_PARSE_LEN
+        beq     SDFS3_BAD_COMMAND
+        ldx     SDFS3_PARSE_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        bne     SDFS3_CMD_TOKEN_START
+        inx
+        stx     SDFS3_PARSE_PTR
+        dec     SDFS3_PARSE_LEN
+        bra     SDFS3_CMD_SKIP_SPACE
+SDFS3_CMD_TOKEN_START:
+        stx     SDFS3_TOKEN_PTR
+        clr     SDFS3_TOKEN_LEN
+SDFS3_CMD_TOKEN_SCAN:
+        tst     SDFS3_PARSE_LEN
+        beq     SDFS3_CMD_TOKEN_DONE
+        ldx     SDFS3_PARSE_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        beq     SDFS3_CMD_TOKEN_DONE
+        inc     SDFS3_TOKEN_LEN
+        inx
+        stx     SDFS3_PARSE_PTR
+        dec     SDFS3_PARSE_LEN
+        bra     SDFS3_CMD_TOKEN_SCAN
+SDFS3_CMD_TOKEN_DONE:
+        ldaa    SDFS3_TOKEN_LEN
+        beq     SDFS3_BAD_COMMAND
+        cmpa    #3
+        bne     SDFS3_CMD_CHECK_4
+        jsr     SDFS3_IS_DIR
+        bcc     SDFS3_CMD_DIR_STUB
+        jsr     SDFS3_IS_RUN
+        bcc     SDFS3_CMD_RUN_STUB
+        bra     SDFS3_CMD_CHECK_COM
+SDFS3_CMD_CHECK_4:
+        cmpa    #4
+        bne     SDFS3_CMD_CHECK_COM
+        jsr     SDFS3_IS_TYPE
+        bcc     SDFS3_CMD_TYPE_STUB
+        jsr     SDFS3_IS_LOAD
+        bcc     SDFS3_CMD_LOAD_STUB
+SDFS3_CMD_CHECK_COM:
+        jsr     SDFS3_IS_COM_TOKEN
+        bcc     SDFS3_CMD_COM_STUB
+        bra     SDFS3_BAD_COMMAND
+
+SDFS3_CMD_DIR_STUB:
+        ldaa    #SDFS3_ERR_DIR_IMPL
+        bra     SDFS3_NOT_IMPLEMENTED_A
+SDFS3_CMD_TYPE_STUB:
+        ldaa    #SDFS3_ERR_TYPE_IMPL
+        bra     SDFS3_NOT_IMPLEMENTED_A
+SDFS3_CMD_LOAD_STUB:
+        ldaa    #SDFS3_ERR_LOAD_IMPL
+        bra     SDFS3_NOT_IMPLEMENTED_A
+SDFS3_CMD_RUN_STUB:
+        ldaa    #SDFS3_ERR_RUN_IMPL
+        bra     SDFS3_NOT_IMPLEMENTED_A
+SDFS3_CMD_COM_STUB:
+        ldaa    #SDFS3_ERR_COM_IMPL
+        bra     SDFS3_NOT_IMPLEMENTED_A
+SDFS3_BAD_COMMAND:
+        ldaa    #SDFS3_ERR_BAD_CMD
+        staa    SDFS3_LAST_ERROR
+        sec
+        rts
 
 SDFS3_LOAD_PATH:
         jmp     SDFS3_NOT_IMPLEMENTED
@@ -65,6 +140,7 @@ SDFS3_READ_STREAM_CLOSE:
 
 SDFS3_NOT_IMPLEMENTED:
         ldaa    #SDFS3_ERR_NOT_IMPL
+SDFS3_NOT_IMPLEMENTED_A:
         staa    SDFS3_LAST_ERROR
         sec
         rts
@@ -86,8 +162,148 @@ SDFS3_GET_CAPS:
         clc
         rts
 
+SDFS3_IS_DIR:
+        ldx     SDFS3_TOKEN_PTR
+        ldaa    0,x
+        jsr     SDFS3_TO_UPPER
+        cmpa    #'D'
+        bne     SDFS3_IS_DIR_FAIL
+        ldaa    1,x
+        jsr     SDFS3_TO_UPPER
+        cmpa    #'I'
+        bne     SDFS3_IS_DIR_FAIL
+        ldaa    2,x
+        jsr     SDFS3_TO_UPPER
+        cmpa    #'R'
+        bne     SDFS3_IS_DIR_FAIL
+        clc
+        rts
+SDFS3_IS_DIR_FAIL:
+        sec
+        rts
+
+SDFS3_IS_RUN:
+        ldx     SDFS3_TOKEN_PTR
+        ldaa    0,x
+        jsr     SDFS3_TO_UPPER
+        cmpa    #'R'
+        bne     SDFS3_IS_RUN_FAIL
+        ldaa    1,x
+        jsr     SDFS3_TO_UPPER
+        cmpa    #'U'
+        bne     SDFS3_IS_RUN_FAIL
+        ldaa    2,x
+        jsr     SDFS3_TO_UPPER
+        cmpa    #'N'
+        bne     SDFS3_IS_RUN_FAIL
+        clc
+        rts
+SDFS3_IS_RUN_FAIL:
+        sec
+        rts
+
+SDFS3_IS_TYPE:
+        ldx     SDFS3_TOKEN_PTR
+        ldaa    0,x
+        jsr     SDFS3_TO_UPPER
+        cmpa    #'T'
+        bne     SDFS3_IS_TYPE_FAIL
+        ldaa    1,x
+        jsr     SDFS3_TO_UPPER
+        cmpa    #'Y'
+        bne     SDFS3_IS_TYPE_FAIL
+        ldaa    2,x
+        jsr     SDFS3_TO_UPPER
+        cmpa    #'P'
+        bne     SDFS3_IS_TYPE_FAIL
+        ldaa    3,x
+        jsr     SDFS3_TO_UPPER
+        cmpa    #'E'
+        bne     SDFS3_IS_TYPE_FAIL
+        clc
+        rts
+SDFS3_IS_TYPE_FAIL:
+        sec
+        rts
+
+SDFS3_IS_LOAD:
+        ldx     SDFS3_TOKEN_PTR
+        ldaa    0,x
+        jsr     SDFS3_TO_UPPER
+        cmpa    #'L'
+        bne     SDFS3_IS_LOAD_FAIL
+        ldaa    1,x
+        jsr     SDFS3_TO_UPPER
+        cmpa    #'O'
+        bne     SDFS3_IS_LOAD_FAIL
+        ldaa    2,x
+        jsr     SDFS3_TO_UPPER
+        cmpa    #'A'
+        bne     SDFS3_IS_LOAD_FAIL
+        ldaa    3,x
+        jsr     SDFS3_TO_UPPER
+        cmpa    #'D'
+        bne     SDFS3_IS_LOAD_FAIL
+        clc
+        rts
+SDFS3_IS_LOAD_FAIL:
+        sec
+        rts
+
+SDFS3_IS_COM_TOKEN:
+        ldaa    SDFS3_TOKEN_LEN
+        cmpa    #5
+        blo     SDFS3_IS_COM_FAIL
+        suba    #4
+        tab
+        ldx     SDFS3_TOKEN_PTR
+SDFS3_COM_EXT_PTR_LOOP:
+        tstb
+        beq     SDFS3_COM_EXT_PTR_DONE
+        inx
+        decb
+        bra     SDFS3_COM_EXT_PTR_LOOP
+SDFS3_COM_EXT_PTR_DONE:
+        ldaa    0,x
+        cmpa    #'.'
+        bne     SDFS3_IS_COM_FAIL
+        ldaa    1,x
+        jsr     SDFS3_TO_UPPER
+        cmpa    #'C'
+        bne     SDFS3_IS_COM_FAIL
+        ldaa    2,x
+        jsr     SDFS3_TO_UPPER
+        cmpa    #'O'
+        bne     SDFS3_IS_COM_FAIL
+        ldaa    3,x
+        jsr     SDFS3_TO_UPPER
+        cmpa    #'M'
+        bne     SDFS3_IS_COM_FAIL
+        clc
+        rts
+SDFS3_IS_COM_FAIL:
+        sec
+        rts
+
+SDFS3_TO_UPPER:
+        cmpa    #'a'
+        blo     SDFS3_TO_UPPER_DONE
+        cmpa    #'z'
+        bhi     SDFS3_TO_UPPER_DONE
+        suba    #$20
+SDFS3_TO_UPPER_DONE:
+        rts
+
 SDFS3_LAST_ERROR:
         fcb     SDFS3_ERR_NONE
+SDFS3_PARSE_PTR:
+        fdb     0
+SDFS3_PARSE_LEN:
+        fcb     0
+SDFS3_TOKEN_PTR:
+        fdb     0
+SDFS3_TOKEN_LEN:
+        fcb     0
 
 SDFS3_END:
         end

--- a/tests/test_sdfs68_v3_build.py
+++ b/tests/test_sdfs68_v3_build.py
@@ -7,7 +7,9 @@ import re
 import subprocess
 import sys
 import tempfile
+from contextlib import contextmanager
 from pathlib import Path
+from uuid import uuid4
 
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
@@ -16,6 +18,7 @@ EMU_PATH = PROJECT_ROOT / "emu" / "sbc6800_emu.py"
 SDFS3SYS_FIXED_LBA = 64
 SECTOR_SIZE = 512
 SDFS3SYS_LOADER_HARNESS_ADDR = 0x0300
+TEMP_ROOT = PROJECT_ROOT / "build" / "tmp"
 
 from mk_sdfs3sys import (  # noqa: E402
     CHECKSUM_OFFSET,
@@ -167,6 +170,62 @@ def test_sdfs3_memtop_and_caps_match_calling_convention() -> None:
     print("[PASS] test_sdfs3_memtop_and_caps_match_calling_convention")
 
 
+def test_sdfs3_cmd_dispatch_parser_classifies_stub_commands() -> None:
+    profile = "sbcio_4000"
+    expected = EXPECTED[profile]
+    _run_make(profile, "bin")
+    _run_make(profile, "sdfs3")
+    suffix = expected["suffix"]
+    resident = (PROJECT_ROOT / "build" / f"SDFS3{suffix}.BIN").read_bytes()
+    symbols = _load_symbols(
+        PROJECT_ROOT / "build" / f"SDFS3{suffix}.lst",
+        "SDFS_LOAD_BASE",
+        "SDFS3_CMD_DISPATCH",
+        "SDFS3_GET_ERROR",
+    )
+    cases = [
+        ("DIR", 0x11),
+        (" dir ", 0x11),
+        ("TYPE README.TXT", 0x12),
+        ("LoAd HELLO.S", 0x13),
+        ("RUN 1234", 0x14),
+        ("FOO.COM ARG", 0x15),
+        ("foo.com", 0x15),
+        ("", 0x02),
+        ("   ", 0x02),
+        ("UNKNOWN", 0x02),
+    ]
+    with _temporary_directory() as tmp:
+        harness = _assemble_cmd_dispatch_harness(Path(tmp), symbols, cases)
+    result_addr = 0x0200
+    stdout, stderr, rc = _run_emu(
+        rom_path=PROJECT_ROOT / "build" / f"mc6800-monitor{suffix}.bin",
+        input_text=(
+            f"M{symbols['SDFS_LOAD_BASE']:04X}\r"
+            f"{_hex_bytes(resident)}\r.\r"
+            "M0300\r"
+            f"{_hex_bytes(harness)}\r.\r"
+            "G0300\r"
+            f"D{result_addr:04X}-{result_addr + len(cases) * 2 - 1:04X}\r"
+            "\r"
+        ),
+        max_cycles=30_000_000,
+        dump_range=f"{result_addr:04X}-{result_addr + len(cases) * 2 - 1:04X}",
+        timeout=20,
+    )
+    assert rc == 0 and "[TIMEOUT]" not in stderr, (
+        f"emulator failed for CMD_DISPATCH parser: rc={rc} stderr={stderr!r}"
+    )
+    values = _dump_range_bytes(stdout, result_addr, len(cases) * 2)
+    expected_values: list[int] = []
+    for _, error_code in cases:
+        expected_values.extend([1, error_code])
+    assert values == expected_values, (
+        f"CMD_DISPATCH parser classification mismatch: {values!r}\nstdout={stdout!r}"
+    )
+    print("[PASS] test_sdfs3_cmd_dispatch_parser_classifies_stub_commands")
+
+
 def test_sdfs3sys_profiles_build_and_match_header() -> None:
     for profile, expected in EXPECTED.items():
         _run_make(profile, "sdfs3sys")
@@ -249,7 +308,7 @@ def test_sdfs3sys_rejects_payload_outside_load_range() -> None:
 
 
 def test_sdfs3sys_cli_reports_bad_input() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with _temporary_directory() as tmp:
         root = Path(tmp)
         payload = root / "SDFS3.BIN"
         listing = root / "SDFS3.lst"
@@ -482,7 +541,7 @@ def test_fixed_lba_loader_harness_loads_sdfs3sys() -> None:
     sdfs3sys = (PROJECT_ROOT / "build" / f"SDFS3SYS{suffix}.BIN").read_bytes()
     assert len(sdfs3sys) <= SECTOR_SIZE, "loader harness is intentionally single-sector"
     payload = sdfs3sys[HEADER_SIZE:]
-    with tempfile.TemporaryDirectory() as tmp:
+    with _temporary_directory() as tmp:
         harness = _assemble_fixed_lba_loader_harness(Path(tmp), symbols)
     stdout, stderr, rc = _run_emu(
         rom_path=PROJECT_ROOT / "build" / f"mc6800-monitor{suffix}.bin",
@@ -532,7 +591,7 @@ def test_fixed_lba_loader_harness_rejects_bad_sdfs3sys() -> None:
     )
     image = (PROJECT_ROOT / "build" / f"SDFS3SYS{suffix}.BIN").read_bytes()
     assert len(image) <= SECTOR_SIZE, "loader harness is intentionally single-sector"
-    with tempfile.TemporaryDirectory() as tmp:
+    with _temporary_directory() as tmp:
         harness = _assemble_fixed_lba_loader_harness(Path(tmp), symbols)
 
     cases = [
@@ -672,6 +731,87 @@ def _assemble_fixed_lba_loader_harness(tmp: Path, symbols: dict[str, int]) -> by
     if result.returncode != 0:
         raise AssertionError(f"p2bin loader harness failed: {result.stdout!r} {result.stderr!r}")
     return bin_path.read_bytes()
+
+
+def _assemble_cmd_dispatch_harness(
+    tmp: Path,
+    symbols: dict[str, int],
+    cases: list[tuple[str, int]],
+) -> bytes:
+    source = tmp / "sdfs3_cmd_dispatch_harness.asm"
+    obj = tmp / "sdfs3_cmd_dispatch_harness.p"
+    bin_path = tmp / "sdfs3_cmd_dispatch_harness.bin"
+    lst = tmp / "sdfs3_cmd_dispatch_harness.lst"
+    source.write_text(_cmd_dispatch_harness_source(symbols, cases), encoding="ascii")
+    result = subprocess.run(
+        ["asl", "-q", "-L", "-olist", str(lst), "-o", str(obj), str(source)],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=10,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"assemble CMD_DISPATCH harness failed: {result.stdout!r} {result.stderr!r}"
+        )
+    result = subprocess.run(
+        ["p2bin", str(obj), str(bin_path), "-q"],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=10,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"p2bin CMD_DISPATCH harness failed: {result.stdout!r} {result.stderr!r}"
+        )
+    return bin_path.read_bytes()
+
+
+def _cmd_dispatch_harness_source(
+    symbols: dict[str, int],
+    cases: list[tuple[str, int]],
+) -> str:
+    lines = [
+        "        cpu     6800",
+        "        org     $0300",
+        "",
+        "RESULTS         equ $0200",
+        f"SDFS3_CMD_DISPATCH equ ${symbols['SDFS3_CMD_DISPATCH']:04X}",
+        f"SDFS3_GET_ERROR equ ${symbols['SDFS3_GET_ERROR']:04X}",
+        "",
+        "START:",
+    ]
+    for index, (tail, _) in enumerate(cases):
+        lines.extend(
+            [
+                f"        ldx     #TAIL{index}",
+                f"        ldab    #{len(tail)}",
+                "        clra",
+                "        jsr     SDFS3_CMD_DISPATCH",
+                f"        bcs     CASE{index}_CARRY",
+                "        clra",
+                f"        bra     CASE{index}_STORE_STATUS",
+                f"CASE{index}_CARRY:",
+                "        ldaa    #1",
+                f"CASE{index}_STORE_STATUS:",
+                f"        staa    RESULTS+{index * 2}",
+                "        jsr     SDFS3_GET_ERROR",
+                f"        staa    RESULTS+{index * 2 + 1}",
+            ]
+        )
+    lines.extend(["        swi", ""])
+    for index, (tail, _) in enumerate(cases):
+        if tail:
+            escaped = tail.replace('"', '""')
+            lines.append(f'TAIL{index}:        fcc     "{escaped}"')
+        else:
+            lines.append(f"TAIL{index}:        fcb     0")
+    return "\n".join(lines) + "\n"
 
 
 def _fixed_lba_loader_harness_source(symbols: dict[str, int]) -> str:
@@ -932,6 +1072,14 @@ def _hex_bytes(data: bytes) -> str:
     return "\r".join(f"{value:02X}" for value in data)
 
 
+@contextmanager
+def _temporary_directory():
+    TEMP_ROOT.mkdir(parents=True, exist_ok=True)
+    path = TEMP_ROOT / f"codex-{uuid4().hex}"
+    path.mkdir()
+    yield str(path)
+
+
 def _run_emu(
     *,
     rom_path: Path,
@@ -941,12 +1089,13 @@ def _run_emu(
     sd_image: bytes | None = None,
     timeout: int = 10,
 ) -> tuple[str, str, int]:
-    with tempfile.NamedTemporaryFile("w", encoding="ascii", delete=False) as f:
+    TEMP_ROOT.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile("w", encoding="ascii", delete=False, dir=TEMP_ROOT) as f:
         f.write(input_text)
         input_path = Path(f.name)
     sd_path: Path | None = None
     if sd_image is not None:
-        with tempfile.NamedTemporaryFile(suffix=".img", delete=False) as f:
+        with tempfile.NamedTemporaryFile(suffix=".img", delete=False, dir=TEMP_ROOT) as f:
             f.write(sd_image)
             sd_path = Path(f.name)
     try:
@@ -1005,8 +1154,11 @@ def _run_make(
     target: str,
     expect_success: bool = True,
 ) -> subprocess.CompletedProcess[str]:
+    make_args = ["make", target, f"MONITOR_PROFILE={profile}"]
+    if sys.platform == "win32":
+        make_args.extend(["PYTHON=python", "ASL_INCLUDE_ARG=build;include;src"])
     result = subprocess.run(
-        ["make", target, f"MONITOR_PROFILE={profile}"],
+        make_args,
         cwd=PROJECT_ROOT,
         capture_output=True,
         text=True,
@@ -1049,6 +1201,7 @@ def main() -> None:
         test_sdfs3_profiles_build_and_match_header,
         test_sdfs3_get_info_matches_calling_convention,
         test_sdfs3_memtop_and_caps_match_calling_convention,
+        test_sdfs3_cmd_dispatch_parser_classifies_stub_commands,
         test_sdfs3sys_profiles_build_and_match_header,
         test_sdfs3sys_rejects_bad_header_and_checksum,
         test_sdfs3sys_rejects_payload_outside_load_range,


### PR DESCRIPTION
## 対応Issue

Closes #281
Refs #272
Refs #276
Refs #259

## 変更内容

- resident stub の SDFS3_CMD_DISPATCH に tail parser を追加
- 先頭空白スキップ、先頭token切り出し、大文字小文字非依存判定を追加
- DIR / TYPE / LOAD / RUN / *.COM を個別 stub 分岐へ分類
- 空tail、空白のみ、未知commandを bad command として返却
- Issue #281 の計画メモを docs/plans/sdfs68_v3/ に追加

## テスト結果

- PASS: python tests/test_sdfs68_v3_build.py
- PASS: $env:REQUIRE_BUILD_ROM='1'; python tests/test_smoke.py
- PASS: $env:REQUIRE_BUILD_ROM='1'; python tests/test_sd_fixture.py
- PASS: $env:REQUIRE_BUILD_ROM='1'; $env:MONITOR_PROFILE='sbcio'; $env:MONITOR_ROM_PATH='build/mc6800-monitor-sbcio.bin'; $env:MONITOR_LST_PATH='build/mc6800-monitor-sbcio.lst'; python tests/test_smoke.py
- PASS: $env:REQUIRE_BUILD_ROM='1'; $env:MONITOR_PROFILE='sbcio'; $env:MONITOR_ROM_PATH='build/mc6800-monitor-sbcio.bin'; $env:MONITOR_LST_PATH='build/mc6800-monitor-sbcio.lst'; python tests/test_sd_fixture.py

## 追加または更新したテスト

- tests/test_sdfs68_v3_build.py に CMD_DISPATCH parser harness を追加
- built resident をRAMへロードし、DIR / dir / TYPE / LoAd / RUN / FOO.COM / foo.com / 空tail / 空白のみ / UNKNOWN の分類結果を GET_ERROR で確認

## 影響範囲

- v3 resident stub の CMD_DISPATCH のみ
- FAT処理、v2 SDFS/68、ROM CMD gateway の呼び出し規約は変更なし

## 未対応事項

- DIR / TYPE / LOAD / RUN / .COM の実処理接続は #280 / #282 で対応
- Windowsローカルの make test は GnuWin32 make が REQUIRE_BUILD_ROM=1 command 形式を解釈できず停止したため、PowerShell形式で同等手順を個別実行した
- tests/test_sdfs68_build.py / tests/test_stage1_build.py は内部 make が python3 を呼ぶため、このWindows環境では環境失敗した
- tests/test_mk_sdfs_image.py は既存の tempfile cleanup 権限問題でCLIテストのみ環境失敗した

## 関連リンク

- #272
- #276
- #259