### PR TITLE
Issue #280 SDFS/68 v3 DIRとTYPEを接続

### DIFF
--- a/docs/plans/sdfs68_v3/issue-280_dir_type_readonly.md
+++ b/docs/plans/sdfs68_v3/issue-280_dir_type_readonly.md
@@ -1,0 +1,56 @@
+# Issue #280 SDFS/68 v3 resident DIR / TYPE read-only接続
+
+## 背景
+
+#281 で resident 側 `SDFS3_CMD_DISPATCH` が `DIR` / `TYPE` / `LOAD` / `RUN` / `*.COM` を分類できるようになった。
+このIssueでは、read-only系の `DIR` と `TYPE` を実処理へ接続する。
+
+## 採用方針
+
+- ROM側の `CMD` gatewayは変更しない。
+- `DIR` / `TYPE` の切り分けと実処理はRAM resident側に置く。
+- v3 residentは phase 1 の実装部品として `sdcard.asm` と `fat32.asm` を直接 include する。
+- 外部ABIとしてstage1 APIには依存しない。
+- `FAT32_MOUNT` はSD初期化込みで呼び、各 `CMD DIR` / `CMD TYPE` ごとにmountする。
+- `CMD DIR` はroot directoryを表示する。
+- `CMD DIR <path>` は既存v2相当の8.3 path parserでdirectoryを解決して表示する。
+- `CMD TYPE <path>` はfileを解決し、`FAT32_STREAM_OPEN` / `FAT32_STREAM_GETC` で内容を出力する。
+- hidden / system / volume label / LFN / AppleDouble系のskip判定は既存v2の `DIR` 表示方針を踏襲する。
+- `LOAD` / `RUN` / `.COM` は引き続き未実装stubのまま残す。
+
+## 実装上の注意
+
+- residentが1 sectorを超えるため、既存の固定LBA loader harnessを複数sector対応へ更新する。
+- system imageのchecksum検査も `image_size` 全体を対象にする。
+- テスト用のv3 SD imageは、`SDFS3SYS` を固定LBA 64へ置き、FAT partitionはLBA 128以降へ置いてsystem領域と重ねない。
+- `TYPE` のEOFは `FAT_BYTES_REMAIN` で判定し、残byteがなければ正常終了とする。
+
+## 対象外
+
+- `LOAD` / `RUN` / `.COM` の接続。
+- FAT write。
+- BASIC SAVE/LOAD。
+- 32bit cluster拡張。
+- ROM側の直接 `DIR` / `TYPE` alias。
+- command hook vector方式の導入。
+
+## 検証方針
+
+- `tests/test_sdfs68_v3_build.py` に `CMD DIR` / `CMD TYPE` のSD fixture実行テストを追加する。
+- 固定LBA loader harnessでresidentをRAMへロードした後、ROM promptから次を確認する。
+  - `CMD DIR` がrootの既知fileとdirectoryを表示する。
+  - `CMD DIR DOCS` がsubdirectory内のfileを表示する。
+  - `CMD TYPE README.TXT` がroot file内容を表示する。
+  - `CMD TYPE DOCS/NOTE.TXT` がsubdirectory file内容を表示する。
+  - missing fileでROM monitorへ `?` 復帰する。
+- 既存v3 header / parser / SDFS3SYS / loader harnessテストも通す。
+- PR前に `make test` 相当を確認する。WindowsローカルではPOSIX形式の環境変数指定に注意する。
+
+## 関連
+
+- #280: 対応Issue。
+- #272: v3 phase 1 実装epic。
+- #281: resident CMD_DISPATCH parser。
+- #282: resident LOAD / RUN / .COM接続。
+- #257: 固定LBA system image。
+- #259: resident API最小セット。

--- a/src/sdfs68_v3/resident_stub.asm
+++ b/src/sdfs68_v3/resident_stub.asm
@@ -11,8 +11,8 @@ SDFS3_CAPS_NONE    equ 0
 SDFS3_ERR_NONE     equ 0
 SDFS3_ERR_NOT_IMPL equ 1
 SDFS3_ERR_BAD_CMD  equ 2
-SDFS3_ERR_DIR_IMPL equ $11
-SDFS3_ERR_TYPE_IMPL equ $12
+SDFS3_ERR_IO       equ 3
+SDFS3_ERR_NOT_FOUND equ 4
 SDFS3_ERR_LOAD_IMPL equ $13
 SDFS3_ERR_RUN_IMPL equ $14
 SDFS3_ERR_COM_IMPL equ $15
@@ -106,11 +106,9 @@ SDFS3_CMD_CHECK_COM:
         bra     SDFS3_BAD_COMMAND
 
 SDFS3_CMD_DIR_STUB:
-        ldaa    #SDFS3_ERR_DIR_IMPL
-        bra     SDFS3_NOT_IMPLEMENTED_A
+        jmp     SDFS3_CMD_DIR
 SDFS3_CMD_TYPE_STUB:
-        ldaa    #SDFS3_ERR_TYPE_IMPL
-        bra     SDFS3_NOT_IMPLEMENTED_A
+        jmp     SDFS3_CMD_TYPE
 SDFS3_CMD_LOAD_STUB:
         ldaa    #SDFS3_ERR_LOAD_IMPL
         bra     SDFS3_NOT_IMPLEMENTED_A
@@ -294,6 +292,604 @@ SDFS3_TO_UPPER:
 SDFS3_TO_UPPER_DONE:
         rts
 
+SDFS3_CMD_DIR:
+        ldx     SDFS3_PARSE_PTR
+        stx     PATH_PTR
+        ldaa    SDFS3_PARSE_LEN
+        staa    PATH_LEN
+        jsr     FAT32_MOUNT
+        bcs     SDFS3_CMD_DIR_FAIL
+        jsr     SDFS3_DIR_PATH
+        bcs     SDFS3_CMD_DIR_PATH_FAIL
+        clr     SDFS3_LAST_ERROR
+        clc
+        rts
+SDFS3_CMD_DIR_PATH_FAIL:
+        ldaa    FAT_ERROR
+        beq     SDFS3_CMD_DIR_NOT_FOUND
+SDFS3_CMD_DIR_FAIL:
+        jmp     SDFS3_FAT_FAIL
+SDFS3_CMD_DIR_NOT_FOUND:
+        jmp     SDFS3_NOT_FOUND
+
+SDFS3_CMD_TYPE:
+        ldx     SDFS3_PARSE_PTR
+        stx     PATH_PTR
+        ldaa    SDFS3_PARSE_LEN
+        staa    PATH_LEN
+        jsr     FAT32_MOUNT
+        bcs     SDFS3_CMD_TYPE_FAT_FAIL
+        jsr     SDFS3_RESOLVE_FILE_SAVED
+        bcs     SDFS3_CMD_TYPE_NOT_FOUND
+        jsr     FAT32_STREAM_OPEN
+        bcs     SDFS3_CMD_TYPE_FAT_FAIL
+SDFS3_TYPE_LOOP:
+        jsr     FAT32_STREAM_GETC
+        bcc     SDFS3_TYPE_PUTC
+        jsr     FAT_BYTES_REMAIN
+        bcs     SDFS3_CMD_TYPE_FAT_FAIL
+        clr     SDFS3_LAST_ERROR
+        clc
+        rts
+SDFS3_TYPE_PUTC:
+        jsr     SDFS3_PUTC
+        bra     SDFS3_TYPE_LOOP
+SDFS3_CMD_TYPE_NOT_FOUND:
+        jmp     SDFS3_NOT_FOUND
+SDFS3_CMD_TYPE_FAT_FAIL:
+        jmp     SDFS3_FAT_FAIL
+
+SDFS3_DIR_PATH:
+        jsr     SDFS3_RESOLVE_DIR_SAVED
+        bcs     SDFS3_DIR_FAIL
+SDFS3_DIR_CLUSTER_LOOP:
+        jsr     FAT_CLUSTER_TO_SD_LBA
+        bcs     SDFS3_DIR_FAIL
+        ldx     #SD_SECTOR_BUF
+        jsr     SD_READ_SECTOR
+        bcs     SDFS3_DIR_SD_FAIL
+        ldx     #SD_SECTOR_BUF
+        stx     FAT_ENTRY_PTR
+        ldaa    #16
+        staa    FAT_DIR_COUNT
+SDFS3_DIR_ENTRY_LOOP:
+        ldx     FAT_ENTRY_PTR
+        ldaa    0,x
+        beq     SDFS3_DIR_DONE
+        cmpa    #$E5
+        beq     SDFS3_DIR_NEXT_ENTRY
+        jsr     SDFS3_DIR_ENTRY_VISIBLE
+        bcs     SDFS3_DIR_NEXT_ENTRY
+        jsr     SDFS3_PRINT_DIR_ENTRY
+SDFS3_DIR_NEXT_ENTRY:
+        jsr     FAT_ADVANCE_ENTRY_PTR
+        dec     FAT_DIR_COUNT
+        bne     SDFS3_DIR_ENTRY_LOOP
+        jsr     FAT32_NEXT_CLUSTER
+        bcs     SDFS3_DIR_NEXT_DONE_OR_FAIL
+        jsr     FAT_COPY_NEXT_TO_CUR
+        bra     SDFS3_DIR_CLUSTER_LOOP
+SDFS3_DIR_NEXT_DONE_OR_FAIL:
+        ldaa    FAT_ERROR
+        bne     SDFS3_DIR_FAIL
+SDFS3_DIR_DONE:
+        clc
+        rts
+SDFS3_DIR_SD_FAIL:
+        ldaa    #FAT_ERR_SD
+        staa    FAT_ERROR
+SDFS3_DIR_FAIL:
+        sec
+        rts
+
+SDFS3_RESOLVE_FILE_SAVED:
+        jsr     SDFS3_PATH_START
+        bcs     SDFS3_RESOLVE_FAIL
+SDFS3_RESOLVE_FILE_LOOP:
+        jsr     SDFS3_PATH_COMPONENT
+        bcs     SDFS3_RESOLVE_FAIL
+        jsr     SDFS3_FIND_IN_CUR
+        bcs     SDFS3_RESOLVE_FAIL
+        tst     PATH_DELIM
+        beq     SDFS3_RESOLVE_FILE_LAST
+        jsr     SDFS3_ENTRY_IS_DIR
+        bcs     SDFS3_RESOLVE_FAIL
+        jsr     FAT_COPY_FILE_TO_CUR
+        bra     SDFS3_RESOLVE_FILE_LOOP
+SDFS3_RESOLVE_FILE_LAST:
+        jsr     SDFS3_ENTRY_IS_FILE
+        bcs     SDFS3_RESOLVE_FAIL
+        clc
+        rts
+
+SDFS3_RESOLVE_DIR_SAVED:
+        jsr     SDFS3_PATH_START_ALLOW_ROOT
+        bcs     SDFS3_RESOLVE_FAIL
+        tst     PATH_LEN
+        beq     SDFS3_RESOLVE_OK
+SDFS3_RESOLVE_DIR_LOOP:
+        jsr     SDFS3_PATH_COMPONENT
+        bcs     SDFS3_RESOLVE_FAIL
+        jsr     SDFS3_FIND_IN_CUR
+        bcs     SDFS3_RESOLVE_FAIL
+        jsr     SDFS3_ENTRY_IS_DIR
+        bcs     SDFS3_RESOLVE_FAIL
+        jsr     FAT_COPY_FILE_TO_CUR
+        tst     PATH_DELIM
+        bne     SDFS3_RESOLVE_DIR_LOOP
+SDFS3_RESOLVE_OK:
+        clc
+        rts
+SDFS3_RESOLVE_FAIL:
+        sec
+        rts
+
+SDFS3_PATH_START:
+        jsr     SDFS3_PATH_SKIP_HEAD
+        bcs     SDFS3_PATH_START_FAIL
+        tst     PATH_LEN
+        beq     SDFS3_PATH_START_FAIL
+        jsr     FAT_COPY_ROOT_TO_CUR
+        clc
+        rts
+SDFS3_PATH_START_ALLOW_ROOT:
+        jsr     SDFS3_PATH_SKIP_HEAD
+        bcs     SDFS3_PATH_START_FAIL
+        jsr     FAT_COPY_ROOT_TO_CUR
+        clc
+        rts
+SDFS3_PATH_START_FAIL:
+        sec
+        rts
+
+SDFS3_PATH_SKIP_HEAD:
+        tst     PATH_LEN
+        beq     SDFS3_PATH_SKIP_DONE
+        ldx     PATH_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        beq     SDFS3_PATH_SKIP_ONE
+        cmpa    #'/'
+        beq     SDFS3_PATH_SKIP_SLASH
+        bra     SDFS3_PATH_SKIP_DONE
+SDFS3_PATH_SKIP_ONE:
+        inx
+        stx     PATH_PTR
+        dec     PATH_LEN
+        bra     SDFS3_PATH_SKIP_HEAD
+SDFS3_PATH_SKIP_SLASH:
+        inx
+        stx     PATH_PTR
+        dec     PATH_LEN
+        beq     SDFS3_PATH_SKIP_FAIL
+SDFS3_PATH_SKIP_DONE:
+        clc
+        rts
+SDFS3_PATH_SKIP_FAIL:
+        sec
+        rts
+
+SDFS3_PATH_COMPONENT:
+        ldx     PATH_PTR
+        stx     ARG2_PTR
+        clr     ARG2_LEN
+        clr     PATH_DELIM
+SDFS3_PATH_COMPONENT_LOOP:
+        tst     PATH_LEN
+        beq     SDFS3_PATH_COMPONENT_DONE
+        ldx     PATH_PTR
+        ldaa    0,x
+        cmpa    #'/'
+        beq     SDFS3_PATH_COMPONENT_SLASH
+        cmpa    #CHR_SPACE
+        beq     SDFS3_PATH_COMPONENT_SPACE
+        inx
+        stx     PATH_PTR
+        dec     PATH_LEN
+        inc     ARG2_LEN
+        bra     SDFS3_PATH_COMPONENT_LOOP
+SDFS3_PATH_COMPONENT_SLASH:
+        ldaa    ARG2_LEN
+        beq     SDFS3_PATH_COMPONENT_FAIL
+        ldx     PATH_PTR
+        inx
+        stx     PATH_PTR
+        dec     PATH_LEN
+        ldaa    #1
+        staa    PATH_DELIM
+        tst     PATH_LEN
+        beq     SDFS3_PATH_COMPONENT_FAIL
+        bra     SDFS3_PATH_COMPONENT_PARSE
+SDFS3_PATH_COMPONENT_SPACE:
+        jsr     SDFS3_PATH_SKIP_TRAILING
+        bcs     SDFS3_PATH_COMPONENT_FAIL
+SDFS3_PATH_COMPONENT_DONE:
+        ldaa    ARG2_LEN
+        beq     SDFS3_PATH_COMPONENT_FAIL
+SDFS3_PATH_COMPONENT_PARSE:
+        ldx     ARG2_PTR
+        ldab    ARG2_LEN
+        jsr     SDFS3_PARSE_FILENAME_83
+        bcs     SDFS3_PATH_COMPONENT_FAIL
+        clc
+        rts
+SDFS3_PATH_COMPONENT_FAIL:
+        sec
+        rts
+
+SDFS3_PATH_SKIP_TRAILING:
+        tst     PATH_LEN
+        beq     SDFS3_PATH_SKIP_TRAILING_OK
+        ldx     PATH_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        bne     SDFS3_PATH_SKIP_TRAILING_FAIL
+        inx
+        stx     PATH_PTR
+        dec     PATH_LEN
+        bra     SDFS3_PATH_SKIP_TRAILING
+SDFS3_PATH_SKIP_TRAILING_OK:
+        clc
+        rts
+SDFS3_PATH_SKIP_TRAILING_FAIL:
+        sec
+        rts
+
+SDFS3_FIND_IN_CUR:
+        jsr     FAT_CLUSTER_TO_SD_LBA
+        bcs     SDFS3_FIND_IN_CUR_FAIL
+        ldx     #SD_SECTOR_BUF
+        jsr     SD_READ_SECTOR
+        bcs     SDFS3_FIND_IN_CUR_SD_FAIL
+        ldx     #SD_SECTOR_BUF
+        stx     FAT_ENTRY_PTR
+        ldaa    #16
+        staa    FAT_DIR_COUNT
+SDFS3_FIND_IN_CUR_ENTRY_LOOP:
+        ldx     FAT_ENTRY_PTR
+        ldaa    0,x
+        beq     SDFS3_FIND_IN_CUR_FAIL
+        cmpa    #$E5
+        beq     SDFS3_FIND_IN_CUR_NEXT_ENTRY
+        ldaa    11,x
+        anda    #$0F
+        cmpa    #$0F
+        beq     SDFS3_FIND_IN_CUR_NEXT_ENTRY
+        ldaa    11,x
+        bita    #$08
+        bne     SDFS3_FIND_IN_CUR_NEXT_ENTRY
+        jsr     FAT_COMPARE_ENTRY_NAME
+        bcc     SDFS3_FIND_IN_CUR_MATCH
+SDFS3_FIND_IN_CUR_NEXT_ENTRY:
+        jsr     FAT_ADVANCE_ENTRY_PTR
+        dec     FAT_DIR_COUNT
+        bne     SDFS3_FIND_IN_CUR_ENTRY_LOOP
+        jsr     FAT32_NEXT_CLUSTER
+        bcs     SDFS3_FIND_IN_CUR_NEXT_DONE_OR_FAIL
+        jsr     FAT_COPY_NEXT_TO_CUR
+        bra     SDFS3_FIND_IN_CUR
+SDFS3_FIND_IN_CUR_NEXT_DONE_OR_FAIL:
+        ldaa    FAT_ERROR
+        bne     SDFS3_FIND_IN_CUR_FAIL
+        bra     SDFS3_FIND_IN_CUR_FAIL
+SDFS3_FIND_IN_CUR_MATCH:
+        jsr     FAT_STORE_FILE_ENTRY
+        clc
+        rts
+SDFS3_FIND_IN_CUR_SD_FAIL:
+        ldaa    #FAT_ERR_SD
+        staa    FAT_ERROR
+SDFS3_FIND_IN_CUR_FAIL:
+        sec
+        rts
+
+SDFS3_ENTRY_IS_DIR:
+        ldx     FAT_ENTRY_PTR
+        ldaa    11,x
+        bita    #$10
+        beq     SDFS3_ENTRY_IS_DIR_FAIL
+        clc
+        rts
+SDFS3_ENTRY_IS_DIR_FAIL:
+        sec
+        rts
+
+SDFS3_ENTRY_IS_FILE:
+        ldx     FAT_ENTRY_PTR
+        ldaa    11,x
+        bita    #$18
+        bne     SDFS3_ENTRY_IS_FILE_FAIL
+        clc
+        rts
+SDFS3_ENTRY_IS_FILE_FAIL:
+        sec
+        rts
+
+SDFS3_PARSE_FILENAME_83:
+        stx     ARG_PTR
+        stab    ARG_LEN
+        jsr     SDFS3_CLEAR_FIND_NAME
+SDFS3_PARSE_FILENAME_SKIP_HEAD:
+        tst     ARG_LEN
+        bne     SDFS3_PARSE_FILENAME_SKIP_HAS
+        jmp     SDFS3_PARSE_FILENAME_FAIL
+SDFS3_PARSE_FILENAME_SKIP_HAS:
+        ldx     ARG_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        bne     SDFS3_PARSE_FILENAME_NAME_START
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        bra     SDFS3_PARSE_FILENAME_SKIP_HEAD
+SDFS3_PARSE_FILENAME_NAME_START:
+        ldx     #FAT_FIND_NAME0
+        stx     FAT_ENTRY_PTR
+        clr     ARG2_LEN
+SDFS3_PARSE_FILENAME_NAME_LOOP:
+        tst     ARG_LEN
+        beq     SDFS3_PARSE_FILENAME_NAME_DONE
+        ldx     ARG_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        bne     SDFS3_PARSE_FILENAME_NAME_NOT_SPACE
+        jmp     SDFS3_PARSE_FILENAME_TRAILING
+SDFS3_PARSE_FILENAME_NAME_NOT_SPACE:
+        cmpa    #'.'
+        bne     SDFS3_PARSE_FILENAME_NAME_NOT_DOT
+        jmp     SDFS3_PARSE_FILENAME_EXT_START
+SDFS3_PARSE_FILENAME_NAME_NOT_DOT:
+        ldab    ARG2_LEN
+        cmpb    #8
+        blo     SDFS3_PARSE_FILENAME_NAME_ROOM
+        jmp     SDFS3_PARSE_FILENAME_FAIL
+SDFS3_PARSE_FILENAME_NAME_ROOM:
+        jsr     SDFS3_TO_UPPER
+        ldx     FAT_ENTRY_PTR
+        staa    0,x
+        inx
+        stx     FAT_ENTRY_PTR
+        inc     ARG2_LEN
+        ldx     ARG_PTR
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        bra     SDFS3_PARSE_FILENAME_NAME_LOOP
+SDFS3_PARSE_FILENAME_NAME_DONE:
+        tst     ARG2_LEN
+        bne     SDFS3_PARSE_FILENAME_NAME_OK
+        jmp     SDFS3_PARSE_FILENAME_FAIL
+SDFS3_PARSE_FILENAME_NAME_OK:
+        jmp     SDFS3_PARSE_FILENAME_OK
+SDFS3_PARSE_FILENAME_EXT_START:
+        tst     ARG2_LEN
+        bne     SDFS3_PARSE_FILENAME_EXT_NAME_OK
+        jmp     SDFS3_PARSE_FILENAME_FAIL
+SDFS3_PARSE_FILENAME_EXT_NAME_OK:
+        ldx     ARG_PTR
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        ldx     #FAT_FIND_NAME8
+        stx     FAT_ENTRY_PTR
+        clr     ARG2_LEN
+SDFS3_PARSE_FILENAME_EXT_LOOP:
+        tst     ARG_LEN
+        bne     SDFS3_PARSE_FILENAME_EXT_HAS_LEN
+        jmp     SDFS3_PARSE_FILENAME_OK
+SDFS3_PARSE_FILENAME_EXT_HAS_LEN:
+        ldx     ARG_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        bne     SDFS3_PARSE_FILENAME_EXT_NOT_SPACE
+        jmp     SDFS3_PARSE_FILENAME_TRAILING
+SDFS3_PARSE_FILENAME_EXT_NOT_SPACE:
+        cmpa    #'.'
+        bne     SDFS3_PARSE_FILENAME_EXT_CHAR_OK
+        jmp     SDFS3_PARSE_FILENAME_FAIL
+SDFS3_PARSE_FILENAME_EXT_CHAR_OK:
+        ldab    ARG2_LEN
+        cmpb    #3
+        blo     SDFS3_PARSE_FILENAME_EXT_ROOM
+        jmp     SDFS3_PARSE_FILENAME_FAIL
+SDFS3_PARSE_FILENAME_EXT_ROOM:
+        jsr     SDFS3_TO_UPPER
+        ldx     FAT_ENTRY_PTR
+        staa    0,x
+        inx
+        stx     FAT_ENTRY_PTR
+        inc     ARG2_LEN
+        ldx     ARG_PTR
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        bra     SDFS3_PARSE_FILENAME_EXT_LOOP
+SDFS3_PARSE_FILENAME_TRAILING:
+        ldx     ARG_PTR
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+SDFS3_PARSE_FILENAME_TRAILING_LOOP:
+        tst     ARG_LEN
+        beq     SDFS3_PARSE_FILENAME_OK
+        ldx     ARG_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        beq     SDFS3_PARSE_FILENAME_TRAILING_SPACE_OK
+        jmp     SDFS3_PARSE_FILENAME_FAIL
+SDFS3_PARSE_FILENAME_TRAILING_SPACE_OK:
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        bra     SDFS3_PARSE_FILENAME_TRAILING_LOOP
+SDFS3_PARSE_FILENAME_OK:
+        clc
+        rts
+SDFS3_PARSE_FILENAME_FAIL:
+        sec
+        rts
+
+SDFS3_CLEAR_FIND_NAME:
+        ldx     #FAT_FIND_NAME0
+        ldab    #11
+SDFS3_CLEAR_FIND_NAME_LOOP:
+        ldaa    #CHR_SPACE
+        staa    0,x
+        inx
+        decb
+        bne     SDFS3_CLEAR_FIND_NAME_LOOP
+        rts
+
+SDFS3_PRINT_DIR_ENTRY:
+        ldx     FAT_ENTRY_PTR
+        ldab    #8
+SDFS3_PRINT_DIR_NAME_LOOP:
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        beq     SDFS3_PRINT_DIR_NAME_DONE
+        jsr     SDFS3_PUTC
+        inx
+        decb
+        bne     SDFS3_PRINT_DIR_NAME_LOOP
+SDFS3_PRINT_DIR_NAME_DONE:
+        jsr     SDFS3_DIR_EXT_HAS_CHAR
+        bcs     SDFS3_PRINT_DIR_NO_EXT
+        ldaa    #'.'
+        jsr     SDFS3_PUTC
+        ldx     FAT_ENTRY_PTR
+        ldab    #8
+SDFS3_PRINT_DIR_EXT_SKIP:
+        inx
+        decb
+        bne     SDFS3_PRINT_DIR_EXT_SKIP
+        ldab    #3
+SDFS3_PRINT_DIR_EXT_LOOP:
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        beq     SDFS3_PRINT_DIR_EXT_DONE
+        jsr     SDFS3_PUTC
+        inx
+        decb
+        bne     SDFS3_PRINT_DIR_EXT_LOOP
+SDFS3_PRINT_DIR_EXT_DONE:
+SDFS3_PRINT_DIR_NO_EXT:
+        ldaa    #CHR_SPACE
+        jsr     SDFS3_PUTC
+        ldx     FAT_ENTRY_PTR
+        ldaa    11,x
+        bita    #$10
+        beq     SDFS3_PRINT_DIR_ATTR_FILE
+        ldaa    #'D'
+        bra     SDFS3_PRINT_DIR_ATTR_OUT
+SDFS3_PRINT_DIR_ATTR_FILE:
+        ldaa    #'A'
+SDFS3_PRINT_DIR_ATTR_OUT:
+        jsr     SDFS3_PUTC
+        ldaa    #CHR_SPACE
+        jsr     SDFS3_PUTC
+        ldx     FAT_ENTRY_PTR
+        ldaa    31,x
+        jsr     SDFS3_PRINT_HEX8
+        ldaa    30,x
+        jsr     SDFS3_PRINT_HEX8
+        ldaa    29,x
+        jsr     SDFS3_PRINT_HEX8
+        ldaa    28,x
+        jsr     SDFS3_PRINT_HEX8
+        ldaa    #CHR_CR
+        jsr     SDFS3_PUTC
+        rts
+
+SDFS3_DIR_EXT_HAS_CHAR:
+        ldx     FAT_ENTRY_PTR
+        ldab    #8
+SDFS3_DIR_EXT_SKIP:
+        inx
+        decb
+        bne     SDFS3_DIR_EXT_SKIP
+        ldab    #3
+SDFS3_DIR_EXT_CHECK_LOOP:
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        bne     SDFS3_DIR_EXT_FOUND
+        inx
+        decb
+        bne     SDFS3_DIR_EXT_CHECK_LOOP
+        sec
+        rts
+SDFS3_DIR_EXT_FOUND:
+        clc
+        rts
+
+SDFS3_DIR_ENTRY_VISIBLE:
+        ldx     FAT_ENTRY_PTR
+        ldaa    11,x
+        anda    #$0E
+        bne     SDFS3_DIR_ENTRY_SKIP
+        ldaa    0,x
+        cmpa    #'.'
+        beq     SDFS3_DIR_ENTRY_SKIP
+        cmpa    #CHR_SPACE
+        beq     SDFS3_DIR_ENTRY_SKIP
+        ldab    #11
+SDFS3_DIR_NAME_CHAR_LOOP:
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        beq     SDFS3_DIR_NAME_CHAR_OK
+        blo     SDFS3_DIR_ENTRY_SKIP
+        cmpa    #$7F
+        bhs     SDFS3_DIR_ENTRY_SKIP
+SDFS3_DIR_NAME_CHAR_OK:
+        inx
+        decb
+        bne     SDFS3_DIR_NAME_CHAR_LOOP
+        clc
+        rts
+SDFS3_DIR_ENTRY_SKIP:
+        sec
+        rts
+
+SDFS3_PRINT_HEX8:
+        psha
+        lsra
+        lsra
+        lsra
+        lsra
+        bsr     SDFS3_PRINT_NIBBLE
+        pula
+        bsr     SDFS3_PRINT_NIBBLE
+        rts
+
+SDFS3_PRINT_NIBBLE:
+        anda    #$0F
+        adda    #'0'
+        cmpa    #'9'+1
+        blo     SDFS3_PRINT_NIBBLE_OUT
+        adda    #7
+SDFS3_PRINT_NIBBLE_OUT:
+        jmp     SDFS3_PUTC
+
+SDFS3_PUTC:
+        psha
+        jsr     MIKBUG_OUTCH
+        pula
+        cmpa    #CHR_CR
+        bne     SDFS3_PUTC_DONE
+        ldaa    #CHR_LF
+        jsr     MIKBUG_OUTCH
+SDFS3_PUTC_DONE:
+        rts
+
+SDFS3_NOT_FOUND:
+        ldaa    #SDFS3_ERR_NOT_FOUND
+        bra     SDFS3_FAIL_A
+SDFS3_FAT_FAIL:
+        ldaa    #SDFS3_ERR_IO
+SDFS3_FAIL_A:
+        staa    SDFS3_LAST_ERROR
+        sec
+        rts
+
 SDFS3_LAST_ERROR:
         fcb     SDFS3_ERR_NONE
 SDFS3_PARSE_PTR:
@@ -304,6 +900,12 @@ SDFS3_TOKEN_PTR:
         fdb     0
 SDFS3_TOKEN_LEN:
         fcb     0
+
+FAT32_INCLUDE_FIND_API equ 1
+FAT32_INCLUDE_FILE_API equ 1
+
+        include "sdcard.asm"
+        include "fat32.asm"
 
 SDFS3_END:
         end

--- a/tests/test_sdfs68_v3_build.py
+++ b/tests/test_sdfs68_v3_build.py
@@ -16,6 +16,7 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "tools"))
 EMU_PATH = PROJECT_ROOT / "emu" / "sbc6800_emu.py"
 SDFS3SYS_FIXED_LBA = 64
+SDFS3SYS_FAT_PARTITION_LBA = 128
 SECTOR_SIZE = 512
 SDFS3SYS_LOADER_HARNESS_ADDR = 0x0300
 TEMP_ROOT = PROJECT_ROOT / "build" / "tmp"
@@ -29,6 +30,7 @@ from mk_sdfs3sys import (  # noqa: E402
     checksum16,
     parse_sdfs3sys_header,
 )
+from fat32_image import Fat32File, build_fat32_image_from_files  # noqa: E402
 
 
 EXPECTED = {
@@ -184,9 +186,9 @@ def test_sdfs3_cmd_dispatch_parser_classifies_stub_commands() -> None:
         "SDFS3_GET_ERROR",
     )
     cases = [
-        ("DIR", 0x11),
-        (" dir ", 0x11),
-        ("TYPE README.TXT", 0x12),
+        ("DIR", 0x03),
+        (" dir ", 0x03),
+        ("TYPE README.TXT", 0x03),
         ("LoAd HELLO.S", 0x13),
         ("RUN 1234", 0x14),
         ("FOO.COM ARG", 0x15),
@@ -539,7 +541,7 @@ def test_fixed_lba_loader_harness_loads_sdfs3sys() -> None:
         "SDFS_LOAD_BASE",
     )
     sdfs3sys = (PROJECT_ROOT / "build" / f"SDFS3SYS{suffix}.BIN").read_bytes()
-    assert len(sdfs3sys) <= SECTOR_SIZE, "loader harness is intentionally single-sector"
+    assert len(sdfs3sys) <= 16 * 1024, "SDFS3SYS harness keeps the phase 1 image under 16KB"
     payload = sdfs3sys[HEADER_SIZE:]
     with _temporary_directory() as tmp:
         harness = _assemble_fixed_lba_loader_harness(Path(tmp), symbols)
@@ -571,6 +573,67 @@ def test_fixed_lba_loader_harness_loads_sdfs3sys() -> None:
     print("[PASS] test_fixed_lba_loader_harness_loads_sdfs3sys")
 
 
+def test_sdfs3_cmd_dir_and_type_read_fat_files() -> None:
+    profile = "sbcio_4000"
+    expected = EXPECTED[profile]
+    _run_make(profile, "bin")
+    _run_make(profile, "sdfs3sys")
+    suffix = expected["suffix"]
+    symbols = _load_symbols(
+        PROJECT_ROOT / "build" / f"mc6800-monitor{suffix}.lst",
+        "SD_INIT",
+        "SD_READ_SECTOR",
+        "SDFS3_FIND_API",
+        "SD_LBA0",
+        "SD_LBA1",
+        "SD_LBA2",
+        "SD_LBA3",
+        "SD_SECTOR_BUF",
+        "SDFS_LOAD_BASE",
+    )
+    sdfs3sys = (PROJECT_ROOT / "build" / f"SDFS3SYS{suffix}.BIN").read_bytes()
+    with _temporary_directory() as tmp:
+        harness = _assemble_fixed_lba_loader_harness(Path(tmp), symbols)
+    sd_image = _build_sdfs3sys_fat_sd_image(
+        sdfs3sys,
+        [
+            Fat32File(b"HELLO   S  ", b"S9030000FC\r\n"),
+            Fat32File(b"README  TXT", b"HELLO FROM README\r\n"),
+            Fat32File(b"NOTE    TXT", b"HELLO FROM DOCS\r\n", path=(b"DOCS       ",)),
+        ],
+    )
+    stdout, stderr, rc = _run_emu(
+        rom_path=PROJECT_ROOT / "build" / f"mc6800-monitor{suffix}.bin",
+        input_text=(
+            f"M{SDFS3SYS_LOADER_HARNESS_ADDR:04X}\r{_hex_bytes(harness)}\r.\r"
+            f"G{SDFS3SYS_LOADER_HARNESS_ADDR:04X}\r"
+            "CMD DIR\r"
+            "CMD DIR DOCS\r"
+            "CMD DIR MISSING\r"
+            "CMD TYPE README.TXT\r"
+            "CMD TYPE DOCS/NOTE.TXT\r"
+            "CMD TYPE MISSING.TXT\r"
+            "\r"
+        ),
+        max_cycles=220_000_000,
+        sd_image=sd_image,
+        timeout=30,
+    )
+    assert rc == 0 and "[TIMEOUT]" not in stderr, (
+        f"emulator failed for SDFS3 DIR/TYPE: rc={rc} stderr={stderr!r}"
+    )
+    assert "HELLO.S A " in stdout, f"CMD DIR did not list HELLO.S: {stdout!r}"
+    assert "README.TXT A 00000013" in stdout, f"CMD DIR did not list README.TXT: {stdout!r}"
+    assert "DOCS D 00000000" in stdout, f"CMD DIR did not list DOCS directory: {stdout!r}"
+    assert "NOTE.TXT A 00000011" in stdout, f"CMD DIR DOCS did not list NOTE.TXT: {stdout!r}"
+    assert "HELLO FROM README" in stdout, f"CMD TYPE README.TXT did not print file: {stdout!r}"
+    assert "HELLO FROM DOCS" in stdout, f"CMD TYPE DOCS/NOTE.TXT did not print file: {stdout!r}"
+    assert stdout.count("\n?\n") == 2, (
+        f"missing DIR/TYPE did not return exactly two monitor errors: {stdout!r}"
+    )
+    print("[PASS] test_sdfs3_cmd_dir_and_type_read_fat_files")
+
+
 def test_fixed_lba_loader_harness_rejects_bad_sdfs3sys() -> None:
     profile = "sbcio_4000"
     expected = EXPECTED[profile]
@@ -590,7 +653,7 @@ def test_fixed_lba_loader_harness_rejects_bad_sdfs3sys() -> None:
         "SDFS_LOAD_BASE",
     )
     image = (PROJECT_ROOT / "build" / f"SDFS3SYS{suffix}.BIN").read_bytes()
-    assert len(image) <= SECTOR_SIZE, "loader harness is intentionally single-sector"
+    assert len(image) <= 16 * 1024, "SDFS3SYS harness keeps the phase 1 image under 16KB"
     with _temporary_directory() as tmp:
         harness = _assemble_fixed_lba_loader_harness(Path(tmp), symbols)
 
@@ -599,7 +662,7 @@ def test_fixed_lba_loader_harness_rejects_bad_sdfs3sys() -> None:
         ("bad version", lambda data: data.__setitem__(0x08, 0x02), 0xE2),
         ("bad load address", lambda data: data.__setitem__(0x0C, 0x40), 0xE3),
         ("bad small size", lambda data: data.__setitem__(slice(0x0E, 0x10), b"\x00\x20"), 0xE4),
-        ("bad oversize", lambda data: data.__setitem__(slice(0x0E, 0x10), b"\x02\x01"), 0xE4),
+        ("bad oversize", lambda data: data.__setitem__(slice(0x0E, 0x10), b"\x40\x01"), 0xE4),
         ("bad checksum", lambda data: data.__setitem__(-1, data[-1] ^ 0x01), 0xE5),
         ("bad resident api", _break_resident_api_and_refresh_checksum, 0xE7),
     ]
@@ -686,11 +749,26 @@ def _mutated_header(load_base: int, offset: int, value: int) -> bytes:
 
 
 def _build_sdfs3sys_sd_image(image: bytes) -> bytes:
-    assert len(image) <= SECTOR_SIZE, "loader harness is intentionally single-sector"
-    sectors = bytearray(SECTOR_SIZE * (SDFS3SYS_FIXED_LBA + 1))
+    image_sectors = (len(image) + SECTOR_SIZE - 1) // SECTOR_SIZE
+    sectors = bytearray(SECTOR_SIZE * (SDFS3SYS_FIXED_LBA + image_sectors))
     start = SECTOR_SIZE * SDFS3SYS_FIXED_LBA
     sectors[start : start + len(image)] = image
     return bytes(sectors)
+
+
+def _build_sdfs3sys_fat_sd_image(system_image: bytes, files: list[Fat32File]) -> bytes:
+    fat_image, _layout = build_fat32_image_from_files(
+        files,
+        with_mbr=True,
+        partition_start_lba=SDFS3SYS_FAT_PARTITION_LBA,
+        total_volume_sectors=256,
+    )
+    system_end = (SDFS3SYS_FIXED_LBA * SECTOR_SIZE) + len(system_image)
+    mutable = bytearray(max(len(fat_image), system_end))
+    mutable[: len(fat_image)] = fat_image
+    start = SDFS3SYS_FIXED_LBA * SECTOR_SIZE
+    mutable[start : start + len(system_image)] = system_image
+    return bytes(mutable)
 
 
 def _break_resident_api_and_refresh_checksum(data: bytearray) -> None:
@@ -830,6 +908,8 @@ COMPUTED_SUM    equ $0205
 REMAIN          equ $0207
 SRC_PTR         equ $0209
 DST_PTR         equ $020B
+PAYLOAD_REMAIN equ $020D
+COUNT           equ $020F
 
 SD_INIT         equ {equ("SD_INIT")}
 SD_READ_SECTOR  equ {equ("SD_READ_SECTOR")}
@@ -844,13 +924,8 @@ SDFS_LOAD_BASE  equ {equ("SDFS_LOAD_BASE")}
 START:
         jsr     SD_INIT
         bcs     FAIL_SD
-        clr     SD_LBA0
-        clr     SD_LBA1
-        clr     SD_LBA2
-        ldaa    #${SDFS3SYS_FIXED_LBA:02X}
-        staa    SD_LBA3
-        ldx     #SD_SECTOR_BUF
-        jsr     SD_READ_SECTOR
+        jsr     SET_FIXED_LBA
+        jsr     READ_CURRENT_SECTOR
         bcs     FAIL_SD
         jsr     CHECK_HEADER
         bcs     FAIL
@@ -948,15 +1023,14 @@ HEADER_SIZE_HI_OK:
         jmp     FAIL_SIZE
 HEADER_SIZE_LO_OK:
         ldaa    14,x
-        cmpa    #2
-        bls     SIZE_HI_UNDER_MAX
-        jmp     FAIL_SIZE
-SIZE_HI_UNDER_MAX:
-        bne     SIZE_NOT_512
+        cmpa    #$40
+        blo     SIZE_UNDER_MAX
+        bne     FAIL_SIZE_JMP
         ldaa    15,x
-        beq     SIZE_OK
+        beq     SIZE_UNDER_MAX
+FAIL_SIZE_JMP:
         jmp     FAIL_SIZE
-SIZE_NOT_512:
+SIZE_UNDER_MAX:
         ldaa    14,x
         bne     SIZE_OK
         ldaa    15,x
@@ -976,16 +1050,18 @@ SIZE_OK:
         staa    REMAIN
         ldaa    15,x
         staa    REMAIN+1
-        ldx     #SD_SECTOR_BUF
-SUM_LOOP:
+        jsr     SUM_CURRENT_BUFFER
+SUM_SECTOR_LOOP:
         ldaa    REMAIN
         oraa    REMAIN+1
         beq     SUM_DONE
-        ldaa    0,x
-        jsr     ADD_SUM
-        inx
-        jsr     DEC_REMAIN
-        bra     SUM_LOOP
+        jsr     INC_LBA
+        jsr     READ_CURRENT_SECTOR
+        bcs     SUM_READ_FAIL
+        jsr     SUM_CURRENT_BUFFER
+        bra     SUM_SECTOR_LOOP
+SUM_READ_FAIL:
+        jmp     FAIL_SD
 SUM_DONE:
         ldaa    COMPUTED_SUM
         cmpa    EXPECTED_SUM
@@ -1000,24 +1076,62 @@ SUM_LO_OK:
         clc
         rts
 
+SUM_CURRENT_BUFFER:
+        jsr     SET_COUNT_MIN_512
+        ldx     #SD_SECTOR_BUF
+SUM_LOOP:
+        ldaa    COUNT
+        oraa    COUNT+1
+        beq     SUM_CURRENT_DONE
+        ldaa    0,x
+        jsr     ADD_SUM
+        inx
+        jsr     DEC_COUNT_AND_REMAIN
+        bra     SUM_LOOP
+SUM_CURRENT_DONE:
+        rts
+
 COPY_PAYLOAD:
+        jsr     SET_FIXED_LBA
+        jsr     READ_CURRENT_SECTOR
+        bcs     COPY_FAIL_SD
         ldx     #SD_SECTOR_BUF
         ldaa    14,x
-        staa    REMAIN
+        staa    PAYLOAD_REMAIN
         ldaa    15,x
         suba    #$20
-        staa    REMAIN+1
+        staa    PAYLOAD_REMAIN+1
         bcc     COPY_SIZE_OK
-        dec     REMAIN
+        dec     PAYLOAD_REMAIN
 COPY_SIZE_OK:
         ldx     #SD_SECTOR_BUF+$20
         stx     SRC_PTR
         ldx     #SDFS_LOAD_BASE
         stx     DST_PTR
-COPY_LOOP:
-        ldaa    REMAIN
-        oraa    REMAIN+1
+        jsr     SET_COUNT_MIN_480
+        jsr     COPY_CURRENT_BUFFER
+COPY_SECTOR_LOOP:
+        ldaa    PAYLOAD_REMAIN
+        oraa    PAYLOAD_REMAIN+1
         beq     COPY_DONE
+        jsr     INC_LBA
+        jsr     READ_CURRENT_SECTOR
+        bcs     COPY_FAIL_SD
+        ldx     #SD_SECTOR_BUF
+        stx     SRC_PTR
+        jsr     SET_PAYLOAD_COUNT_MIN_512
+        jsr     COPY_CURRENT_BUFFER
+        bra     COPY_SECTOR_LOOP
+COPY_DONE:
+        rts
+COPY_FAIL_SD:
+        jmp     FAIL_SD
+
+COPY_CURRENT_BUFFER:
+COPY_LOOP:
+        ldaa    COUNT
+        oraa    COUNT+1
+        beq     COPY_CURRENT_DONE
         ldx     SRC_PTR
         ldaa    0,x
         inx
@@ -1026,9 +1140,76 @@ COPY_LOOP:
         staa    0,x
         inx
         stx     DST_PTR
-        jsr     DEC_REMAIN
+        jsr     DEC_COUNT_AND_PAYLOAD
         bra     COPY_LOOP
-COPY_DONE:
+COPY_CURRENT_DONE:
+        rts
+
+SET_FIXED_LBA:
+        clr     SD_LBA0
+        clr     SD_LBA1
+        clr     SD_LBA2
+        ldaa    #${SDFS3SYS_FIXED_LBA:02X}
+        staa    SD_LBA3
+        rts
+
+READ_CURRENT_SECTOR:
+        ldx     #SD_SECTOR_BUF
+        jmp     SD_READ_SECTOR
+
+INC_LBA:
+        inc     SD_LBA3
+        bne     INC_LBA_DONE
+        inc     SD_LBA2
+        bne     INC_LBA_DONE
+        inc     SD_LBA1
+        bne     INC_LBA_DONE
+        inc     SD_LBA0
+INC_LBA_DONE:
+        rts
+
+SET_COUNT_MIN_512:
+        ldaa    REMAIN
+        cmpa    #2
+        bhs     SET_COUNT_512
+        staa    COUNT
+        ldaa    REMAIN+1
+        staa    COUNT+1
+        rts
+SET_COUNT_512:
+        ldaa    #2
+        staa    COUNT
+        clr     COUNT+1
+        rts
+
+SET_PAYLOAD_COUNT_MIN_512:
+        ldaa    PAYLOAD_REMAIN
+        cmpa    #2
+        bhs     SET_COUNT_512
+        staa    COUNT
+        ldaa    PAYLOAD_REMAIN+1
+        staa    COUNT+1
+        rts
+
+SET_COUNT_MIN_480:
+        ldaa    PAYLOAD_REMAIN
+        cmpa    #1
+        bhi     SET_COUNT_480
+        bne     SET_COUNT_PAYLOAD_REMAIN
+        ldaa    PAYLOAD_REMAIN+1
+        cmpa    #$E0
+        bhs     SET_COUNT_480
+SET_COUNT_PAYLOAD_REMAIN:
+        ldaa    PAYLOAD_REMAIN
+        staa    COUNT
+        ldaa    PAYLOAD_REMAIN+1
+        staa    COUNT+1
+        rts
+SET_COUNT_480:
+        ldaa    #1
+        staa    COUNT
+        ldaa    #$E0
+        staa    COUNT+1
         rts
 
 ADD_SUM:
@@ -1039,13 +1220,33 @@ ADD_SUM:
 ADD_SUM_DONE:
         rts
 
-DEC_REMAIN:
+DEC_COUNT_AND_REMAIN:
+        jsr     DEC_COUNT
         dec     REMAIN+1
         ldaa    REMAIN+1
         cmpa    #$FF
         bne     DEC_REMAIN_DONE
         dec     REMAIN
 DEC_REMAIN_DONE:
+        rts
+
+DEC_COUNT_AND_PAYLOAD:
+        jsr     DEC_COUNT
+        dec     PAYLOAD_REMAIN+1
+        ldaa    PAYLOAD_REMAIN+1
+        cmpa    #$FF
+        bne     DEC_PAYLOAD_DONE
+        dec     PAYLOAD_REMAIN
+DEC_PAYLOAD_DONE:
+        rts
+
+DEC_COUNT:
+        dec     COUNT+1
+        ldaa    COUNT+1
+        cmpa    #$FF
+        bne     DEC_COUNT_DONE
+        dec     COUNT
+DEC_COUNT_DONE:
         rts
 
 FAIL_MAGIC:
@@ -1209,6 +1410,7 @@ def main() -> None:
         test_rom_detects_sdfs3_api_header,
         test_rom_cmd_gateway_calls_resident_dispatch,
         test_fixed_lba_loader_harness_loads_sdfs3sys,
+        test_sdfs3_cmd_dir_and_type_read_fat_files,
         test_fixed_lba_loader_harness_rejects_bad_sdfs3sys,
     ]
     passed = 0


### PR DESCRIPTION
## 対応Issue

Closes #280
Refs #272
Refs #273

## 変更内容

- SDFS/68 v3 resident の `CMD DIR` / `CMD TYPE` を未実装stubからFAT32 read-only処理へ接続しました。
- ROM側の `CMD` gatewayは変更せず、resident側でpathを解決してroot/subdirectoryのDIR表示とTYPE出力を行います。
- `sdcard.asm` / `fat32.asm` をv3 residentへ直接includeし、SDFS3SYSが複数sectorになっても固定LBA loader harnessで読み込めるようテスト側を更新しました。
- `DIR` / `TYPE` のnot foundとSD/FAT I/O errorの扱いを分け、レビューで見つかったFAT chain/EOC判定の曖昧さも `FAT_ERROR` で分類するよう補正しました。
- `docs/plans/sdfs68_v3/issue-280_dir_type_readonly.md` に実装方針と検証方針を残しました。

## テスト結果

- `python tests/test_sdfs68_v3_build.py` → 14 passed
- `make sdfs3sys MONITOR_PROFILE=sbcio_4000 PYTHON=python ASL_INCLUDE_ARG=build;include;src` → PASS
- `make sdfs3sys MONITOR_PROFILE=k6802_4000 PYTHON=python ASL_INCLUDE_ARG=build;include;src` → PASS
- `make bin MONITOR_PROFILE=base PYTHON=python ASL_INCLUDE_ARG=build;include;src` → PASS
- `make bin MONITOR_PROFILE=sbcio PYTHON=python ASL_INCLUDE_ARG=build;include;src` → PASS
- `REQUIRE_BUILD_ROM=1 MONITOR_PROFILE=base ... python tests/test_smoke.py` → 37 passed
- `REQUIRE_BUILD_ROM=1 MONITOR_PROFILE=base ... python tests/test_sd_fixture.py` → 10 passed
- `REQUIRE_BUILD_ROM=1 MONITOR_PROFILE=sbcio ... python tests/test_smoke.py` → 37 passed
- `REQUIRE_BUILD_ROM=1 MONITOR_PROFILE=sbcio ... python tests/test_sd_fixture.py` → 10 passed
- `git diff --check` → PASS

## 補足

Windowsローカルでは共有 `build/monitor_config.inc` があるため、base/sbcioのROM生成とsmoke/fixtureはプロファイルごとに単独再生成して確認しました。