### PR TITLE
Issue #291 SDFS3 resident配置をv2 SDFSから分離

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,12 @@ endif
 ifneq ($(filter command line environment environment override,$(origin VDG_VRAM_CONFIG)),)
 AXIS_OVERRIDE := 1
 endif
+ifneq ($(filter command line environment environment override,$(origin SDFS3_LOAD_BASE)),)
+AXIS_OVERRIDE := 1
+endif
+ifneq ($(filter command line environment environment override,$(origin SDFS3_LOAD_LIMIT)),)
+AXIS_OVERRIDE := 1
+endif
 
 MEMORY_CONFIG ?= $(PROFILE_MEMORY_CONFIG)
 BOARD_IO ?= $(PROFILE_BOARD_IO)
@@ -103,6 +109,8 @@ FEATURE_VDG ?= $(PROFILE_FEATURE_VDG)
 FEATURE_KEYBOARD ?= $(PROFILE_FEATURE_KEYBOARD)
 FEATURE_I2C ?= $(PROFILE_FEATURE_I2C)
 VDG_VRAM_CONFIG ?= $(PROFILE_VDG_VRAM_CONFIG)
+SDFS3_LOAD_BASE ?=
+SDFS3_LOAD_LIMIT ?=
 
 VALID_MEMORY_CONFIGS := base8k ram64_c000_work ram64_a000_work ram64_4000_work
 VALID_BOARD_IO := none sbcio
@@ -265,7 +273,7 @@ $(OUTDIR):
 	$(MKDIR_P)
 
 $(CONFIG_INC): FORCE tools/generate_monitor_config.py | $(OUTDIR)
-	"$(PYTHON)" tools/generate_monitor_config.py --output "$(CONFIG_INC)" --monitor-profile "$(MONITOR_PROFILE)" --memory-config "$(MEMORY_CONFIG)" --board-io "$(BOARD_IO)" --feature-sd "$(FEATURE_SD)" --feature-fat "$(FEATURE_FAT)" --feature-vdg "$(FEATURE_VDG)" --feature-keyboard "$(FEATURE_KEYBOARD)" --feature-i2c "$(FEATURE_I2C)" --vdg-vram-config "$(VDG_VRAM_CONFIG)"
+	"$(PYTHON)" tools/generate_monitor_config.py --output "$(CONFIG_INC)" --monitor-profile "$(MONITOR_PROFILE)" --memory-config "$(MEMORY_CONFIG)" --board-io "$(BOARD_IO)" --feature-sd "$(FEATURE_SD)" --feature-fat "$(FEATURE_FAT)" --feature-vdg "$(FEATURE_VDG)" --feature-keyboard "$(FEATURE_KEYBOARD)" --feature-i2c "$(FEATURE_I2C)" --vdg-vram-config "$(VDG_VRAM_CONFIG)" --sdfs3-load-base "$(SDFS3_LOAD_BASE)" --sdfs3-load-limit "$(SDFS3_LOAD_LIMIT)"
 
 $(OBJ): FORCE $(TOPSRC) include/hardware.inc include/mikbug.inc $(CONFIG_INC) src/acia6850.asm src/sdcard.asm src/fat32.asm | $(OUTDIR)
 	"$(ASL)" -q -L -olist $(LST) -o $(OBJ) -i $(ASL_INCLUDE_ARG) $(TOPSRC)

--- a/docs/plans/sdfs68_v3/README.md
+++ b/docs/plans/sdfs68_v3/README.md
@@ -33,3 +33,4 @@ v3 は、現行の `BOOT -> stage1 -> SDFS.BIN -> SDFS> ` 方式を単純に拡�
 | #276 | [issue-276_cmd_gateway.md](issue-276_cmd_gateway.md) | ROM CMD gateway |
 | #278 | [issue-278_sdfs3sys_image.md](issue-278_sdfs3sys_image.md) | SDFS3SYS system image生成 |
 | #277 | [issue-277_fixed_lba_loader.md](issue-277_fixed_lba_loader.md) | 固定LBA loader harness |
+| #291 | [issue-291_sdfs3_load_base.md](issue-291_sdfs3_load_base.md) | v2 SDFSロード先とv3 resident検出先の分離 |

--- a/docs/plans/sdfs68_v3/issue-291_sdfs3_load_base.md
+++ b/docs/plans/sdfs68_v3/issue-291_sdfs3_load_base.md
@@ -1,0 +1,36 @@
+# Issue #291 SDFS/68 v3 resident検出アドレス分離
+
+## 背景
+
+ROM側 `CMD` gateway は、v3 resident API header `SDFS3API` を `SDFS_LOAD_BASE` で検出していた。
+
+`SDFS_LOAD_BASE` は本来、v2 SDFS/68本体をstage1がロードする位置である。`k6802_vdg` では `$B000`、`k6802_4000` では `$5000` になる。
+
+このため、K6802-SBC + VDG の既存v2環境で `BOOT` し、v2からv3 residentを `$5000` へロードして `CMD` で確認する経路が取れなかった。
+
+## 方針
+
+- v2用の `SDFS_LOAD_BASE` / `SDFS_LOAD_LIMIT` はそのまま維持する。
+- v3用に `SDFS3_LOAD_BASE` / `SDFS3_LOAD_LIMIT` を追加する。
+- 未指定時は既存互換として `SDFS3_LOAD_BASE=SDFS_LOAD_BASE`、`SDFS3_LOAD_LIMIT=SDFS_LOAD_LIMIT` とする。
+- ROM側 `SDFS3_FIND_API` は `SDFS3_LOAD_BASE` を見る。
+- v3 resident の `org` と header内work baseは `SDFS3_LOAD_BASE` を使う。
+- `SDFS3SYS` 生成も `SDFS3_LOAD_*` を使う。
+
+## 確認用構成
+
+K6802-SBC + VDG で既存v2 system SDを使い、v3 residentだけ `$5000` に置く確認用構成は次の軸指定で作る。
+
+```powershell
+make rombin MONITOR_PROFILE=k6802_vdg ROM_KIND=W27C512 SDFS3_LOAD_BASE=0x5000 SDFS3_LOAD_LIMIT=0x7EFF BUILD_CONFIG_NAME=k6802-vdg-sdfs3-5000 PYTHON=python ASL_INCLUDE_ARG="build;include;src"
+make sdfs3 sdfs-tools MONITOR_PROFILE=k6802_vdg SDFS3_LOAD_BASE=0x5000 SDFS3_LOAD_LIMIT=0x7EFF BUILD_CONFIG_NAME=k6802-vdg-sdfs3-5000 PYTHON=python ASL_INCLUDE_ARG="build;include;src"
+```
+
+この構成では、v2 SDFS/68本体のロード先は `$B000` のまま、v3 resident検出先だけ `$5000` になる。
+
+## 検証方針
+
+- 既存の `sbcio_4000` / `k6802_4000` v3 resident / SDFS3SYS テストを維持する。
+- `k6802_vdg` + `SDFS3_LOAD_BASE=0x5000` のビルドで、`SDFS_LOAD_BASE=$B000` と `SDFS3_LOAD_BASE=$5000` が分離されることをテストする。
+- K6802-SBC実機手順は `docs/testing/k6802_sdfs3_via_v2_bringup.md` に反映する。
+

--- a/docs/testing/k6802_sdfs3_via_v2_bringup.md
+++ b/docs/testing/k6802_sdfs3_via_v2_bringup.md
@@ -1,0 +1,161 @@
+# K6802-SBC VDG環境でSDFS/68 v2からv3 residentを確認する手順
+
+## 目的
+
+K6802-SBC + K68-VDG実機で、Ph-2の `BOOT3` 実装前に SDFS/68 v3 resident の `CMD` 経由動作を確認する。
+
+この手順では、既存のv2 system SDをそのまま使う。ROMは `k6802_vdg` ベースにし、v2 SDFS/68のロード先 `$B000` は維持したまま、v3 residentの検出先だけ `$5000` にする。
+
+```text
+]BOOT
+  -> SDFS/68 v2 起動
+SDFS> LOAD SDFS3.S
+  -> v3 residentを $5000 へロード
+SDFS> EXIT
+  -> ROM monitorへ戻る
+]CMD DIR
+  -> $5000 の v3 residentを使う
+```
+
+## 前提
+
+- ROMは `k6802_vdg` ベースで作る。
+- `SDFS3_LOAD_BASE=0x5000`、`SDFS3_LOAD_LIMIT=0x7EFF` を指定する。
+- v2 system SDの `SDFS.BIN` は既存の `k6802_vdg` 用を使う。
+- `k6802_4000` 用に生成した `$5000` 配置のv2 `SDFS.BIN` は、この手順では使わない。
+
+この構成では、v2とv3の配置は次のように分離される。
+
+```text
+v2 SDFS.BIN:      $B000-
+v3 resident:      $5000-
+K68-VDG VRAM:     $C000-$DFFF
+SD/FAT work:      $A000-$BFFF
+```
+
+## ビルド
+
+Windows PowerShell例。
+
+```powershell
+make rombin MONITOR_PROFILE=k6802_vdg ROM_KIND=W27C512 SDFS3_LOAD_BASE=0x5000 SDFS3_LOAD_LIMIT=0x7EFF BUILD_CONFIG_NAME=k6802-vdg-sdfs3-5000 PYTHON=python ASL_INCLUDE_ARG="build;include;src"
+make sdfs3 sdfs-tools MONITOR_PROFILE=k6802_vdg SDFS3_LOAD_BASE=0x5000 SDFS3_LOAD_LIMIT=0x7EFF BUILD_CONFIG_NAME=k6802-vdg-sdfs3-5000 PYTHON=python ASL_INCLUDE_ARG="build;include;src"
+```
+
+主な生成物:
+
+```text
+build/mc6800-monitor-k6802-vdg-sdfs3-5000-W27C512.bin
+build/SDFS3-k6802-vdg-sdfs3-5000.BIN
+build/SDFS3-k6802-vdg-sdfs3-5000.p
+build/HELLO.S
+build/HELLO.COM
+build/ARGS.COM
+```
+
+SDに置くS-recordを作る。
+
+```powershell
+p2hex build\SDFS3-k6802-vdg-sdfs3-5000.p build\SDFS3.S -q -F Moto -M 2
+```
+
+## SDカード準備
+
+既存v2のsystem SDとして起動できるカードを用意する。FAT32 rootに、最低限次を置く。
+
+```text
+SDFS.BIN
+SDFS3.S
+README.TXT
+HELLO.S
+HELLO.COM
+ARGS.COM
+```
+
+`SDFS.BIN` は既存v2環境のものを使う。`SDFS3.S` は上記の `SDFS3-k6802-vdg-sdfs3-5000.p` から作ったものを置く。
+
+ファイル名は8.3 short nameで扱えるようにする。まずはサブディレクトリ、長いファイル名、日本語ファイル名、exFATは避ける。
+
+## 実機手順
+
+1. `build/mc6800-monitor-k6802-vdg-sdfs3-5000-W27C512.bin` をW27C512へ焼いて起動する。
+
+```text
+]
+```
+
+2. VDG画面とシリアルの両方でmonitor表示が出ることを確認する。
+
+3. v2 SDFS/68を起動する。
+
+```text
+]BOOT
+SDFS>
+```
+
+4. v2側でSD rootが見えることを確認する。
+
+```text
+SDFS> DIR
+```
+
+`SDFS3.S`、`HELLO.S`、`HELLO.COM`、`ARGS.COM` が見えることを確認する。
+
+5. v3 residentを `$5000` へロードする。
+
+```text
+SDFS> LOAD SDFS3.S
+OK
+```
+
+6. ROM monitorへ戻る。
+
+```text
+SDFS> EXIT
+]
+```
+
+7. v3 residentがROM `CMD` から使えることを確認する。
+
+```text
+]CMD DIR
+]CMD TYPE README.TXT
+]CMD LOAD HELLO.S
+]D0200-020F
+]CMD RUN HELLO.S
+]CMD HELLO.COM
+]CMD ARGS.COM AAA BBB
+```
+
+期待値:
+
+| コマンド | 期待結果 |
+| --- | --- |
+| `CMD DIR` | FAT32 rootの8.3通常ファイルが表示される |
+| `CMD TYPE README.TXT` | テキスト内容が表示される |
+| `CMD LOAD HELLO.S` | `OK` が表示される |
+| `CMD RUN HELLO.S` | `HELLO SREC` が表示され、SWIでmonitorに戻る |
+| `CMD HELLO.COM` | `HELLO COM` が表示され、monitorに戻る |
+| `CMD ARGS.COM AAA BBB` | `ARGS AAA BBB` が表示され、monitorに戻る |
+
+## v2へ戻る
+
+v2へ戻りたい場合は、ROM monitorから再度 `BOOT` する。
+
+```text
+]BOOT
+SDFS>
+```
+
+これはRAM上に残っているv2へ復帰するのではなく、SDからv2を再ロードする動作である。
+
+## 切り分け
+
+| 症状 | 見る場所 |
+| --- | --- |
+| `BOOT` でSDFSに入れない | ROM、stage1、system SD、`SDFS.BIN` |
+| `SDFS> LOAD SDFS3.S` が失敗する | FAT32 root、8.3名、ファイル破損 |
+| `CMD DIR` が `?` | ROMとresidentの `SDFS3_LOAD_BASE` が一致しているか |
+| `CMD DIR` が固まる | SD SPI配線、PIAアドレス、カード相性 |
+| `CMD TYPE` / `CMD LOAD` だけ失敗 | FAT32 entry、file size、cluster chain |
+

--- a/src/main.asm
+++ b/src/main.asm
@@ -1761,7 +1761,7 @@ SDFS3_API_MAJOR    equ 1
 SDFS3_API_MIN_COUNT equ 9
 
 SDFS3_FIND_API:
-        ldx     #SDFS_LOAD_BASE
+        ldx     #SDFS3_LOAD_BASE
         ldaa    0,x
         cmpa    #'S'
         bne     SDFS3_FIND_API_FAIL
@@ -1792,7 +1792,7 @@ SDFS3_FIND_API:
         ldaa    10,x
         cmpa    #SDFS3_API_MIN_COUNT
         blo     SDFS3_FIND_API_FAIL
-        ldx     #SDFS_LOAD_BASE
+        ldx     #SDFS3_LOAD_BASE
         clc
         rts
 SDFS3_FIND_API_FAIL:

--- a/src/sdfs68_v3/resident_stub.asm
+++ b/src/sdfs68_v3/resident_stub.asm
@@ -26,7 +26,7 @@ SDFS3_COM_MAX_LO equ SDFS3_COM_MAX_SIZE-SDFS3_COM_MAX_HI*256
         error   "SDFS/68 v3 resident is not supported for this memory configuration"
         endif
 
-        org     SDFS_LOAD_BASE
+        org     SDFS3_LOAD_BASE
 
 SDFS3_API_HEADER:
         fcc     "SDFS3API"
@@ -35,7 +35,7 @@ SDFS3_API_HEADER:
         fcb     SDFS3_API_COUNT
         fcb     SDFS3_FLAG_NONE
         fdb     SDFS3_JUMP_TABLE
-        fdb     SDFS_LOAD_BASE
+        fdb     SDFS3_LOAD_BASE
         fdb     SDFS3_END-1
         fdb     USER_RAM_END
         fdb     0
@@ -1583,4 +1583,7 @@ FAT32_INCLUDE_FILE_API equ 1
         include "fat32.asm"
 
 SDFS3_END:
+        if SDFS3_END-1 > SDFS3_LOAD_LIMIT
+        error   "SDFS/68 v3 resident exceeds configured load area"
+        endif
         end

--- a/tests/test_sdfs68_v3_build.py
+++ b/tests/test_sdfs68_v3_build.py
@@ -36,14 +36,14 @@ from fat32_image import Fat32File, build_fat32_image_from_files  # noqa: E402
 EXPECTED = {
     "sbcio_4000": {
         "suffix": "-sbcio-4000",
-        "SDFS_LOAD_BASE": 0x5000,
-        "SDFS_LOAD_LIMIT": 0x7EFF,
+        "SDFS3_LOAD_BASE": 0x5000,
+        "SDFS3_LOAD_LIMIT": 0x7EFF,
         "USER_RAM_END": 0x3FFF,
     },
     "k6802_4000": {
         "suffix": "-k6802-4000",
-        "SDFS_LOAD_BASE": 0x5000,
-        "SDFS_LOAD_LIMIT": 0x7EFF,
+        "SDFS3_LOAD_BASE": 0x5000,
+        "SDFS3_LOAD_LIMIT": 0x7EFF,
         "USER_RAM_END": 0x3FFF,
     },
 }
@@ -58,8 +58,8 @@ def test_sdfs3_profiles_build_and_match_header() -> None:
         data = bin_path.read_bytes()
         symbols = _load_symbols(
             lst_path,
-            "SDFS_LOAD_BASE",
-            "SDFS_LOAD_LIMIT",
+            "SDFS3_LOAD_BASE",
+            "SDFS3_LOAD_LIMIT",
             "USER_RAM_END",
             "SDFS3_API_HEADER",
             "SDFS3_JUMP_TABLE",
@@ -74,24 +74,24 @@ def test_sdfs3_profiles_build_and_match_header() -> None:
             "SDFS3_GET_CAPS",
             "SDFS3_END",
         )
-        assert symbols["SDFS_LOAD_BASE"] == expected["SDFS_LOAD_BASE"]
-        assert symbols["SDFS_LOAD_LIMIT"] == expected["SDFS_LOAD_LIMIT"]
+        assert symbols["SDFS3_LOAD_BASE"] == expected["SDFS3_LOAD_BASE"]
+        assert symbols["SDFS3_LOAD_LIMIT"] == expected["SDFS3_LOAD_LIMIT"]
         assert symbols["USER_RAM_END"] == expected["USER_RAM_END"]
-        assert symbols["SDFS3_API_HEADER"] == symbols["SDFS_LOAD_BASE"]
-        assert len(data) <= symbols["SDFS_LOAD_LIMIT"] - symbols["SDFS_LOAD_BASE"] + 1
-        assert len(data) == symbols["SDFS3_END"] - symbols["SDFS_LOAD_BASE"]
+        assert symbols["SDFS3_API_HEADER"] == symbols["SDFS3_LOAD_BASE"]
+        assert len(data) <= symbols["SDFS3_LOAD_LIMIT"] - symbols["SDFS3_LOAD_BASE"] + 1
+        assert len(data) == symbols["SDFS3_END"] - symbols["SDFS3_LOAD_BASE"]
         assert data[0:8] == b"SDFS3API"
         assert data[8] == 1, "SDFS3 api major mismatch"
         assert data[9] == 0, "SDFS3 api minor mismatch"
         assert data[10] == 9, "SDFS3 api count mismatch"
         assert data[11] == 0, "SDFS3 flags should be zero in stub"
         assert _word(data, 0x0C) == symbols["SDFS3_JUMP_TABLE"]
-        assert _word(data, 0x0E) == symbols["SDFS_LOAD_BASE"]
+        assert _word(data, 0x0E) == symbols["SDFS3_LOAD_BASE"]
         assert _word(data, 0x10) == symbols["SDFS3_END"] - 1
         assert _word(data, 0x12) == expected["USER_RAM_END"]
         assert _word(data, 0x14) == 0
         assert _word(data, 0x16) == 0
-        jump_table = symbols["SDFS3_JUMP_TABLE"] - symbols["SDFS_LOAD_BASE"]
+        jump_table = symbols["SDFS3_JUMP_TABLE"] - symbols["SDFS3_LOAD_BASE"]
         assert _word(data, jump_table) == symbols["SDFS3_GET_INFO"]
         assert _word(data, jump_table + 2) == symbols["SDFS3_CMD_DISPATCH"]
         assert _word(data, jump_table + 4) == symbols["SDFS3_LOAD_PATH"]
@@ -101,7 +101,7 @@ def test_sdfs3_profiles_build_and_match_header() -> None:
         assert _word(data, jump_table + 12) == symbols["SDFS3_GET_ERROR"]
         assert _word(data, jump_table + 14) == symbols["SDFS3_GET_MEMTOP"]
         assert _word(data, jump_table + 16) == symbols["SDFS3_GET_CAPS"]
-        get_error = symbols["SDFS3_GET_ERROR"] - symbols["SDFS_LOAD_BASE"]
+        get_error = symbols["SDFS3_GET_ERROR"] - symbols["SDFS3_LOAD_BASE"]
         assert data[get_error + 3 : get_error + 5] == bytes([0x0C, 0x39])
     print("[PASS] test_sdfs3_profiles_build_and_match_header")
 
@@ -114,11 +114,11 @@ def test_sdfs3_get_info_matches_calling_convention() -> None:
     data = (PROJECT_ROOT / "build" / f"SDFS3{suffix}.BIN").read_bytes()
     symbols = _load_symbols(
         PROJECT_ROOT / "build" / f"SDFS3{suffix}.lst",
-        "SDFS_LOAD_BASE",
+        "SDFS3_LOAD_BASE",
         "SDFS3_GET_INFO",
         "SDFS3_API_HEADER",
     )
-    get_info = symbols["SDFS3_GET_INFO"] - symbols["SDFS_LOAD_BASE"]
+    get_info = symbols["SDFS3_GET_INFO"] - symbols["SDFS3_LOAD_BASE"]
     header = symbols["SDFS3_API_HEADER"]
     assert data[get_info : get_info + 8] == bytes(
         [
@@ -143,18 +143,18 @@ def test_sdfs3_memtop_and_caps_match_calling_convention() -> None:
         data = (PROJECT_ROOT / "build" / f"SDFS3{suffix}.BIN").read_bytes()
         symbols = _load_symbols(
             PROJECT_ROOT / "build" / f"SDFS3{suffix}.lst",
-            "SDFS_LOAD_BASE",
+            "SDFS3_LOAD_BASE",
             "SDFS3_API_HEADER",
             "SDFS3_GET_MEMTOP",
             "SDFS3_GET_CAPS",
         )
-        get_memtop = symbols["SDFS3_GET_MEMTOP"] - symbols["SDFS_LOAD_BASE"]
+        get_memtop = symbols["SDFS3_GET_MEMTOP"] - symbols["SDFS3_LOAD_BASE"]
         memtop = expected["USER_RAM_END"]
         assert data[get_memtop : get_memtop + 5] == bytes(
             [0xCE, (memtop >> 8) & 0xFF, memtop & 0xFF, 0x0C, 0x39]
         )
 
-        get_caps = symbols["SDFS3_GET_CAPS"] - symbols["SDFS_LOAD_BASE"]
+        get_caps = symbols["SDFS3_GET_CAPS"] - symbols["SDFS3_LOAD_BASE"]
         header = symbols["SDFS3_API_HEADER"]
         assert data[get_caps : get_caps + 9] == bytes(
             [
@@ -181,7 +181,7 @@ def test_sdfs3_cmd_dispatch_parser_classifies_stub_commands() -> None:
     resident = (PROJECT_ROOT / "build" / f"SDFS3{suffix}.BIN").read_bytes()
     symbols = _load_symbols(
         PROJECT_ROOT / "build" / f"SDFS3{suffix}.lst",
-        "SDFS_LOAD_BASE",
+        "SDFS3_LOAD_BASE",
         "SDFS3_CMD_DISPATCH",
         "SDFS3_GET_ERROR",
     )
@@ -203,7 +203,7 @@ def test_sdfs3_cmd_dispatch_parser_classifies_stub_commands() -> None:
     stdout, stderr, rc = _run_emu(
         rom_path=PROJECT_ROOT / "build" / f"mc6800-monitor{suffix}.bin",
         input_text=(
-            f"M{symbols['SDFS_LOAD_BASE']:04X}\r"
+            f"M{symbols['SDFS3_LOAD_BASE']:04X}\r"
             f"{_hex_bytes(resident)}\r.\r"
             "M0300\r"
             f"{_hex_bytes(harness)}\r.\r"
@@ -239,8 +239,8 @@ def test_sdfs3sys_profiles_build_and_match_header() -> None:
         payload = bin_path.read_bytes()
         symbols = _load_symbols(
             lst_path,
-            "SDFS_LOAD_BASE",
-            "SDFS_LOAD_LIMIT",
+            "SDFS3_LOAD_BASE",
+            "SDFS3_LOAD_LIMIT",
             "SDFS3_JUMP_TABLE",
             "SDFS3_GET_INFO",
         )
@@ -250,18 +250,57 @@ def test_sdfs3sys_profiles_build_and_match_header() -> None:
         assert header.abi_major == 1
         assert header.abi_minor == 0
         assert header.flags == FLAG_CHECKSUM16
-        assert header.load_address == expected["SDFS_LOAD_BASE"]
-        assert header.load_address == symbols["SDFS_LOAD_BASE"]
-        assert len(payload) <= symbols["SDFS_LOAD_LIMIT"] - symbols["SDFS_LOAD_BASE"] + 1
+        assert header.load_address == expected["SDFS3_LOAD_BASE"]
+        assert header.load_address == symbols["SDFS3_LOAD_BASE"]
+        assert len(payload) <= symbols["SDFS3_LOAD_LIMIT"] - symbols["SDFS3_LOAD_BASE"] + 1
         assert header.image_size == HEADER_SIZE + len(payload)
-        assert header.entry_offset == symbols["SDFS3_GET_INFO"] - symbols["SDFS_LOAD_BASE"]
-        assert header.api_table_offset == symbols["SDFS3_JUMP_TABLE"] - symbols["SDFS_LOAD_BASE"]
+        assert header.entry_offset == symbols["SDFS3_GET_INFO"] - symbols["SDFS3_LOAD_BASE"]
+        assert header.api_table_offset == symbols["SDFS3_JUMP_TABLE"] - symbols["SDFS3_LOAD_BASE"]
         assert header.work_min == 0
         assert header.bank_window_hint == 0
         assert header.header_size == HEADER_SIZE
         assert header.checksum == checksum16(image)
         assert image[HEADER_SIZE:] == payload
     print("[PASS] test_sdfs3sys_profiles_build_and_match_header")
+
+
+def test_sdfs3_load_base_can_differ_from_v2_sdfs_load_base() -> None:
+    profile = "k6802_vdg"
+    suffix = "-k6802-vdg-sdfs3-5000"
+    extra_args = [
+        "SDFS3_LOAD_BASE=0x5000",
+        "SDFS3_LOAD_LIMIT=0x7EFF",
+        "BUILD_CONFIG_NAME=k6802-vdg-sdfs3-5000",
+    ]
+    _run_make(profile, "bin", extra_args=extra_args)
+    _run_make(profile, "sdfs3", extra_args=extra_args)
+
+    rom_symbols = _load_symbols(
+        PROJECT_ROOT / "build" / f"mc6800-monitor{suffix}.lst",
+        "SDFS_LOAD_BASE",
+        "SDFS3_LOAD_BASE",
+    )
+    resident_symbols = _load_symbols(
+        PROJECT_ROOT / "build" / f"SDFS3{suffix}.lst",
+        "SDFS_LOAD_BASE",
+        "SDFS_LOAD_LIMIT",
+        "SDFS3_LOAD_BASE",
+        "SDFS3_LOAD_LIMIT",
+        "SDFS3_API_HEADER",
+        "SDFS3_END",
+    )
+    data = (PROJECT_ROOT / "build" / f"SDFS3{suffix}.BIN").read_bytes()
+
+    assert rom_symbols["SDFS_LOAD_BASE"] == 0xB000
+    assert rom_symbols["SDFS3_LOAD_BASE"] == 0x5000
+    assert resident_symbols["SDFS_LOAD_BASE"] == 0xB000
+    assert resident_symbols["SDFS_LOAD_LIMIT"] == 0xBEFF
+    assert resident_symbols["SDFS3_LOAD_BASE"] == 0x5000
+    assert resident_symbols["SDFS3_LOAD_LIMIT"] == 0x7EFF
+    assert resident_symbols["SDFS3_API_HEADER"] == 0x5000
+    assert len(data) == resident_symbols["SDFS3_END"] - resident_symbols["SDFS3_LOAD_BASE"]
+    assert _word(data, 0x0E) == 0x5000
+    print("[PASS] test_sdfs3_load_base_can_differ_from_v2_sdfs_load_base")
 
 
 def test_sdfs3sys_rejects_bad_header_and_checksum() -> None:
@@ -355,7 +394,7 @@ def test_rom_detects_sdfs3_api_header() -> None:
     symbols = _load_symbols(
         PROJECT_ROOT / "build" / f"mc6800-monitor{suffix}.lst",
         "SDFS3_FIND_API",
-        "SDFS_LOAD_BASE",
+        "SDFS3_LOAD_BASE",
     )
     status_addr = 0x0200
     result_addr = 0x0201
@@ -387,17 +426,17 @@ def test_rom_detects_sdfs3_api_header() -> None:
     )
 
     cases = [
-        ("valid", _sdfs3_header(symbols["SDFS_LOAD_BASE"]), 0x42),
-        ("bad magic", b"XDFS3API" + _sdfs3_header(symbols["SDFS_LOAD_BASE"])[8:], 0xE1),
-        ("bad major", _mutated_header(symbols["SDFS_LOAD_BASE"], 8, 0x02), 0xE1),
-        ("legacy api count 7", _mutated_header(symbols["SDFS_LOAD_BASE"], 10, 0x07), 0xE1),
-        ("short api count 8", _mutated_header(symbols["SDFS_LOAD_BASE"], 10, 0x08), 0xE1),
+        ("valid", _sdfs3_header(symbols["SDFS3_LOAD_BASE"]), 0x42),
+        ("bad magic", b"XDFS3API" + _sdfs3_header(symbols["SDFS3_LOAD_BASE"])[8:], 0xE1),
+        ("bad major", _mutated_header(symbols["SDFS3_LOAD_BASE"], 8, 0x02), 0xE1),
+        ("legacy api count 7", _mutated_header(symbols["SDFS3_LOAD_BASE"], 10, 0x07), 0xE1),
+        ("short api count 8", _mutated_header(symbols["SDFS3_LOAD_BASE"], 10, 0x08), 0xE1),
     ]
     for label, header, expected_status in cases:
         stdout, stderr, rc = _run_emu(
             rom_path=PROJECT_ROOT / "build" / f"mc6800-monitor{suffix}.bin",
             input_text=(
-                f"M{symbols['SDFS_LOAD_BASE']:04X}\r"
+                f"M{symbols['SDFS3_LOAD_BASE']:04X}\r"
                 f"{_hex_bytes(header)}\r.\r"
                 f"M{harness_addr:04X}\r"
                 f"{_hex_bytes(harness)}\r.\r"
@@ -416,8 +455,8 @@ def test_rom_detects_sdfs3_api_header() -> None:
         )
         if expected_status == 0x42:
             assert values[1:3] == [
-                (symbols["SDFS_LOAD_BASE"] >> 8) & 0xFF,
-                symbols["SDFS_LOAD_BASE"] & 0xFF,
+                (symbols["SDFS3_LOAD_BASE"] >> 8) & 0xFF,
+                symbols["SDFS3_LOAD_BASE"] & 0xFF,
             ], f"{label} returned header address mismatch: {values!r}"
     print("[PASS] test_rom_detects_sdfs3_api_header")
 
@@ -430,12 +469,12 @@ def test_rom_cmd_gateway_calls_resident_dispatch() -> None:
     symbols = _load_symbols(
         PROJECT_ROOT / "build" / f"mc6800-monitor{suffix}.lst",
         "LINE_BUF",
-        "SDFS_LOAD_BASE",
+        "SDFS3_LOAD_BASE",
     )
     status_addr = 0x0200
     b_addr = 0x0201
     x_addr = 0x0202
-    load_base = symbols["SDFS_LOAD_BASE"]
+    load_base = symbols["SDFS3_LOAD_BASE"]
     jump_table = load_base + 0x18
     dispatch = jump_table + 0x12
     header = _sdfs3_header(load_base, jump_table=jump_table, work_end=dispatch + 13)
@@ -538,7 +577,7 @@ def test_fixed_lba_loader_harness_loads_sdfs3sys() -> None:
         "SD_LBA2",
         "SD_LBA3",
         "SD_SECTOR_BUF",
-        "SDFS_LOAD_BASE",
+        "SDFS3_LOAD_BASE",
     )
     sdfs3sys = (PROJECT_ROOT / "build" / f"SDFS3SYS{suffix}.BIN").read_bytes()
     assert len(sdfs3sys) <= 16 * 1024, "SDFS3SYS harness keeps the phase 1 image under 16KB"
@@ -551,11 +590,11 @@ def test_fixed_lba_loader_harness_loads_sdfs3sys() -> None:
             f"M{SDFS3SYS_LOADER_HARNESS_ADDR:04X}\r{_hex_bytes(harness)}\r.\r"
             f"G{SDFS3SYS_LOADER_HARNESS_ADDR:04X}\r"
             "D0200-0202\r"
-            f"D{symbols['SDFS_LOAD_BASE']:04X}-{symbols['SDFS_LOAD_BASE'] + len(payload) - 1:04X}\r"
+            f"D{symbols['SDFS3_LOAD_BASE']:04X}-{symbols['SDFS3_LOAD_BASE'] + len(payload) - 1:04X}\r"
             "\r"
         ),
         max_cycles=120_000_000,
-        dump_range=f"0200-{symbols['SDFS_LOAD_BASE'] + len(payload) - 1:04X}",
+        dump_range=f"0200-{symbols['SDFS3_LOAD_BASE'] + len(payload) - 1:04X}",
         sd_image=_build_sdfs3sys_sd_image(sdfs3sys),
         timeout=20,
     )
@@ -565,10 +604,10 @@ def test_fixed_lba_loader_harness_loads_sdfs3sys() -> None:
     status = _dump_bytes(stdout, 0x0200)
     assert status[0] == 0x42, f"SDFS3SYS loader should report success: {status!r}\nstdout={stdout!r}"
     assert status[1:3] == [
-        (symbols["SDFS_LOAD_BASE"] >> 8) & 0xFF,
-        symbols["SDFS_LOAD_BASE"] & 0xFF,
+        (symbols["SDFS3_LOAD_BASE"] >> 8) & 0xFF,
+        symbols["SDFS3_LOAD_BASE"] & 0xFF,
     ], f"SDFS3_FIND_API should return resident base: {status!r}"
-    loaded = _dump_range_bytes(stdout, symbols["SDFS_LOAD_BASE"], len(payload))
+    loaded = _dump_range_bytes(stdout, symbols["SDFS3_LOAD_BASE"], len(payload))
     assert bytes(loaded) == payload, f"resident payload was not fully loaded: {stdout!r}"
     print("[PASS] test_fixed_lba_loader_harness_loads_sdfs3sys")
 
@@ -589,7 +628,7 @@ def test_sdfs3_cmd_dir_and_type_read_fat_files() -> None:
         "SD_LBA2",
         "SD_LBA3",
         "SD_SECTOR_BUF",
-        "SDFS_LOAD_BASE",
+        "SDFS3_LOAD_BASE",
     )
     sdfs3sys = (PROJECT_ROOT / "build" / f"SDFS3SYS{suffix}.BIN").read_bytes()
     with _temporary_directory() as tmp:
@@ -651,7 +690,7 @@ def test_sdfs3_cmd_load_run_and_com_read_fat_files() -> None:
         "SD_LBA2",
         "SD_LBA3",
         "SD_SECTOR_BUF",
-        "SDFS_LOAD_BASE",
+        "SDFS3_LOAD_BASE",
     )
     sdfs3sys = (PROJECT_ROOT / "build" / f"SDFS3SYS{suffix}.BIN").read_bytes()
     hello_com = (PROJECT_ROOT / "build" / "HELLO.COM").read_bytes()
@@ -742,7 +781,7 @@ def test_fixed_lba_loader_harness_rejects_bad_sdfs3sys() -> None:
         "SD_LBA2",
         "SD_LBA3",
         "SD_SECTOR_BUF",
-        "SDFS_LOAD_BASE",
+        "SDFS3_LOAD_BASE",
     )
     image = (PROJECT_ROOT / "build" / f"SDFS3SYS{suffix}.BIN").read_bytes()
     assert len(image) <= 16 * 1024, "SDFS3SYS harness keeps the phase 1 image under 16KB"
@@ -1025,8 +1064,8 @@ def _fixed_lba_loader_harness_source(symbols: dict[str, int]) -> str:
     def equ(name: str) -> str:
         return f"${symbols[name]:04X}"
 
-    load_base_hi = (symbols["SDFS_LOAD_BASE"] >> 8) & 0xFF
-    load_base_lo = symbols["SDFS_LOAD_BASE"] & 0xFF
+    load_base_hi = (symbols["SDFS3_LOAD_BASE"] >> 8) & 0xFF
+    load_base_lo = symbols["SDFS3_LOAD_BASE"] & 0xFF
     return f"""        cpu     6800
         org     ${SDFS3SYS_LOADER_HARNESS_ADDR:04X}
 
@@ -1048,7 +1087,7 @@ SD_LBA1         equ {equ("SD_LBA1")}
 SD_LBA2         equ {equ("SD_LBA2")}
 SD_LBA3         equ {equ("SD_LBA3")}
 SD_SECTOR_BUF   equ {equ("SD_SECTOR_BUF")}
-SDFS_LOAD_BASE  equ {equ("SDFS_LOAD_BASE")}
+SDFS3_LOAD_BASE  equ {equ("SDFS3_LOAD_BASE")}
 
 START:
         jsr     SD_INIT
@@ -1235,7 +1274,7 @@ COPY_PAYLOAD:
 COPY_SIZE_OK:
         ldx     #SD_SECTOR_BUF+$20
         stx     SRC_PTR
-        ldx     #SDFS_LOAD_BASE
+        ldx     #SDFS3_LOAD_BASE
         stx     DST_PTR
         jsr     SET_COUNT_MIN_480
         jsr     COPY_CURRENT_BUFFER
@@ -1483,8 +1522,11 @@ def _run_make(
     profile: str,
     target: str,
     expect_success: bool = True,
+    extra_args: list[str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     make_args = ["make", target, f"MONITOR_PROFILE={profile}"]
+    if extra_args:
+        make_args.extend(extra_args)
     if sys.platform == "win32":
         make_args.extend(["PYTHON=python", "ASL_INCLUDE_ARG=build;include;src"])
     result = subprocess.run(
@@ -1533,6 +1575,7 @@ def main() -> None:
         test_sdfs3_memtop_and_caps_match_calling_convention,
         test_sdfs3_cmd_dispatch_parser_classifies_stub_commands,
         test_sdfs3sys_profiles_build_and_match_header,
+        test_sdfs3_load_base_can_differ_from_v2_sdfs_load_base,
         test_sdfs3sys_rejects_bad_header_and_checksum,
         test_sdfs3sys_rejects_payload_outside_load_range,
         test_sdfs3sys_cli_reports_bad_input,

--- a/tools/generate_monitor_config.py
+++ b/tools/generate_monitor_config.py
@@ -104,6 +104,21 @@ def feature(value: str) -> int:
     return int(value)
 
 
+def optional_address(value: str) -> str | None:
+    if value == "":
+        return None
+    try:
+        if value.startswith("$"):
+            parsed = int(value[1:], 16)
+        else:
+            parsed = int(value, 0)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid address: {value}") from exc
+    if not 0 <= parsed <= 0xFFFF:
+        raise argparse.ArgumentTypeError(f"address out of range: {value}")
+    return f"${parsed:04X}"
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--output", required=True)
@@ -116,12 +131,18 @@ def main() -> None:
     parser.add_argument("--feature-keyboard", type=feature, required=True)
     parser.add_argument("--feature-i2c", type=feature, required=True)
     parser.add_argument("--vdg-vram-config", choices=VDG_VRAM, required=True)
+    parser.add_argument("--sdfs3-load-base", type=optional_address, default=None)
+    parser.add_argument("--sdfs3-load-limit", type=optional_address, default=None)
     args = parser.parse_args()
     feature_fat = args.feature_sd if args.feature_fat is None else args.feature_fat
     if feature_fat and not args.feature_sd:
         raise SystemExit("FEATURE_FAT=1 requires FEATURE_SD=1")
+    if (args.sdfs3_load_base is None) != (args.sdfs3_load_limit is None):
+        raise SystemExit("SDFS3_LOAD_BASE and SDFS3_LOAD_LIMIT must be specified together")
 
     memory = MEMORY_CONFIGS[args.memory_config]
+    sdfs3_load_base = args.sdfs3_load_base or memory["SDFS_LOAD_BASE"]
+    sdfs3_load_limit = args.sdfs3_load_limit or memory["SDFS_LOAD_LIMIT"]
     is_base = args.memory_config == "base8k" and args.board_io == "none"
     is_sbcio = args.board_io == "sbcio"
     is_k6802_vdg = (
@@ -173,6 +194,8 @@ def main() -> None:
         f"S1_LIMIT        equ {memory['S1_LIMIT']}",
         f"SDFS_LOAD_BASE  equ {memory['SDFS_LOAD_BASE']}",
         f"SDFS_LOAD_LIMIT equ {memory['SDFS_LOAD_LIMIT']}",
+        f"SDFS3_LOAD_BASE equ {sdfs3_load_base}",
+        f"SDFS3_LOAD_LIMIT equ {sdfs3_load_limit}",
         "STACK_TOP        equ MIKBUG_STACK_TOP",
         "",
     ])

--- a/tools/mk_sdfs3sys.py
+++ b/tools/mk_sdfs3sys.py
@@ -157,15 +157,15 @@ def main(argv: list[str] | None = None) -> int:
     try:
         symbols = load_symbols(
             args.listing,
-            "SDFS_LOAD_BASE",
-            "SDFS_LOAD_LIMIT",
+            "SDFS3_LOAD_BASE",
+            "SDFS3_LOAD_LIMIT",
             "SDFS3_GET_INFO",
             "SDFS3_JUMP_TABLE",
         )
         image = build_sdfs3sys_image(
             resident_data=args.input.read_bytes(),
-            load_address=symbols["SDFS_LOAD_BASE"],
-            load_limit=symbols["SDFS_LOAD_LIMIT"],
+            load_address=symbols["SDFS3_LOAD_BASE"],
+            load_limit=symbols["SDFS3_LOAD_LIMIT"],
             entry_address=symbols["SDFS3_GET_INFO"],
             api_table_address=symbols["SDFS3_JUMP_TABLE"],
         )


### PR DESCRIPTION
## 対応Issue

Closes #291

## 変更内容

- SDFS3_LOAD_BASE / SDFS3_LOAD_LIMIT を追加し、未指定時は従来どおり SDFS_LOAD_BASE / SDFS_LOAD_LIMIT を使うようにしました。
- ROM側 SDFS3_FIND_API と v3 resident の org / header / SDFS3SYS生成を SDFS3_LOAD_* へ切り替えました。
- k6802_vdg で v2 SDFSロード先 $B000 と v3 resident検出先 $5000 を分離できるテストを追加しました。
- K6802-SBC + VDG 実機で、v2から SDFS3.S をロードして CMD を確認する手順を追加しました。

## テスト

- python tests\\test_sdfs68_v3_build.py → 16 passed
- git diff --check → OK
- 実機用確認ビルド:
  - uild/mc6800-monitor-k6802-vdg-sdfs3-5000-W27C512.bin
  - uild/SDFS3.S

## 補足

Windowsローカルで python tests\\test_stage1_build.py も確認しましたが、エミュレータ系ケースは個別に [TIMEOUT] となりました。レイアウト系の先頭4件は通過しており、今回のv3分離は専用テストで確認済みです。