### PR TITLE
Issue #293 SDFS LOAD境界回帰を修正

### DIFF
--- a/docs/usage/sdfs68_system_sd.md
+++ b/docs/usage/sdfs68_system_sd.md
@@ -147,8 +147,8 @@ SDFS/68 v1 はloaderの書き込み先アドレスを保護しない。`SDFS.BIN
 ## SDFS/68 v2 コマンド
 
 SDFS/68 v2以降では、DOS風の通常操作を本線にする。
-SDFS/68 V1.3ではサブディレクトリとroot起点の明示path指定を追加し、起動時は `SDFS/68 V1.3 #157` のように表示する。
-`#157` は元Issue番号をbuild番号相当として扱う。
+SDFS/68 V1.3ではサブディレクトリとroot起点の明示path指定を追加し、起動時は `SDFS/68 V1.3 #293` のように表示する。
+`#293` は直近の修正Issue番号をbuild番号相当として扱う。
 SDFS.BIN headerのversion byteはstage1が読むバイナリ形式versionであり、起動表示のバージョンとは別に扱う。
 
 | コマンド | 用途 |

--- a/src/sdfs68.asm
+++ b/src/sdfs68.asm
@@ -1390,12 +1390,12 @@ SDFS_READ_HEXBYTE_INPUT:
         lsla
         lsla
         lsla
-        tab
+        staa    HEX_NIBBLE
         jsr     SDFS_API_STREAM_GETC
         bcs     SDFS_READ_HEXBYTE_INPUT_FAIL
         jsr     SDFS_HEX_TO_NIBBLE
         bcs     SDFS_READ_HEXBYTE_INPUT_FAIL
-        aba
+        adda    HEX_NIBBLE
         pulb
         clc
         rts
@@ -1735,7 +1735,7 @@ SDFS_PUTC_DONE:
 
 TXT_BANNER:
         fcb     CHR_CR
-        fcc     "SDFS/68 V1.3 #157"
+        fcc     "SDFS/68 V1.3 #293"
         fcb     CHR_CR,0
 
 TXT_PROMPT:

--- a/src/sdfs68_v3/resident_stub.asm
+++ b/src/sdfs68_v3/resident_stub.asm
@@ -127,17 +127,9 @@ SDFS3_BAD_COMMAND:
         rts
 
 SDFS3_LOAD_PATH:
-        jmp     SDFS3_NOT_IMPLEMENTED
-
 SDFS3_READ_STREAM_OPEN:
-        jmp     SDFS3_NOT_IMPLEMENTED
-
 SDFS3_READ_STREAM_GETC:
-        jmp     SDFS3_NOT_IMPLEMENTED
-
 SDFS3_READ_STREAM_CLOSE:
-        jmp     SDFS3_NOT_IMPLEMENTED
-
 SDFS3_NOT_IMPLEMENTED:
         ldaa    #SDFS3_ERR_NOT_IMPL
 SDFS3_NOT_IMPLEMENTED_A:
@@ -1130,12 +1122,12 @@ SDFS3_READ_HEXBYTE_INPUT:
         lsla
         lsla
         lsla
-        tab
+        staa    HEX_NIBBLE
         jsr     FAT32_STREAM_GETC
         bcs     SDFS3_READ_HEXBYTE_INPUT_FAIL
         jsr     SDFS3_HEX_TO_NIBBLE
         bcs     SDFS3_READ_HEXBYTE_INPUT_FAIL
-        aba
+        adda    HEX_NIBBLE
         pulb
         clc
         rts

--- a/tests/test_sdfs68_build.py
+++ b/tests/test_sdfs68_build.py
@@ -113,7 +113,7 @@ def test_sdfs_accepts_sd_axis_4000() -> None:
     assert rc == 0 and "[TIMEOUT]" not in stderr, (
         f"emulator failed for sbcio 4000 axis: rc={rc} stderr={stderr!r}"
     )
-    assert "SDFS/68 V1.3 #157" in stdout, f"missing SDFS banner: {stdout!r}"
+    assert "SDFS/68 V1.3 #293" in stdout, f"missing SDFS banner: {stdout!r}"
     assert "SDFS> " in stdout, f"missing SDFS prompt: {stdout!r}"
     print("[PASS] test_sdfs_accepts_sd_axis_4000")
 
@@ -161,7 +161,7 @@ def test_sdfs_accepts_sd_axis_without_vdg() -> None:
     assert rc == 0 and "[TIMEOUT]" not in stderr, (
         f"emulator failed for sbcio SD axis: rc={rc} stderr={stderr!r}"
     )
-    assert "SDFS/68 V1.3 #157" in stdout, f"missing SDFS banner: {stdout!r}"
+    assert "SDFS/68 V1.3 #293" in stdout, f"missing SDFS banner: {stdout!r}"
     assert "SDFS> " in stdout, f"missing SDFS prompt: {stdout!r}"
     print("[PASS] test_sdfs_accepts_sd_axis_without_vdg")
 
@@ -274,7 +274,7 @@ def test_stage1_boot_runs_built_sdfs_binary() -> None:
         assert rc == 0 and "[TIMEOUT]" not in stderr, (
             f"emulator failed for {profile}: rc={rc} stderr={stderr!r}"
         )
-        assert "SDFS/68 V1.3 #157" in stdout, f"missing SDFS banner for {profile}: {stdout!r}"
+        assert "SDFS/68 V1.3 #293" in stdout, f"missing SDFS banner for {profile}: {stdout!r}"
         assert "SDFS> " in stdout, f"missing SDFS prompt for {profile}: {stdout!r}"
     print("[PASS] test_stage1_boot_runs_built_sdfs_binary")
 
@@ -310,6 +310,34 @@ def test_sdfs_loads_srec_and_ihex_files() -> None:
         assert "0202 4E" in stdout, f"EOF-without-newline HEX did not load for {profile}: {stdout!r}"
         assert stdout.count("OK") >= 3, f"missing load success messages for {profile}: {stdout!r}"
     print("[PASS] test_sdfs_loads_srec_and_ihex_files")
+
+
+def test_sdfs_loads_multisector_srec_file() -> None:
+    profile = "k6802_vdg"
+    expected = EXPECTED[profile]
+    _run_make(profile, "bin")
+    _run_make(profile, "stage1")
+    _run_make(profile, "sdfs")
+    suffix = expected["suffix"]
+    stage1 = (PROJECT_ROOT / "build" / f"stage1{suffix}.bin").read_bytes()
+    sdfs = (PROJECT_ROOT / "build" / f"SDFS{suffix}.BIN").read_bytes()
+    payload = bytes((index & 0xFF) for index in range(256))
+    image = build_sdfs_image(
+        stage1_data=stage1,
+        sdfs_data=sdfs,
+        extra_files=[_file("T256.S", _srec_records_file(0x0200, payload))],
+    )
+    stdout, stderr, rc = _run_emu_with_sd(
+        rom_path=PROJECT_ROOT / "build" / f"mc6800-monitor{suffix}.bin",
+        input_text="BOOT\rLOAD T256.S\rD0200\rD02F0\rX",
+        sd_image=image,
+        max_cycles=180_000_000,
+    )
+    assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
+    assert "OK" in stdout, f"multisector S-record load failed: {stdout!r}"
+    assert "0200 00" in stdout, f"first byte missing after multisector load: {stdout!r}"
+    assert "02F0 F0" in stdout, f"second-sector data missing after multisector load: {stdout!r}"
+    print("[PASS] test_sdfs_loads_multisector_srec_file")
 
 
 def test_sdfs_dir_lists_root_files_and_skips_non_files() -> None:
@@ -513,7 +541,7 @@ def test_sdfs_exit_returns_to_monitor_and_boots_again() -> None:
         max_cycles=180_000_000,
     )
     assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
-    assert stdout.count("SDFS/68 V1.3 #157") >= 2, f"EXIT did not allow BOOT again: {stdout!r}"
+    assert stdout.count("SDFS/68 V1.3 #293") >= 2, f"EXIT did not allow BOOT again: {stdout!r}"
     assert stdout.count("] ") >= 2, f"monitor prompt did not return after EXIT: {stdout!r}"
     print("[PASS] test_sdfs_exit_returns_to_monitor_and_boots_again")
 
@@ -1225,6 +1253,30 @@ def _srec_file(
     return text.encode("ascii")
 
 
+def _srec_records_file(
+    address: int,
+    data: bytes,
+    record_size: int = 16,
+    trailing_newline: bool = True,
+    entry_address: int = 0,
+) -> bytes:
+    records = []
+    for offset in range(0, len(data), record_size):
+        chunk = data[offset : offset + record_size]
+        record_address = address + offset
+        count = len(chunk) + 3
+        values = [count, (record_address >> 8) & 0xFF, record_address & 0xFF, *chunk]
+        checksum = (~sum(values)) & 0xFF
+        records.append("S1" + "".join(f"{value:02X}" for value in [*values, checksum]))
+    entry_values = [3, (entry_address >> 8) & 0xFF, entry_address & 0xFF]
+    entry_checksum = (~sum(entry_values)) & 0xFF
+    records.append("S9" + "".join(f"{value:02X}" for value in [*entry_values, entry_checksum]))
+    text = "\r\n".join(records)
+    if trailing_newline:
+        text += "\r\n"
+    return text.encode("ascii")
+
+
 def _ihex_file(address: int, data: bytes, trailing_newline: bool = True) -> bytes:
     values = [len(data), (address >> 8) & 0xFF, address & 0xFF, 0x00, *data]
     checksum = (-sum(values)) & 0xFF
@@ -1266,6 +1318,7 @@ def main() -> None:
         test_sdfs_api_wrappers_target_stage1_jump_table,
         test_stage1_boot_runs_built_sdfs_binary,
         test_sdfs_loads_srec_and_ihex_files,
+        test_sdfs_loads_multisector_srec_file,
         test_sdfs_dir_lists_root_files_and_skips_non_files,
         test_sdfs_vdg_dir_does_not_insert_blank_line_after_command,
         test_sdfs_dir_scans_root_chain,


### PR DESCRIPTION
## 対応Issue
Closes #293

## 変更内容
- SDFS/68 v2系の `SDFS_READ_HEXBYTE_INPUT` で、hex上位nibbleをBレジスタではなくwork変数へ退避するよう修正しました。
- SDFS/68 v3 residentの同等処理も同じ方針で修正しました。
- v3 residentの未実装API入口を同一処理へ畳み、修正後も `SDFS3_LOAD_BASE=0x5000` / `SDFS3_LOAD_LIMIT=0x7EFF` に収まるようにしました。
- SDFS/68起動バナーを `SDFS/68 V1.3 #293` に更新し、実機で差し替え済みか見えるようにしました。
- 2セクタ超えS-Recordを `SDFS> LOAD` する回帰テストを追加しました。

## 原因
`READ_HEXBYTE_INPUT` はhex 2文字を1 byteへ変換する際、上位nibbleをBレジスタへ保持していました。2文字目の読み取りがFAT streamのセクタ境界に当たると、stage1 stream API側の処理でBが破壊され、checksumが合わず `?S5` / `?I5` になっていました。

`.COM` はraw byteコピー経路なのでこのhex変換を通らず、同じSDでも読める場合がありました。

## テスト
- `PYTHON=python python -c "import tests.test_sdfs68_build as t; t.test_sdfs_loads_srec_and_ihex_files(); t.test_sdfs_loads_multisector_srec_file()"`
- `PYTHON=python make sdfs MONITOR_PROFILE=k6802_vdg PYTHON=python ASL_INCLUDE_ARG="build;include;src"`
- `PYTHON=python make sdfs3 MONITOR_PROFILE=k6802_vdg SDFS3_LOAD_BASE=0x5000 SDFS3_LOAD_LIMIT=0x7EFF BUILD_CONFIG_NAME=k6802-vdg-sdfs3-5000 PYTHON=python ASL_INCLUDE_ARG="build;include;src"`

補足: `make sdfs` と `make sdfs3` は共通の `build/monitor_config.inc` を生成するため、異なる構成を並列実行すると競合します。上記は直列で確認しました。

## 実機確認
K6802-SBC + K68-VDG 環境で、更新済み `SDFS.BIN` を含むSDイメージにより以下を確認しました。

- `LOAD T256.S` が成功
- `LOAD SDFS3.S` が成功
- ROM側 `CMD DIR` が動作

## 影響範囲
- SDFS/68 v2系のS-Record / Intel HEX LOAD
- SDFS/68 v3 residentのS-Record / Intel HEX LOAD
- `.COM` rawロード経路の仕様変更はありません