### PR TITLE
Issue #282 SDFS/68 v3 LOAD RUN COMを接続

### DIFF
--- a/docs/plans/sdfs68_v3/issue-282_load_run_com.md
+++ b/docs/plans/sdfs68_v3/issue-282_load_run_com.md
@@ -1,0 +1,42 @@
+# Issue #282 SDFS/68 v3 resident LOAD / RUN / .COM 接続
+
+## 背景
+
+#280 で `DIR` / `TYPE` を v3 resident の read-only FAT 処理へ接続した。
+このIssueでは phase 1 の v2 互換範囲として、`CMD LOAD`、`CMD RUN`、明示 `.COM` 実行を resident 側へ接続する。
+
+## 採用方針
+
+- ROM 側の `CMD` gateway は変更しない。
+- `LOAD` / `RUN` / `.COM` の判定後の実処理は resident 側へ置く。
+- `LOAD` は v2 の S-Record / Intel HEX parser を `SDFS3_` 名前空間へ移植し、FAT stream から読ませる。
+- `LOAD` 成功時は v2 互換として `OK` を出力してから ROM monitor へ戻る。
+- `RUN addr` は v2 同様に指定アドレスへ `JMP` する。
+- `RUN path` は `LOAD` 後、S-Record の entry record がある場合だけ entry へ `JMP` する。
+- `.COM` は明示 `.COM` 入力のみ対象とし、raw binary を `$0100` へロードして `JSR $0100` 相当で呼ぶ。
+- v3 の `.COM` は ROM `CMD` gateway から呼ばれるため、`.COM` 呼び出し前に stack を初期化しない。ROM 側の戻り先を保持したまま、`.COM` の `RTS` 復帰後に resident が carry clear で戻る。
+
+## 対象外
+
+- `FOO` から `FOO.COM` を補完探索する処理。
+- FAT write。
+- BASIC SAVE/LOAD adapter。
+- system 更新。
+- v2 SDFS/68 の削除。
+
+## 検証方針
+
+- 固定LBA loader harness で `SDFS3SYS` を RAM へ配置し、ROM prompt の `CMD` 経由で確認する。
+- fixture SD 上の S-Record / Intel HEX を `CMD LOAD` でロードし、dump 結果で書き込み先を確認する。
+- `CMD RUN addr` が指定アドレスへジャンプすることを SWI break で確認する。
+- entry record 付き S-Record を `CMD RUN path` で実行できることを確認する。
+- `.COM` が実行され、引数tailが `X` / `B` で渡ることを確認する。
+- 不正 `.COM`、entry なし `RUN path`、サイズ超過 `.COM` が `?` でエラー復帰することを確認する。
+
+## 関連
+
+- #282: 対応Issue。
+- #272: v3 phase 1 実装epic。
+- #273: v3設計epic。
+- #280: resident `DIR` / `TYPE` 接続。
+- #281: resident `CMD_DISPATCH` parser。

--- a/src/sdfs68_v3/resident_stub.asm
+++ b/src/sdfs68_v3/resident_stub.asm
@@ -13,9 +13,14 @@ SDFS3_ERR_NOT_IMPL equ 1
 SDFS3_ERR_BAD_CMD  equ 2
 SDFS3_ERR_IO       equ 3
 SDFS3_ERR_NOT_FOUND equ 4
-SDFS3_ERR_LOAD_IMPL equ $13
-SDFS3_ERR_RUN_IMPL equ $14
-SDFS3_ERR_COM_IMPL equ $15
+SDFS3_ERR_LOAD    equ 5
+SDFS3_ERR_RUN     equ 6
+SDFS3_ERR_COM     equ 7
+
+SDFS3_COM_LOAD_BASE equ $0100
+SDFS3_COM_MAX_SIZE equ USER_RAM_END-SDFS3_COM_LOAD_BASE+1
+SDFS3_COM_MAX_HI equ SDFS3_COM_MAX_SIZE/256
+SDFS3_COM_MAX_LO equ SDFS3_COM_MAX_SIZE-SDFS3_COM_MAX_HI*256
 
         if S1_SUPPORTED = 0
         error   "SDFS/68 v3 resident is not supported for this memory configuration"
@@ -110,14 +115,11 @@ SDFS3_CMD_DIR_STUB:
 SDFS3_CMD_TYPE_STUB:
         jmp     SDFS3_CMD_TYPE
 SDFS3_CMD_LOAD_STUB:
-        ldaa    #SDFS3_ERR_LOAD_IMPL
-        bra     SDFS3_NOT_IMPLEMENTED_A
+        jmp     SDFS3_CMD_LOAD
 SDFS3_CMD_RUN_STUB:
-        ldaa    #SDFS3_ERR_RUN_IMPL
-        bra     SDFS3_NOT_IMPLEMENTED_A
+        jmp     SDFS3_CMD_RUN
 SDFS3_CMD_COM_STUB:
-        ldaa    #SDFS3_ERR_COM_IMPL
-        bra     SDFS3_NOT_IMPLEMENTED_A
+        jmp     SDFS3_CMD_COM
 SDFS3_BAD_COMMAND:
         ldaa    #SDFS3_ERR_BAD_CMD
         staa    SDFS3_LAST_ERROR
@@ -338,6 +340,148 @@ SDFS3_CMD_TYPE_NOT_FOUND:
         jmp     SDFS3_NOT_FOUND
 SDFS3_CMD_TYPE_FAT_FAIL:
         jmp     SDFS3_FAT_FAIL
+
+SDFS3_CMD_LOAD:
+        ldx     SDFS3_PARSE_PTR
+        ldab    SDFS3_PARSE_LEN
+        jsr     SDFS3_LOAD_FILE
+        bcs     SDFS3_CMD_LOAD_FAIL
+        ldx     #SDFS3_TXT_OK
+        jsr     SDFS3_PRINT
+        clr     SDFS3_LAST_ERROR
+        clc
+        rts
+SDFS3_CMD_LOAD_FAIL:
+        ldaa    #SDFS3_ERR_LOAD
+        jmp     SDFS3_FAIL_A
+
+SDFS3_LOAD_FILE:
+        clr     LOADER_MODE
+        clr     LOADER_STAGE
+        clr     SDFS_RUN_ENTRY_SET
+        stx     PATH_PTR
+        stab    PATH_LEN
+        jsr     FAT32_MOUNT
+        bcs     SDFS3_LOAD_FILE_FAIL
+        jsr     SDFS3_RESOLVE_FILE_SAVED
+        bcs     SDFS3_LOAD_FILE_FAIL
+        jsr     FAT32_STREAM_OPEN
+        bcs     SDFS3_LOAD_FILE_FAIL
+SDFS3_LOAD_LOOP:
+        jsr     SDFS3_READ_LOADER_RECORD
+        bcs     SDFS3_LOAD_FILE_FAIL
+        cmpa    #1
+        beq     SDFS3_LOAD_FILE_DONE
+        bra     SDFS3_LOAD_LOOP
+SDFS3_LOAD_FILE_DONE:
+        clc
+        rts
+SDFS3_LOAD_FILE_FAIL:
+        sec
+        rts
+
+SDFS3_CMD_RUN:
+        ldx     SDFS3_PARSE_PTR
+        ldab    SDFS3_PARSE_LEN
+        jsr     SDFS3_PARSE_HEX16
+        bcs     SDFS3_CMD_RUN_FILE
+        lds     #STACK_TOP
+        ldx     HEX_VALUE_HI
+        jmp     0,x
+SDFS3_CMD_RUN_FILE:
+        ldx     SDFS3_PARSE_PTR
+        ldab    SDFS3_PARSE_LEN
+        jsr     SDFS3_LOAD_FILE
+        bcs     SDFS3_CMD_RUN_FAIL
+        ldaa    LOADER_MODE
+        cmpa    #LOAD_MODE_SREC
+        bne     SDFS3_CMD_RUN_FAIL
+        ldaa    SDFS_RUN_ENTRY_SET
+        beq     SDFS3_CMD_RUN_FAIL
+        lds     #STACK_TOP
+        ldx     SDFS_RUN_ENTRY
+        jmp     0,x
+SDFS3_CMD_RUN_FAIL:
+        ldaa    #SDFS3_ERR_RUN
+        jmp     SDFS3_FAIL_A
+
+SDFS3_CMD_COM:
+        ldx     SDFS3_TOKEN_PTR
+        ldab    SDFS3_TOKEN_LEN
+        addb    SDFS3_PARSE_LEN
+        jsr     SDFS3_PARSE_COM_PATH_COMMAND
+        bcs     SDFS3_CMD_COM_FAIL
+        jsr     FAT32_MOUNT
+        bcs     SDFS3_CMD_COM_FAIL
+        jsr     SDFS3_RESOLVE_FILE_SAVED
+        bcs     SDFS3_CMD_COM_FAIL
+        jsr     SDFS3_PARSE_COM_CHECK_EXT
+        bcs     SDFS3_CMD_COM_FAIL
+        jsr     SDFS3_COM_CHECK_SIZE
+        bcs     SDFS3_CMD_COM_FAIL
+        jsr     FAT32_STREAM_OPEN
+        bcs     SDFS3_CMD_COM_FAIL
+        jsr     SDFS3_COM_LOAD_RAW
+        bcs     SDFS3_CMD_COM_FAIL
+        jsr     SDFS3_COM_RESTORE_ARGS
+        ldx     ARG2_PTR
+        ldab    ARG2_LEN
+        clra
+        jsr     SDFS3_COM_LOAD_BASE
+        clr     SDFS3_LAST_ERROR
+        clc
+        rts
+SDFS3_CMD_COM_FAIL:
+        ldaa    #SDFS3_ERR_COM
+        jmp     SDFS3_FAIL_A
+
+SDFS3_COM_CHECK_SIZE:
+        ldaa    FAT_FILE_SIZE0
+        oraa    FAT_FILE_SIZE1
+        bne     SDFS3_COM_CHECK_FAIL
+        ldaa    FAT_FILE_SIZE2
+        oraa    FAT_FILE_SIZE3
+        beq     SDFS3_COM_CHECK_FAIL
+        ldaa    FAT_FILE_SIZE2
+        cmpa    #SDFS3_COM_MAX_HI
+        bhi     SDFS3_COM_CHECK_FAIL
+        blo     SDFS3_COM_CHECK_OK
+        ldaa    FAT_FILE_SIZE3
+        cmpa    #SDFS3_COM_MAX_LO
+        bhi     SDFS3_COM_CHECK_FAIL
+SDFS3_COM_CHECK_OK:
+        clc
+        rts
+SDFS3_COM_CHECK_FAIL:
+        sec
+        rts
+
+SDFS3_COM_LOAD_RAW:
+        ldx     #SDFS3_COM_LOAD_BASE
+        stx     FAT_READ_PTR
+SDFS3_COM_LOAD_LOOP:
+        jsr     FAT_BYTES_REMAIN
+        bcc     SDFS3_COM_LOAD_DONE
+        jsr     FAT32_STREAM_GETC
+        bcs     SDFS3_COM_LOAD_FAIL
+        ldx     FAT_READ_PTR
+        staa    0,x
+        inx
+        stx     FAT_READ_PTR
+        bra     SDFS3_COM_LOAD_LOOP
+SDFS3_COM_LOAD_DONE:
+        clc
+        rts
+SDFS3_COM_LOAD_FAIL:
+        sec
+        rts
+
+SDFS3_COM_RESTORE_ARGS:
+        ldx     PATH_ARG_PTR
+        stx     ARG2_PTR
+        ldaa    PATH_ARG_LEN
+        staa    ARG2_LEN
+        rts
 
 SDFS3_DIR_PATH:
         jsr     SDFS3_RESOLVE_DIR_SAVED
@@ -740,6 +884,525 @@ SDFS3_CLEAR_FIND_NAME_LOOP:
         bne     SDFS3_CLEAR_FIND_NAME_LOOP
         rts
 
+SDFS3_PARSE_COM_PATH_COMMAND:
+        stx     ARG_PTR
+        stab    ARG_LEN
+SDFS3_PARSE_COM_PATH_SKIP_HEAD:
+        tst     ARG_LEN
+        beq     SDFS3_PARSE_COM_PATH_FAIL
+        ldx     ARG_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        bne     SDFS3_PARSE_COM_PATH_START
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        bra     SDFS3_PARSE_COM_PATH_SKIP_HEAD
+SDFS3_PARSE_COM_PATH_START:
+        ldx     ARG_PTR
+        stx     PATH_PTR
+        clr     PATH_LEN
+SDFS3_PARSE_COM_PATH_TOKEN:
+        tst     ARG_LEN
+        beq     SDFS3_PARSE_COM_PATH_NO_ARGS
+        ldx     ARG_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        beq     SDFS3_PARSE_COM_PATH_ARG_SKIP
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        inc     PATH_LEN
+        bra     SDFS3_PARSE_COM_PATH_TOKEN
+SDFS3_PARSE_COM_PATH_ARG_SKIP:
+        ldaa    PATH_LEN
+        beq     SDFS3_PARSE_COM_PATH_FAIL
+        ldx     ARG_PTR
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+SDFS3_PARSE_COM_PATH_ARG_SKIP_LOOP:
+        tst     ARG_LEN
+        beq     SDFS3_PARSE_COM_PATH_NO_ARGS
+        ldx     ARG_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        bne     SDFS3_PARSE_COM_PATH_ARGS
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        bra     SDFS3_PARSE_COM_PATH_ARG_SKIP_LOOP
+SDFS3_PARSE_COM_PATH_ARGS:
+        ldx     ARG_PTR
+        stx     PATH_ARG_PTR
+        ldaa    ARG_LEN
+        staa    PATH_ARG_LEN
+        clc
+        rts
+SDFS3_PARSE_COM_PATH_NO_ARGS:
+        ldaa    PATH_LEN
+        beq     SDFS3_PARSE_COM_PATH_FAIL
+        ldx     ARG_PTR
+        stx     PATH_ARG_PTR
+        clr     PATH_ARG_LEN
+        clc
+        rts
+SDFS3_PARSE_COM_PATH_FAIL:
+        sec
+        rts
+
+SDFS3_PARSE_COM_CHECK_EXT:
+        ldaa    FAT_FIND_NAME8
+        cmpa    #'C'
+        bne     SDFS3_PARSE_COM_CHECK_FAIL
+        ldaa    FAT_FIND_NAME9
+        cmpa    #'O'
+        bne     SDFS3_PARSE_COM_CHECK_FAIL
+        ldaa    FAT_FIND_NAME10
+        cmpa    #'M'
+        bne     SDFS3_PARSE_COM_CHECK_FAIL
+        clc
+        rts
+SDFS3_PARSE_COM_CHECK_FAIL:
+        sec
+        rts
+
+SDFS3_PARSE_HEX16:
+        stx     ARG_PTR
+        stab    ARG_LEN
+        clr     HEX_VALUE_HI
+        clr     HEX_VALUE_LO
+        clr     ARG2_LEN
+SDFS3_PARSE_HEX16_SKIP:
+        tst     ARG_LEN
+        bne     SDFS3_PARSE_HEX16_SKIP_HAS
+        jmp     SDFS3_PARSE_HEX16_FAIL
+SDFS3_PARSE_HEX16_SKIP_HAS:
+        ldx     ARG_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        bne     SDFS3_PARSE_HEX16_LOOP
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        bra     SDFS3_PARSE_HEX16_SKIP
+SDFS3_PARSE_HEX16_LOOP:
+        tst     ARG_LEN
+        beq     SDFS3_PARSE_HEX16_DONE
+        ldx     ARG_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        beq     SDFS3_PARSE_HEX16_TRAILING
+        jsr     SDFS3_HEX_TO_NIBBLE
+        bcs     SDFS3_PARSE_HEX16_FAIL
+        ldab    ARG2_LEN
+        cmpb    #4
+        bhs     SDFS3_PARSE_HEX16_FAIL
+        tstb
+        beq     SDFS3_PARSE_HEX16_HI_H
+        cmpb    #1
+        beq     SDFS3_PARSE_HEX16_HI_L
+        cmpb    #2
+        beq     SDFS3_PARSE_HEX16_LO_H
+        oraa    HEX_VALUE_LO
+        staa    HEX_VALUE_LO
+        bra     SDFS3_PARSE_HEX16_ADVANCE
+SDFS3_PARSE_HEX16_HI_H:
+        lsla
+        lsla
+        lsla
+        lsla
+        staa    HEX_VALUE_HI
+        bra     SDFS3_PARSE_HEX16_ADVANCE
+SDFS3_PARSE_HEX16_HI_L:
+        oraa    HEX_VALUE_HI
+        staa    HEX_VALUE_HI
+        bra     SDFS3_PARSE_HEX16_ADVANCE
+SDFS3_PARSE_HEX16_LO_H:
+        lsla
+        lsla
+        lsla
+        lsla
+        staa    HEX_VALUE_LO
+SDFS3_PARSE_HEX16_ADVANCE:
+        ldx     ARG_PTR
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        inc     ARG2_LEN
+        bra     SDFS3_PARSE_HEX16_LOOP
+SDFS3_PARSE_HEX16_TRAILING:
+        ldx     ARG_PTR
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+SDFS3_PARSE_HEX16_TRAILING_LOOP:
+        tst     ARG_LEN
+        beq     SDFS3_PARSE_HEX16_DONE
+        ldx     ARG_PTR
+        ldaa    0,x
+        cmpa    #CHR_SPACE
+        bne     SDFS3_PARSE_HEX16_FAIL
+        inx
+        stx     ARG_PTR
+        dec     ARG_LEN
+        bra     SDFS3_PARSE_HEX16_TRAILING_LOOP
+SDFS3_PARSE_HEX16_DONE:
+        ldaa    ARG2_LEN
+        cmpa    #4
+        bne     SDFS3_PARSE_HEX16_FAIL
+        clc
+        rts
+SDFS3_PARSE_HEX16_FAIL:
+        sec
+        rts
+
+SDFS3_READ_LOADER_RECORD:
+        jsr     SDFS3_READ_RECORD_HEAD
+        bcs     SDFS3_READ_LOADER_RECORD_FAIL
+        ldaa    LOADER_MODE
+        bne     SDFS3_READ_LOADER_RECORD_MODE_SET
+        ldaa    HEX_NIBBLE
+        cmpa    #'S'
+        beq     SDFS3_READ_LOADER_RECORD_SET_SREC
+        cmpa    #':'
+        beq     SDFS3_READ_LOADER_RECORD_SET_IHEX
+        sec
+        rts
+SDFS3_READ_LOADER_RECORD_SET_SREC:
+        ldaa    #LOAD_MODE_SREC
+        staa    LOADER_MODE
+        bra     SDFS3_READ_LOADER_RECORD_MODE_SET
+SDFS3_READ_LOADER_RECORD_SET_IHEX:
+        ldaa    #LOAD_MODE_IHEX
+        staa    LOADER_MODE
+SDFS3_READ_LOADER_RECORD_MODE_SET:
+        ldaa    LOADER_MODE
+        cmpa    #LOAD_MODE_SREC
+        beq     SDFS3_READ_SREC_RECORD
+        cmpa    #LOAD_MODE_IHEX
+        bne     SDFS3_READ_LOADER_RECORD_FAIL
+        jmp     SDFS3_READ_IHEX_RECORD
+SDFS3_READ_LOADER_RECORD_FAIL:
+        sec
+        rts
+
+SDFS3_READ_RECORD_HEAD:
+        jsr     FAT32_STREAM_GETC
+        bcs     SDFS3_READ_RECORD_HEAD_FAIL
+        cmpa    #CHR_LF
+        beq     SDFS3_READ_RECORD_HEAD
+        cmpa    #CHR_CR
+        beq     SDFS3_READ_RECORD_HEAD
+        cmpa    #CHR_SPACE
+        blo     SDFS3_READ_RECORD_HEAD
+        staa    HEX_NIBBLE
+        clc
+        rts
+SDFS3_READ_RECORD_HEAD_FAIL:
+        sec
+        rts
+
+SDFS3_READ_RECORD_TRAILER:
+        jsr     FAT32_STREAM_GETC
+        bcs     SDFS3_READ_RECORD_TRAILER_EOF_OR_FAIL
+        cmpa    #CHR_LF
+        beq     SDFS3_READ_RECORD_TRAILER_OK
+        cmpa    #CHR_CR
+        beq     SDFS3_READ_RECORD_TRAILER_OK
+SDFS3_READ_RECORD_TRAILER_FAIL:
+        sec
+        rts
+SDFS3_READ_RECORD_TRAILER_EOF_OR_FAIL:
+        jsr     FAT_BYTES_REMAIN
+        bcs     SDFS3_READ_RECORD_TRAILER_FAIL
+SDFS3_READ_RECORD_TRAILER_OK:
+        clc
+        rts
+
+SDFS3_READ_HEXBYTE_INPUT:
+        pshb
+        jsr     FAT32_STREAM_GETC
+        bcs     SDFS3_READ_HEXBYTE_INPUT_FAIL
+        jsr     SDFS3_HEX_TO_NIBBLE
+        bcs     SDFS3_READ_HEXBYTE_INPUT_FAIL
+        lsla
+        lsla
+        lsla
+        lsla
+        tab
+        jsr     FAT32_STREAM_GETC
+        bcs     SDFS3_READ_HEXBYTE_INPUT_FAIL
+        jsr     SDFS3_HEX_TO_NIBBLE
+        bcs     SDFS3_READ_HEXBYTE_INPUT_FAIL
+        aba
+        pulb
+        clc
+        rts
+SDFS3_READ_HEXBYTE_INPUT_FAIL:
+        pulb
+        sec
+        rts
+
+SDFS3_READ_SREC_RECORD:
+        ldaa    HEX_NIBBLE
+        cmpa    #'S'
+        beq     SDFS3_READ_SREC_HEAD_OK
+        jmp     SDFS3_READ_SREC_FAIL
+SDFS3_READ_SREC_HEAD_OK:
+        ldaa    #1
+        staa    LOADER_STAGE
+        jsr     FAT32_STREAM_GETC
+        bcs     SDFS3_READ_SREC_FAIL_NEAR0
+        staa    LOADER_TYPE
+        cmpa    #'0'
+        beq     SDFS3_READ_SREC_TYPE_OK
+        cmpa    #'1'
+        beq     SDFS3_READ_SREC_TYPE_OK
+        cmpa    #'2'
+        beq     SDFS3_READ_SREC_TYPE_OK
+        cmpa    #'5'
+        beq     SDFS3_READ_SREC_TYPE_OK
+        cmpa    #'8'
+        beq     SDFS3_READ_SREC_TYPE_OK
+        cmpa    #'9'
+        beq     SDFS3_READ_SREC_TYPE_OK
+        jmp     SDFS3_READ_SREC_FAIL
+SDFS3_READ_SREC_FAIL_NEAR0:
+        jmp     SDFS3_READ_SREC_FAIL
+SDFS3_READ_SREC_TYPE_OK:
+        ldaa    #2
+        staa    LOADER_STAGE
+        jsr     SDFS3_READ_HEXBYTE_INPUT
+        bcs     SDFS3_READ_SREC_FAIL_NEAR1
+        staa    LOADER_COUNT
+        staa    LOADER_SUM
+        ldaa    LOADER_TYPE
+        cmpa    #'2'
+        beq     SDFS3_READ_SREC_ADDR24
+        cmpa    #'8'
+        beq     SDFS3_READ_SREC_ADDR24
+        ldaa    LOADER_COUNT
+        cmpa    #3
+        blo     SDFS3_READ_SREC_FAIL_NEAR1
+        ldaa    #3
+        staa    LOADER_STAGE
+        jsr     SDFS3_READ_HEXBYTE_INPUT
+        bcs     SDFS3_READ_SREC_FAIL_NEAR1
+        staa    LOADER_ADDR
+        jsr     SDFS3_ADD_TO_LOADER_SUM
+        jsr     SDFS3_READ_HEXBYTE_INPUT
+        bcs     SDFS3_READ_SREC_FAIL_NEAR1
+        staa    LOADER_ADDR+1
+        jsr     SDFS3_ADD_TO_LOADER_SUM
+        ldab    LOADER_COUNT
+        subb    #3
+        bra     SDFS3_READ_SREC_DATA_LOOP
+SDFS3_READ_SREC_FAIL_NEAR1:
+        jmp     SDFS3_READ_SREC_FAIL
+SDFS3_READ_SREC_ADDR24:
+        ldaa    LOADER_COUNT
+        cmpa    #4
+        blo     SDFS3_READ_SREC_FAIL_NEAR2
+        ldaa    #3
+        staa    LOADER_STAGE
+        jsr     SDFS3_READ_HEXBYTE_INPUT
+        bcs     SDFS3_READ_SREC_FAIL_NEAR2
+        staa    HEX_NIBBLE
+        jsr     SDFS3_ADD_TO_LOADER_SUM
+        ldaa    HEX_NIBBLE
+        bne     SDFS3_READ_SREC_FAIL_NEAR2
+        jsr     SDFS3_READ_HEXBYTE_INPUT
+        bcs     SDFS3_READ_SREC_FAIL_NEAR2
+        staa    LOADER_ADDR
+        jsr     SDFS3_ADD_TO_LOADER_SUM
+        jsr     SDFS3_READ_HEXBYTE_INPUT
+        bcs     SDFS3_READ_SREC_FAIL_NEAR2
+        staa    LOADER_ADDR+1
+        jsr     SDFS3_ADD_TO_LOADER_SUM
+        ldab    LOADER_COUNT
+        subb    #4
+        bra     SDFS3_READ_SREC_DATA_LOOP
+SDFS3_READ_SREC_FAIL_NEAR2:
+        jmp     SDFS3_READ_SREC_FAIL
+SDFS3_READ_SREC_DATA_LOOP:
+        ldaa    #4
+        staa    LOADER_STAGE
+        tstb
+        beq     SDFS3_READ_SREC_CHECKSUM
+        jsr     SDFS3_READ_HEXBYTE_INPUT
+        bcs     SDFS3_READ_SREC_FAIL
+        staa    HEX_NIBBLE
+        jsr     SDFS3_ADD_TO_LOADER_SUM
+        ldaa    LOADER_TYPE
+        cmpa    #'1'
+        beq     SDFS3_READ_SREC_STORE
+        cmpa    #'2'
+        bne     SDFS3_READ_SREC_SKIP_STORE
+SDFS3_READ_SREC_STORE:
+        ldaa    HEX_NIBBLE
+        pshb
+        ldx     LOADER_ADDR
+        staa    0,x
+        inx
+        stx     LOADER_ADDR
+        pulb
+SDFS3_READ_SREC_SKIP_STORE:
+        decb
+        bra     SDFS3_READ_SREC_DATA_LOOP
+SDFS3_READ_SREC_CHECKSUM:
+        ldaa    #5
+        staa    LOADER_STAGE
+        jsr     SDFS3_READ_HEXBYTE_INPUT
+        bcs     SDFS3_READ_SREC_FAIL
+        jsr     SDFS3_ADD_TO_LOADER_SUM
+        cmpa    #$FF
+        bne     SDFS3_READ_SREC_FAIL
+        jsr     SDFS3_READ_RECORD_TRAILER
+        bcs     SDFS3_READ_SREC_FAIL
+        ldaa    LOADER_TYPE
+        cmpa    #'8'
+        beq     SDFS3_READ_SREC_EOF
+        cmpa    #'9'
+        beq     SDFS3_READ_SREC_EOF
+        ldaa    #0
+        clc
+        rts
+SDFS3_READ_SREC_EOF:
+        ldaa    LOADER_ADDR
+        staa    SDFS_RUN_ENTRY
+        ldaa    LOADER_ADDR+1
+        staa    SDFS_RUN_ENTRY+1
+        ldaa    #1
+        staa    SDFS_RUN_ENTRY_SET
+        ldaa    #1
+        clc
+        rts
+SDFS3_READ_SREC_FAIL:
+        sec
+        rts
+
+SDFS3_READ_IHEX_RECORD:
+        ldaa    HEX_NIBBLE
+        cmpa    #':'
+        beq     SDFS3_READ_IHEX_HEAD_OK
+        jmp     SDFS3_READ_IHEX_FAIL
+SDFS3_READ_IHEX_HEAD_OK:
+        ldaa    #1
+        staa    LOADER_STAGE
+        ldaa    #2
+        staa    LOADER_STAGE
+        jsr     SDFS3_READ_HEXBYTE_INPUT
+        bcs     SDFS3_READ_IHEX_FAIL_NEAR1
+        staa    LOADER_COUNT
+        staa    LOADER_SUM
+        ldaa    #3
+        staa    LOADER_STAGE
+        jsr     SDFS3_READ_HEXBYTE_INPUT
+        bcs     SDFS3_READ_IHEX_FAIL_NEAR1
+        staa    LOADER_ADDR
+        jsr     SDFS3_ADD_TO_LOADER_SUM
+        jsr     SDFS3_READ_HEXBYTE_INPUT
+        bcs     SDFS3_READ_IHEX_FAIL_NEAR1
+        staa    LOADER_ADDR+1
+        jsr     SDFS3_ADD_TO_LOADER_SUM
+        jsr     SDFS3_READ_HEXBYTE_INPUT
+        bcs     SDFS3_READ_IHEX_FAIL_NEAR1
+        staa    LOADER_TYPE
+        jsr     SDFS3_ADD_TO_LOADER_SUM
+        ldaa    LOADER_TYPE
+        cmpa    #$00
+        beq     SDFS3_READ_IHEX_DATA
+        cmpa    #$01
+        bne     SDFS3_READ_IHEX_FAIL
+        ldaa    LOADER_COUNT
+        bne     SDFS3_READ_IHEX_FAIL
+        bra     SDFS3_READ_IHEX_DATA
+SDFS3_READ_IHEX_FAIL_NEAR1:
+        jmp     SDFS3_READ_IHEX_FAIL
+SDFS3_READ_IHEX_DATA:
+        ldaa    #4
+        staa    LOADER_STAGE
+        ldab    LOADER_COUNT
+SDFS3_READ_IHEX_DATA_LOOP:
+        tstb
+        beq     SDFS3_READ_IHEX_CHECKSUM
+        jsr     SDFS3_READ_HEXBYTE_INPUT
+        bcs     SDFS3_READ_IHEX_FAIL
+        staa    HEX_NIBBLE
+        jsr     SDFS3_ADD_TO_LOADER_SUM
+        ldaa    LOADER_TYPE
+        cmpa    #$00
+        bne     SDFS3_READ_IHEX_SKIP_STORE
+        ldaa    HEX_NIBBLE
+        pshb
+        ldx     LOADER_ADDR
+        staa    0,x
+        inx
+        stx     LOADER_ADDR
+        pulb
+SDFS3_READ_IHEX_SKIP_STORE:
+        decb
+        bra     SDFS3_READ_IHEX_DATA_LOOP
+SDFS3_READ_IHEX_CHECKSUM:
+        ldaa    #5
+        staa    LOADER_STAGE
+        jsr     SDFS3_READ_HEXBYTE_INPUT
+        bcs     SDFS3_READ_IHEX_FAIL
+        jsr     SDFS3_ADD_TO_LOADER_SUM
+        cmpa    #$00
+        bne     SDFS3_READ_IHEX_FAIL
+        jsr     SDFS3_READ_RECORD_TRAILER
+        bcs     SDFS3_READ_IHEX_FAIL
+        ldaa    LOADER_TYPE
+        cmpa    #$01
+        beq     SDFS3_READ_IHEX_EOF
+        ldaa    #0
+        clc
+        rts
+SDFS3_READ_IHEX_EOF:
+        ldaa    #1
+        clc
+        rts
+SDFS3_READ_IHEX_FAIL:
+        sec
+        rts
+
+SDFS3_HEX_TO_NIBBLE:
+        cmpa    #'0'
+        blo     SDFS3_HEX_TO_NIBBLE_FAIL
+        cmpa    #'9'
+        bhi     SDFS3_HEX_ALPHA
+        suba    #'0'
+        clc
+        rts
+SDFS3_HEX_ALPHA:
+        cmpa    #'A'
+        blo     SDFS3_HEX_LOWER
+        cmpa    #'F'
+        bhi     SDFS3_HEX_LOWER
+        suba    #'A'
+        adda    #10
+        clc
+        rts
+SDFS3_HEX_LOWER:
+        cmpa    #'a'
+        blo     SDFS3_HEX_TO_NIBBLE_FAIL
+        cmpa    #'f'
+        bhi     SDFS3_HEX_TO_NIBBLE_FAIL
+        suba    #'a'
+        adda    #10
+        clc
+        rts
+SDFS3_HEX_TO_NIBBLE_FAIL:
+        sec
+        rts
+
+SDFS3_ADD_TO_LOADER_SUM:
+        adda    LOADER_SUM
+        staa    LOADER_SUM
+        rts
+
 SDFS3_PRINT_DIR_ENTRY:
         ldx     FAT_ENTRY_PTR
         ldab    #8
@@ -869,6 +1532,15 @@ SDFS3_PRINT_NIBBLE:
 SDFS3_PRINT_NIBBLE_OUT:
         jmp     SDFS3_PUTC
 
+SDFS3_PRINT:
+        ldaa    0,x
+        beq     SDFS3_PRINT_DONE
+        jsr     SDFS3_PUTC
+        inx
+        bra     SDFS3_PRINT
+SDFS3_PRINT_DONE:
+        rts
+
 SDFS3_PUTC:
         psha
         jsr     MIKBUG_OUTCH
@@ -900,6 +1572,9 @@ SDFS3_TOKEN_PTR:
         fdb     0
 SDFS3_TOKEN_LEN:
         fcb     0
+SDFS3_TXT_OK:
+        fcc     "OK"
+        fcb     CHR_CR,0
 
 FAT32_INCLUDE_FIND_API equ 1
 FAT32_INCLUDE_FILE_API equ 1

--- a/tests/test_sdfs68_v3_build.py
+++ b/tests/test_sdfs68_v3_build.py
@@ -189,10 +189,10 @@ def test_sdfs3_cmd_dispatch_parser_classifies_stub_commands() -> None:
         ("DIR", 0x03),
         (" dir ", 0x03),
         ("TYPE README.TXT", 0x03),
-        ("LoAd HELLO.S", 0x13),
-        ("RUN 1234", 0x14),
-        ("FOO.COM ARG", 0x15),
-        ("foo.com", 0x15),
+        ("LoAd HELLO.S", 0x05),
+        ("RUN MISSING.S", 0x06),
+        ("FOO.COM ARG", 0x07),
+        ("foo.com", 0x07),
         ("", 0x02),
         ("   ", 0x02),
         ("UNKNOWN", 0x02),
@@ -634,6 +634,98 @@ def test_sdfs3_cmd_dir_and_type_read_fat_files() -> None:
     print("[PASS] test_sdfs3_cmd_dir_and_type_read_fat_files")
 
 
+def test_sdfs3_cmd_load_run_and_com_read_fat_files() -> None:
+    profile = "sbcio_4000"
+    expected = EXPECTED[profile]
+    _run_make(profile, "bin")
+    _run_make(profile, "sdfs3sys")
+    _run_make(profile, "sdfs-tools")
+    suffix = expected["suffix"]
+    symbols = _load_symbols(
+        PROJECT_ROOT / "build" / f"mc6800-monitor{suffix}.lst",
+        "SD_INIT",
+        "SD_READ_SECTOR",
+        "SDFS3_FIND_API",
+        "SD_LBA0",
+        "SD_LBA1",
+        "SD_LBA2",
+        "SD_LBA3",
+        "SD_SECTOR_BUF",
+        "SDFS_LOAD_BASE",
+    )
+    sdfs3sys = (PROJECT_ROOT / "build" / f"SDFS3SYS{suffix}.BIN").read_bytes()
+    hello_com = (PROJECT_ROOT / "build" / "HELLO.COM").read_bytes()
+    args_com = (PROJECT_ROOT / "build" / "ARGS.COM").read_bytes()
+    run_program = bytes(
+        [
+            0xCE,
+            0x01,
+            0x07,
+            0xBD,
+            0xE0,
+            0x7E,
+            0x3F,
+            0x0D,
+            0x0A,
+            *b"HELLO, WORLD",
+            0x0D,
+            0x0A,
+            0x04,
+        ]
+    )
+    with _temporary_directory() as tmp:
+        harness = _assemble_fixed_lba_loader_harness(Path(tmp), symbols)
+    sd_image = _build_sdfs3sys_fat_sd_image(
+        sdfs3sys,
+        [
+            _file("HELLO.S", _srec_file(0x0200, b"S")),
+            _file("HELLO.HEX", _ihex_file(0x0201, b"I")),
+            _file("RUN.S", _srec_file(0x0100, run_program, entry_address=0x0100)),
+            _file("HELLO.COM", hello_com),
+            _file("ARGS.COM", args_com),
+            _file("EMPTY.COM", b""),
+            _file("BIG.COM", b"\x39" * 0x3F01),
+        ],
+    )
+    stdout, stderr, rc = _run_emu(
+        rom_path=PROJECT_ROOT / "build" / f"mc6800-monitor{suffix}.bin",
+        input_text=(
+            "M0110\r3F\r.\r"
+            f"M{SDFS3SYS_LOADER_HARNESS_ADDR:04X}\r{_hex_bytes(harness)}\r.\r"
+            f"G{SDFS3SYS_LOADER_HARNESS_ADDR:04X}\r"
+            "CMD LOAD HELLO.S\r"
+            "D0200-0200\r"
+            "CMD LOAD HELLO.HEX\r"
+            "D0201-0201\r"
+            "CMD RUN 0110\r"
+            "CMD HELLO.COM\r"
+            "CMD ARGS.COM AAA BBB\r"
+            "CMD NOFILE.COM\r"
+            "CMD EMPTY.COM\r"
+            "CMD BIG.COM\r"
+            "CMD RUN HELLO.HEX\r"
+            "CMD RUN RUN.S\r"
+            "\r"
+        ),
+        max_cycles=360_000_000,
+        sd_image=sd_image,
+        timeout=40,
+    )
+    assert rc == 0 and "[TIMEOUT]" not in stderr, (
+        f"emulator failed for SDFS3 LOAD/RUN/.COM: rc={rc} stderr={stderr!r}"
+    )
+    assert stdout.count("OK") >= 2, f"CMD LOAD did not report success: {stdout!r}"
+    assert "0200 53" in stdout, f"CMD LOAD HELLO.S did not write S-record data: {stdout!r}"
+    assert "0201 49" in stdout, f"CMD LOAD HELLO.HEX did not write HEX data: {stdout!r}"
+    assert "BRK 0110" in stdout, f"CMD RUN addr did not jump to the requested address: {stdout!r}"
+    assert "HELLO COM" in stdout, f"CMD HELLO.COM did not execute: {stdout!r}"
+    assert "ARGS AAA BBB" in stdout, f"CMD ARGS.COM did not pass arguments: {stdout!r}"
+    assert stdout.count("\n?\n") == 4, f"bad .COM/RUN inputs were not rejected exactly once: {stdout!r}"
+    assert "HELLO, WORLD" in stdout, f"CMD RUN RUN.S did not execute S-record entry: {stdout!r}"
+    assert "BRK 0106" in stdout, f"RUN.S did not reach SWI through entry address: {stdout!r}"
+    print("[PASS] test_sdfs3_cmd_load_run_and_com_read_fat_files")
+
+
 def test_fixed_lba_loader_harness_rejects_bad_sdfs3sys() -> None:
     profile = "sbcio_4000"
     expected = EXPECTED[profile]
@@ -769,6 +861,43 @@ def _build_sdfs3sys_fat_sd_image(system_image: bytes, files: list[Fat32File]) ->
     start = SDFS3SYS_FIXED_LBA * SECTOR_SIZE
     mutable[start : start + len(system_image)] = system_image
     return bytes(mutable)
+
+
+def _file(name: str, data: bytes, path: tuple[str, ...] = ()) -> Fat32File:
+    stem, _dot, ext = name.partition(".")
+    name83 = stem.upper().encode("ascii").ljust(8, b" ")
+    name83 += ext.upper().encode("ascii").ljust(3, b" ")
+    path83 = tuple(part.upper().encode("ascii").ljust(8, b" ") + b"   " for part in path)
+    return Fat32File(name83, data, path=path83)
+
+
+def _srec_file(
+    address: int,
+    data: bytes,
+    trailing_newline: bool = True,
+    entry_address: int = 0,
+) -> bytes:
+    count = len(data) + 3
+    values = [count, (address >> 8) & 0xFF, address & 0xFF, *data]
+    checksum = (~sum(values)) & 0xFF
+    record = "S1" + "".join(f"{value:02X}" for value in [*values, checksum])
+    entry_values = [3, (entry_address >> 8) & 0xFF, entry_address & 0xFF]
+    entry_checksum = (~sum(entry_values)) & 0xFF
+    entry_record = "S9" + "".join(f"{value:02X}" for value in [*entry_values, entry_checksum])
+    text = record + "\r\n" + entry_record
+    if trailing_newline:
+        text += "\r\n"
+    return text.encode("ascii")
+
+
+def _ihex_file(address: int, data: bytes, trailing_newline: bool = True) -> bytes:
+    values = [len(data), (address >> 8) & 0xFF, address & 0xFF, 0x00, *data]
+    checksum = (-sum(values)) & 0xFF
+    record = ":" + "".join(f"{value:02X}" for value in [*values, checksum])
+    text = record + "\r\n:00000001FF"
+    if trailing_newline:
+        text += "\r\n"
+    return text.encode("ascii")
 
 
 def _break_resident_api_and_refresh_checksum(data: bytearray) -> None:
@@ -1411,6 +1540,7 @@ def main() -> None:
         test_rom_cmd_gateway_calls_resident_dispatch,
         test_fixed_lba_loader_harness_loads_sdfs3sys,
         test_sdfs3_cmd_dir_and_type_read_fat_files,
+        test_sdfs3_cmd_load_run_and_com_read_fat_files,
         test_fixed_lba_loader_harness_rejects_bad_sdfs3sys,
     ]
     passed = 0


### PR DESCRIPTION
## 対応Issue

Closes #282
Refs #272
Refs #273
Refs #280
Refs #281

## 変更内容

- SDFS/68 v3 resident の `CMD LOAD` / `CMD RUN` / 明示 `.COM` 実行を未実装stubから実処理へ接続しました。
- v2相当の S-Record / Intel HEX loader parser を resident 内の FAT stream 入力で動くよう移植しました。
- `CMD LOAD <path>` はロード成功時に `OK` を表示し、ROM monitorへ復帰します。
- `CMD RUN <addr>` は指定アドレスへ `JMP`、`CMD RUN <path>` はS-Record entry recordがある場合にentryへ `JMP` します。
- `.COM` はraw binaryを `$0100` へロードし、`X` / `B` / `A=0` の引数ABIで `JSR $0100` 相当で呼びます。v3のROM `CMD` gateway復帰用stackを壊さないよう、`.COM` 呼び出し前のstack初期化は行いません。
- `docs/plans/sdfs68_v3/issue-282_load_run_com.md` に実装方針と検証方針を残しました。

## レビュー指摘への対応

- `FAT32_STREAM_GETC` のcarry setをEOFとerrorで取り違えないよう、record trailerでは `FAT_BYTES_REMAIN` でEOF正常と途中errorを分類しました。
- 異常系テストは `NOFILE.COM` / `EMPTY.COM` / `BIG.COM` / entryなし `RUN HELLO.HEX` の4件がそれぞれエラー復帰する前提で、エラー数を厳密化しました。

## テスト結果

- `python tests/test_sdfs68_v3_build.py` → 15 passed
- `make sdfs3sys MONITOR_PROFILE=sbcio_4000 PYTHON=python ASL_INCLUDE_ARG=build;include;src` → PASS
- `make sdfs3sys MONITOR_PROFILE=k6802_4000 PYTHON=python ASL_INCLUDE_ARG=build;include;src` → PASS
- `make bin MONITOR_PROFILE=base PYTHON=python ASL_INCLUDE_ARG=build;include;src` → PASS
- `make bin MONITOR_PROFILE=sbcio PYTHON=python ASL_INCLUDE_ARG=build;include;src` → PASS
- `REQUIRE_BUILD_ROM=1 MONITOR_PROFILE=base ... python tests/test_smoke.py` → 37 passed
- `REQUIRE_BUILD_ROM=1 MONITOR_PROFILE=base ... python tests/test_sd_fixture.py` → 10 passed
- `REQUIRE_BUILD_ROM=1 MONITOR_PROFILE=sbcio ... python tests/test_smoke.py` → 37 passed
- `REQUIRE_BUILD_ROM=1 MONITOR_PROFILE=sbcio ... python tests/test_sd_fixture.py` → 10 passed
- `git diff --check` → PASS

## 補足

SDFS3本体は `5060 bytes`、SDFS3SYSは `5092 bytes` で、`sbcio_4000` / `k6802_4000` の resident 領域内に収まっています。
Windowsローカルでは共有 `build/monitor_config.inc` があるため、base/sbcioのROM生成とsmoke/fixtureはプロファイルごとに単独再生成して確認しました。