### PR TITLE
Issue #295 BOOT3固定LBAローダを追加

### DIFF
--- a/docs/plans/sdfs68_v3/issue-295_boot3_fixed_lba.md
+++ b/docs/plans/sdfs68_v3/issue-295_boot3_fixed_lba.md
@@ -1,0 +1,38 @@
+# Issue #295 SDFS/68 v3 BOOT3固定LBAローダ
+
+親epic: #296 SDFS/68 v3 phase 2 実機起動・system運用epic
+
+## 背景
+
+#277 では `SDFS3SYS` 固定LBAローダをRAM harnessとして検証した。PH2ではこの経路をROMモニタの `BOOT3` コマンドにし、v2 SDFS/68を経由せずに v3 resident を直接RAMへロードできるようにする。
+
+## 採用方針
+
+- `BOOT` は既存の v2 stage1 起動経路として維持する。
+- `BOOT3` は physical LBA `64` から `SDFS3SYS` を読み込む。
+- `SDFS3SYS` の magic、header version、ABI major、flags、load address、header size、image size、checksum をROM側で検証する。
+- resident payload は `SDFS3_LOAD_BASE` へ配置し、配置後に `SDFS3_FIND_API` でAPI headerを確認する。
+- 正常終了時は `OK` を表示してROM monitorへ戻る。以後 `CMD DIR` などの `CMD` gatewayからresidentを呼び出す。
+- 異常時は通常のmonitor errorとして `?` を返す。
+
+## 対象構成
+
+主対象は K6802-SBC + K68-VDG の次の構成とする。
+
+```powershell
+make rombin MONITOR_PROFILE=k6802_vdg ROM_KIND=W27C512 SDFS3_LOAD_BASE=0x5000 SDFS3_LOAD_LIMIT=0x7EFF BUILD_CONFIG_NAME=k6802-vdg-sdfs3-5000 PYTHON=python ASL_INCLUDE_ARG="build;include;src"
+make sdfs3sys MONITOR_PROFILE=k6802_vdg SDFS3_LOAD_BASE=0x5000 SDFS3_LOAD_LIMIT=0x7EFF BUILD_CONFIG_NAME=k6802-vdg-sdfs3-5000 PYTHON=python ASL_INCLUDE_ARG="build;include;src"
+```
+
+`BOOT3` 自体は `FEATURE_SD=1` かつ `S1_SUPPORTED=1` のROMに入る。`SDFS3_LOAD_BASE` はROMとresidentで一致させる必要がある。
+
+## 検証方針
+
+- `BOOT3` が `SDFS3SYS` をロードし、直後に `CMD DIR` がFAT32 rootを読めることをエミュレータで確認する。
+- bad magicの `SDFS3SYS` を `BOOT3` が拒否し、resident未ロード状態の `CMD DIR` も失敗することを確認する。
+- 既存の #277 RAM harness テストと v3 `DIR` / `TYPE` / `LOAD` / `RUN` / `.COM` テストを維持する。
+
+## 後続作業
+
+- system SD作成ツールで `SDFS3SYS` をLBA `64` に配置する正式手順は別Issueで扱う。
+- `BOOT3` の自動起動、slot A/B、active marker、FAT writeを伴うsystem updateは別Issueで扱う。

--- a/docs/testing/k6802_sdfs3_via_v2_bringup.md
+++ b/docs/testing/k6802_sdfs3_via_v2_bringup.md
@@ -2,7 +2,8 @@
 
 ## 目的
 
-K6802-SBC + K68-VDG実機で、Ph-2の `BOOT3` 実装前に SDFS/68 v3 resident の `CMD` 経由動作を確認する。
+K6802-SBC + K68-VDG実機で、SDFS/68 v3 resident の `CMD` 経由動作を確認する。
+PH2の `BOOT3` 実装後は fixed LBA `64` の `SDFS3SYS` から直接residentをロードできる。v2経由の `LOAD SDFS3.S` 手順は比較・退避用として残す。
 
 この手順では、既存のv2 system SDをそのまま使う。ROMは `k6802_vdg` ベースにし、v2 SDFS/68のロード先 `$B000` は維持したまま、v3 residentの検出先だけ `$5000` にする。
 
@@ -39,7 +40,7 @@ Windows PowerShell例。
 
 ```powershell
 make rombin MONITOR_PROFILE=k6802_vdg ROM_KIND=W27C512 SDFS3_LOAD_BASE=0x5000 SDFS3_LOAD_LIMIT=0x7EFF BUILD_CONFIG_NAME=k6802-vdg-sdfs3-5000 PYTHON=python ASL_INCLUDE_ARG="build;include;src"
-make sdfs3 sdfs-tools MONITOR_PROFILE=k6802_vdg SDFS3_LOAD_BASE=0x5000 SDFS3_LOAD_LIMIT=0x7EFF BUILD_CONFIG_NAME=k6802-vdg-sdfs3-5000 PYTHON=python ASL_INCLUDE_ARG="build;include;src"
+make sdfs3 sdfs3sys sdfs-tools MONITOR_PROFILE=k6802_vdg SDFS3_LOAD_BASE=0x5000 SDFS3_LOAD_LIMIT=0x7EFF BUILD_CONFIG_NAME=k6802-vdg-sdfs3-5000 PYTHON=python ASL_INCLUDE_ARG="build;include;src"
 ```
 
 主な生成物:
@@ -47,6 +48,7 @@ make sdfs3 sdfs-tools MONITOR_PROFILE=k6802_vdg SDFS3_LOAD_BASE=0x5000 SDFS3_LOA
 ```text
 build/mc6800-monitor-k6802-vdg-sdfs3-5000-W27C512.bin
 build/SDFS3-k6802-vdg-sdfs3-5000.BIN
+build/SDFS3SYS-k6802-vdg-sdfs3-5000.BIN
 build/SDFS3-k6802-vdg-sdfs3-5000.p
 build/HELLO.S
 build/HELLO.COM
@@ -61,7 +63,8 @@ p2hex build\SDFS3-k6802-vdg-sdfs3-5000.p build\SDFS3.S -q -F Moto -M 2
 
 ## SDカード準備
 
-既存v2のsystem SDとして起動できるカードを用意する。FAT32 rootに、最低限次を置く。
+`BOOT3` を使う場合は、physical LBA `64` に `build/SDFS3SYS-k6802-vdg-sdfs3-5000.BIN` を配置し、FAT32 partitionを physical LBA `128` 以降へ置く。
+v2経由の比較も行う場合は、既存v2のsystem SDとして起動できるカードを用意する。FAT32 rootに、最低限次を置く。
 
 ```text
 SDFS.BIN
@@ -86,14 +89,47 @@ ARGS.COM
 
 2. VDG画面とシリアルの両方でmonitor表示が出ることを確認する。
 
-3. v2 SDFS/68を起動する。
+3. `BOOT3` でv3 residentをロードする。
+
+```text
+]BOOT3
+OK
+]
+```
+
+4. v3 residentがROM `CMD` から使えることを確認する。
+
+```text
+]CMD DIR
+]CMD TYPE README.TXT
+]CMD LOAD HELLO.S
+]D0200-020F
+]CMD RUN HELLO.S
+]CMD HELLO.COM
+]CMD ARGS.COM AAA BBB
+```
+
+期待値:
+
+| コマンド | 期待結果 |
+| --- | --- |
+| `CMD DIR` | FAT32 rootの8.3通常ファイルが表示される |
+| `CMD TYPE README.TXT` | テキスト内容が表示される |
+| `CMD LOAD HELLO.S` | `OK` が表示される |
+| `CMD RUN HELLO.S` | `HELLO SREC` が表示され、SWIでmonitorに戻る |
+| `CMD HELLO.COM` | `HELLO COM` が表示され、monitorに戻る |
+| `CMD ARGS.COM AAA BBB` | `ARGS AAA BBB` が表示され、monitorに戻る |
+
+## v2経由の比較手順
+
+1. v2 SDFS/68を起動する。
 
 ```text
 ]BOOT
 SDFS>
 ```
 
-4. v2側でSD rootが見えることを確認する。
+2. v2側でSD rootが見えることを確認する。
 
 ```text
 SDFS> DIR
@@ -101,21 +137,21 @@ SDFS> DIR
 
 `SDFS3.S`、`HELLO.S`、`HELLO.COM`、`ARGS.COM` が見えることを確認する。
 
-5. v3 residentを `$5000` へロードする。
+3. v3 residentを `$5000` へロードする。
 
 ```text
 SDFS> LOAD SDFS3.S
 OK
 ```
 
-6. ROM monitorへ戻る。
+4. ROM monitorへ戻る。
 
 ```text
 SDFS> EXIT
 ]
 ```
 
-7. v3 residentがROM `CMD` から使えることを確認する。
+5. v3 residentがROM `CMD` から使えることを確認する。
 
 ```text
 ]CMD DIR
@@ -155,7 +191,7 @@ SDFS>
 | --- | --- |
 | `BOOT` でSDFSに入れない | ROM、stage1、system SD、`SDFS.BIN` |
 | `SDFS> LOAD SDFS3.S` が失敗する | FAT32 root、8.3名、ファイル破損 |
-| `CMD DIR` が `?` | ROMとresidentの `SDFS3_LOAD_BASE` が一致しているか |
+| `BOOT3` が `?` | LBA64の `SDFS3SYS`、checksum、ROMとresidentの `SDFS3_LOAD_BASE` |
+| `CMD DIR` が `?` | `BOOT3` または `LOAD SDFS3.S` でresidentがロード済みか、ROMとresidentの `SDFS3_LOAD_BASE` が一致しているか |
 | `CMD DIR` が固まる | SD SPI配線、PIAアドレス、カード相性 |
 | `CMD TYPE` / `CMD LOAD` だけ失敗 | FAT32 entry、file size、cluster chain |
-

--- a/docs/usage/monitor_commands.md
+++ b/docs/usage/monitor_commands.md
@@ -46,10 +46,12 @@ ROM単体で使える低レベル操作、復旧口、マシン語デバッグ�
 ### SDFS/68起動入口
 
 `BOOT` はROM上のファイル操作コマンドではなく、system SD上のstage1を起動してSDFS/68へ制御を渡す入口である。
+`BOOT3` は v3 resident 用の入口で、fixed system area の `SDFS3SYS` をRAMへロードしてROM monitorへ戻る。
 
 | コマンド | 用途 |
 | --- | --- |
 | `BOOT` | 固定LBAからSDFS/68 stage1 loaderを読み込んで、第2段システムへ移行する。`FEATURE_SD=1` かつ stage1対応RAM構成のROMで有効 |
+| `BOOT3` | fixed LBA `64` の `SDFS3SYS` を検証し、payloadを `SDFS3_LOAD_BASE` へロードする。成功後は `CMD <tail>` でv3 residentを呼び出す |
 | `CMD <tail>` | RAM上のSDFS/68 v3 resident APIを検出し、slot 1 `SDFS3_CMD_DISPATCH` へ `tail` を渡す。`FEATURE_SD=1` かつ stage1対応RAM構成のROMで有効 |
 
 ### ROM常駐FAT互換コマンド
@@ -360,11 +362,11 @@ D M MAP RAMTEST G L B C R U H F
 ]
 ```
 
-`FEATURE_SD=1` かつ `FEATURE_FAT=0` のROMでは、固定LBA stage1起動用の `BOOT` を含めて表示する。
+`FEATURE_SD=1` かつ `FEATURE_FAT=0` のROMでは、固定LBA stage1起動用の `BOOT` と v3 resident用の `BOOT3` を含めて表示する。
 
 ```text
 ] H
-D M MAP RAMTEST G L BOOT CMD B C R U H F
+D M MAP RAMTEST G L BOOT BOOT3 CMD B C R U H F
 ]
 ```
 
@@ -372,15 +374,15 @@ D M MAP RAMTEST G L BOOT CMD B C R U H F
 
 ```text
 ] H
-D DIR M MAP RAMTEST G L LF BOOT CMD B C R U H F
+D DIR M MAP RAMTEST G L LF BOOT BOOT3 CMD B C R U H F
 ]
 ```
 
-`FEATURE_SD=1` かつ `FEATURE_FAT=0` のROMでは、ROM側FAT互換コマンドではなく `BOOT` を含める。VDG/キーボード診断はROMコマンドではなく、SD上の診断用S-Recordから実行する。
+`FEATURE_SD=1` かつ `FEATURE_FAT=0` のROMでは、ROM側FAT互換コマンドではなく `BOOT` / `BOOT3` を含める。VDG/キーボード診断はROMコマンドではなく、SD上の診断用S-Recordから実行する。
 
 ```text
 ] H
-D M MAP RAMTEST G L BOOT CMD B C R U H F
+D M MAP RAMTEST G L BOOT BOOT3 CMD B C R U H F
 ]
 ```
 

--- a/docs/usage/sdfs68_system_sd.md
+++ b/docs/usage/sdfs68_system_sd.md
@@ -4,13 +4,16 @@
 ここに書く `DIR`、`TYPE`、`RUN`、`LOAD`、`L`、`EXIT` は、ROMモニタの `] ` プロンプトで使うコマンドではなく、SDFS/68起動後の `SDFS> ` プロンプトで使うコマンドである。
 
 SDFS/68 は、ROM モニタの `BOOT` から起動する第2段システムである。ROM は固定LBAからstage1 loaderを読み、stage1がFAT root の `SDFS.BIN` を読み込む。
+SDFS/68 v3 resident は `BOOT3` でも起動できる。`BOOT3` は fixed LBA `64` の `SDFS3SYS` をROMが直接読み、resident payloadを `SDFS3_LOAD_BASE` へロードしてからROM monitorへ戻る。
 ROM単体ではメモリ変更、メモリダンプ、指定アドレス実行、マシン語デバッグを行い、通常のSDファイル操作はSDFS/68へ寄せる。
 
 ```mermaid
 flowchart TD
     NORMAL["通常運用"]
     BOOT["] BOOT"]
+    BOOT3["] BOOT3"]
     SDFS["SDFS>"]
+    CMD["] CMD DIR"]
     DIR["DIR"]
     RUN["RUN addr"]
     DEBUG["デバッグ運用"]
@@ -18,8 +21,10 @@ flowchart TD
     ROM["] M / D / U / B / R"]
 
     NORMAL --> BOOT --> SDFS --> DIR --> RUN
+    NORMAL --> BOOT3 --> CMD
     DEBUG --> EXIT --> ROM
     ROM --> BOOT
+    ROM --> BOOT3
 ```
 
 ## 基本方針
@@ -38,7 +43,9 @@ flowchart TD
 | --- | --- | --- |
 | ROMモニタ起動、`D` / `M` / `G` / `L` / `B` / `C` / `R` / `U` | 不要 | ROMモニタ |
 | ROM `BOOT` でSDFS/68へ移行 | 必要 | ROM入口 + stage1 |
+| ROM `BOOT3` でv3 residentをロード | 必要 | ROM入口 + fixed `SDFS3SYS` |
 | SDFS/68の `DIR` / `TYPE` / `RUN` / `LOAD` / `EXIT` | 必要 | SDFS/68 |
+| ROM `CMD <tail>` でv3 residentを呼ぶ | `BOOT3` または別手段でresidentロード済みなら必要 | ROM入口 + v3 resident |
 | 直接指定ROMのROM常駐FAT `DIR` / `LF` | SDFS/68用system SDは不要。ただしFAT32 SDカードは必要 | ROM互換FAT |
 
 ROM常駐FATは `FEATURE_SD=1 FEATURE_FAT=1` を直接指定したときだけ使う互換機能であり、SDFS/68本線ではない。
@@ -78,7 +85,9 @@ python tools\mk_sdfs_image.py --stage1 STAGE1.BIN --sdfs SDFS.BIN --output sdfs.
 
 - FAT32 形式の SDイメージファイル。
 - partition開始前の physical LBA `16` 以降にstage1 loaderを配置する。
-- FAT32 partition は既定で physical LBA `32` から開始する。
+- v3 `BOOT3` 用に physical LBA `64` 以降へ `SDFS3SYS` を配置する。
+- v2/stage1だけのSDではFAT32 partitionを physical LBA `32` から開始できる。
+- `BOOT3` 用の `SDFS3SYS` を同居させるv3 system SDでは、system領域と重ならないようにFAT32 partitionを physical LBA `128` 以降から開始する。
 - 既定出力はホストOSがFAT32として扱えるクラスタ数を持つ。
 - root directory に `SDFS.BIN` を配置し、相対パス付きの指定ファイルは対応するサブディレクトリに配置する。
 - テスト用には小さい決定的イメージを生成できるようにする。

--- a/include/hardware.inc
+++ b/include/hardware.inc
@@ -189,6 +189,7 @@ FAT_ERR_BPB      equ 4
 FAT_ERR_NOT_FOUND equ 5
 FAT_ERR_CHAIN    equ 6
 FAT_ERR_SIZE     equ 7
+FAT_ERR_CHECKSUM equ 8
  endif
 
 LOAD_MODE_NONE   equ 0

--- a/src/main.asm
+++ b/src/main.asm
@@ -117,7 +117,11 @@ CHK_CMD_BREAK:
  if MONITOR_FEATURE_SD
  if S1_SUPPORTED
         jsr     IS_CMD_BOOT
+        bcc     MAIN_DISPATCH_BOOT
+        jsr     IS_CMD_BOOT3
         bcs     MAIN_DISPATCH_BREAK
+        jmp     CMD_BOOT3
+MAIN_DISPATCH_BOOT:
         jmp     CMD_BOOT
 MAIN_DISPATCH_BREAK:
  endif
@@ -283,6 +287,28 @@ IS_CMD_BOOT:
         clc
         rts
 IS_CMD_BOOT_FAIL:
+        sec
+        rts
+
+IS_CMD_BOOT3:
+        ldab    LINE_LEN
+        cmpb    #5
+        bne     IS_CMD_BOOT3_FAIL
+        ldaa    LINE_BUF+1
+        cmpa    #'O'
+        bne     IS_CMD_BOOT3_FAIL
+        ldaa    LINE_BUF+2
+        cmpa    #'O'
+        bne     IS_CMD_BOOT3_FAIL
+        ldaa    LINE_BUF+3
+        cmpa    #'T'
+        bne     IS_CMD_BOOT3_FAIL
+        ldaa    LINE_BUF+4
+        cmpa    #'3'
+        bne     IS_CMD_BOOT3_FAIL
+        clc
+        rts
+IS_CMD_BOOT3_FAIL:
         sec
         rts
 
@@ -1757,6 +1783,307 @@ BOOT_FAIL_A:
         sec
         rts
 
+SDFS3SYS_FIXED_LBA equ 64
+SDFS3SYS_HEADER_SIZE equ $20
+SDFS3SYS_MAX_HI equ $40
+SDFS3SYS_MAX_LO equ $00
+SDFS3SYS_MIN_LO equ SDFS3SYS_HEADER_SIZE+1
+
+BOOT3_EXPECTED_SUM equ FAT_VOLUME_LBA0
+BOOT3_COMPUTED_SUM equ FAT_VOLUME_LBA2
+BOOT3_REMAIN       equ FAT_FAT_LBA0
+BOOT3_PAYLOAD      equ FAT_FAT_LBA2
+BOOT3_COUNT        equ FAT_DATA_LBA0
+BOOT3_SRC_PTR      equ FAT_DATA_LBA2
+BOOT3_DST_PTR      equ FAT_ROOT_CLUS0
+
+CMD_BOOT3:
+        jsr     SD_INIT
+        bcs     CMD_BOOT3_ERROR
+        jsr     BOOT3_SET_LBA
+        jsr     BOOT3_READ_SECTOR
+        bcs     CMD_BOOT3_ERROR
+        jsr     BOOT3_CHECK_HEADER
+        bcs     CMD_BOOT3_ERROR
+        jsr     BOOT3_COPY_PAYLOAD
+        bcs     CMD_BOOT3_ERROR
+        jsr     SDFS3_FIND_API
+        bcs     CMD_BOOT3_ERROR
+        ldx     #TXT_OK
+        jsr     PDATA1
+        jmp     MAIN_LOOP
+CMD_BOOT3_ERROR:
+        jmp     MAIN_LOOP_ERROR
+
+BOOT3_CHECK_HEADER:
+        ldx     #SD_SECTOR_BUF
+        ldaa    0,x
+        cmpa    #'S'
+        bne     BOOT3_HEADER_FAIL_SIG
+        ldaa    1,x
+        cmpa    #'D'
+        bne     BOOT3_HEADER_FAIL_SIG
+        ldaa    2,x
+        cmpa    #'F'
+        bne     BOOT3_HEADER_FAIL_SIG
+        ldaa    3,x
+        cmpa    #'S'
+        bne     BOOT3_HEADER_FAIL_SIG
+        ldaa    4,x
+        cmpa    #'3'
+        bne     BOOT3_HEADER_FAIL_SIG
+        ldaa    5,x
+        cmpa    #'S'
+        bne     BOOT3_HEADER_FAIL_SIG
+        ldaa    6,x
+        cmpa    #'Y'
+        bne     BOOT3_HEADER_FAIL_SIG
+        ldaa    7,x
+        cmpa    #'S'
+        bne     BOOT3_HEADER_FAIL_SIG
+        ldaa    8,x
+        cmpa    #1
+        bne     BOOT3_HEADER_FAIL_SIG
+        ldaa    9,x
+        cmpa    #SDFS3_API_MAJOR
+        bne     BOOT3_HEADER_FAIL_SIG
+        ldaa    11,x
+        cmpa    #1
+        bne     BOOT3_HEADER_FAIL_SIG
+        ldaa    12,x
+        cmpa    #SDFS3_LOAD_BASE/$0100
+        bne     BOOT3_HEADER_FAIL_SIZE
+        ldaa    13,x
+        cmpa    #SDFS3_LOAD_BASE&$00FF
+        bne     BOOT3_HEADER_FAIL_SIZE
+        ldaa    26,x
+        bne     BOOT3_HEADER_FAIL_SIZE
+        ldaa    27,x
+        cmpa    #SDFS3SYS_HEADER_SIZE
+        bne     BOOT3_HEADER_FAIL_SIZE
+        ldaa    14,x
+        cmpa    #SDFS3SYS_MAX_HI
+        bhi     BOOT3_HEADER_FAIL_SIZE
+        blo     BOOT3_CHECK_MIN
+        ldaa    15,x
+        cmpa    #SDFS3SYS_MAX_LO
+        bhi     BOOT3_HEADER_FAIL_SIZE
+BOOT3_CHECK_MIN:
+        ldaa    14,x
+        bne     BOOT3_CHECKSUM_PREP
+        ldaa    15,x
+        cmpa    #SDFS3SYS_MIN_LO
+        blo     BOOT3_HEADER_FAIL_SIZE
+        bra     BOOT3_CHECKSUM_PREP
+BOOT3_HEADER_FAIL_SIG:
+        jmp     BOOT3_FAIL_SIG
+BOOT3_HEADER_FAIL_SIZE:
+        jmp     BOOT3_FAIL_SIZE
+BOOT3_CHECKSUM_PREP:
+        ldaa    24,x
+        staa    BOOT3_EXPECTED_SUM
+        ldaa    25,x
+        staa    BOOT3_EXPECTED_SUM+1
+        clr     24,x
+        clr     25,x
+        clr     BOOT3_COMPUTED_SUM
+        clr     BOOT3_COMPUTED_SUM+1
+        ldaa    14,x
+        staa    BOOT3_REMAIN
+        ldaa    15,x
+        staa    BOOT3_REMAIN+1
+        jsr     BOOT3_SUM_CURRENT
+BOOT3_SUM_LOOP:
+        ldaa    BOOT3_REMAIN
+        oraa    BOOT3_REMAIN+1
+        beq     BOOT3_SUM_DONE
+        jsr     BOOT_INC_SD_LBA
+        jsr     BOOT3_READ_SECTOR
+        bcs     BOOT3_SUM_FAIL_SD
+        jsr     BOOT3_SUM_CURRENT
+        bra     BOOT3_SUM_LOOP
+BOOT3_SUM_DONE:
+        ldaa    BOOT3_COMPUTED_SUM
+        cmpa    BOOT3_EXPECTED_SUM
+        bne     BOOT3_SUM_FAIL_SUM
+        ldaa    BOOT3_COMPUTED_SUM+1
+        cmpa    BOOT3_EXPECTED_SUM+1
+        bne     BOOT3_SUM_FAIL_SUM
+        clc
+        rts
+BOOT3_SUM_FAIL_SD:
+        jmp     BOOT3_FAIL_SD
+BOOT3_SUM_FAIL_SUM:
+        jmp     BOOT3_FAIL_SUM
+
+BOOT3_COPY_PAYLOAD:
+        jsr     BOOT3_SET_LBA
+        jsr     BOOT3_READ_SECTOR
+        bcs     BOOT3_COPY_FAIL_SD
+        ldx     #SD_SECTOR_BUF
+        ldaa    14,x
+        staa    BOOT3_PAYLOAD
+        ldaa    15,x
+        suba    #SDFS3SYS_HEADER_SIZE
+        staa    BOOT3_PAYLOAD+1
+        bcc     BOOT3_COPY_SIZE_OK
+        dec     BOOT3_PAYLOAD
+BOOT3_COPY_SIZE_OK:
+        ldx     #SD_SECTOR_BUF+SDFS3SYS_HEADER_SIZE
+        stx     BOOT3_SRC_PTR
+        ldx     #SDFS3_LOAD_BASE
+        stx     BOOT3_DST_PTR
+        jsr     BOOT3_SET_COUNT_480
+        jsr     BOOT3_COPY_CURRENT
+BOOT3_COPY_LOOP:
+        ldaa    BOOT3_PAYLOAD
+        oraa    BOOT3_PAYLOAD+1
+        beq     BOOT3_COPY_DONE
+        jsr     BOOT_INC_SD_LBA
+        jsr     BOOT3_READ_SECTOR
+        bcs     BOOT3_COPY_FAIL_SD
+        ldx     #SD_SECTOR_BUF
+        stx     BOOT3_SRC_PTR
+        jsr     BOOT3_SET_PAYLOAD_COUNT_512
+        jsr     BOOT3_COPY_CURRENT
+        bra     BOOT3_COPY_LOOP
+BOOT3_COPY_DONE:
+        clc
+        rts
+BOOT3_COPY_FAIL_SD:
+        jmp     BOOT3_FAIL_SD
+
+BOOT3_SUM_CURRENT:
+        jsr     BOOT3_SET_REMAIN_COUNT_512
+        ldx     #SD_SECTOR_BUF
+BOOT3_SUM_BYTE:
+        ldaa    BOOT3_COUNT
+        oraa    BOOT3_COUNT+1
+        beq     BOOT3_SUM_CURRENT_DONE
+        ldaa    0,x
+        adda    BOOT3_COMPUTED_SUM+1
+        staa    BOOT3_COMPUTED_SUM+1
+        bcc     BOOT3_SUM_NO_CARRY
+        inc     BOOT3_COMPUTED_SUM
+BOOT3_SUM_NO_CARRY:
+        inx
+        jsr     BOOT3_DEC_COUNT_REMAIN
+        bra     BOOT3_SUM_BYTE
+BOOT3_SUM_CURRENT_DONE:
+        rts
+
+BOOT3_COPY_CURRENT:
+        ldaa    BOOT3_COUNT
+        oraa    BOOT3_COUNT+1
+        beq     BOOT3_COPY_CURRENT_DONE
+        ldx     BOOT3_SRC_PTR
+        ldaa    0,x
+        inx
+        stx     BOOT3_SRC_PTR
+        ldx     BOOT3_DST_PTR
+        staa    0,x
+        inx
+        stx     BOOT3_DST_PTR
+        jsr     BOOT3_DEC_COUNT_PAYLOAD
+        bra     BOOT3_COPY_CURRENT
+BOOT3_COPY_CURRENT_DONE:
+        rts
+
+BOOT3_SET_REMAIN_COUNT_512:
+        ldaa    BOOT3_REMAIN
+        cmpa    #2
+        bhs     BOOT3_SET_COUNT_512
+        staa    BOOT3_COUNT
+        ldaa    BOOT3_REMAIN+1
+        staa    BOOT3_COUNT+1
+        rts
+BOOT3_SET_PAYLOAD_COUNT_512:
+        ldaa    BOOT3_PAYLOAD
+        cmpa    #2
+        bhs     BOOT3_SET_COUNT_512
+        staa    BOOT3_COUNT
+        ldaa    BOOT3_PAYLOAD+1
+        staa    BOOT3_COUNT+1
+        rts
+BOOT3_SET_COUNT_512:
+        ldaa    #2
+        staa    BOOT3_COUNT
+        clr     BOOT3_COUNT+1
+        rts
+BOOT3_SET_COUNT_480:
+        ldaa    BOOT3_PAYLOAD
+        cmpa    #1
+        bhi     BOOT3_COUNT_480
+        bne     BOOT3_COUNT_PAYLOAD
+        ldaa    BOOT3_PAYLOAD+1
+        cmpa    #$E0
+        bhs     BOOT3_COUNT_480
+BOOT3_COUNT_PAYLOAD:
+        ldaa    BOOT3_PAYLOAD
+        staa    BOOT3_COUNT
+        ldaa    BOOT3_PAYLOAD+1
+        staa    BOOT3_COUNT+1
+        rts
+BOOT3_COUNT_480:
+        ldaa    #1
+        staa    BOOT3_COUNT
+        ldaa    #$E0
+        staa    BOOT3_COUNT+1
+        rts
+
+BOOT3_DEC_COUNT_REMAIN:
+        jsr     BOOT3_DEC_COUNT
+        dec     BOOT3_REMAIN+1
+        ldaa    BOOT3_REMAIN+1
+        cmpa    #$FF
+        bne     BOOT3_DEC_REMAIN_DONE
+        dec     BOOT3_REMAIN
+BOOT3_DEC_REMAIN_DONE:
+        rts
+BOOT3_DEC_COUNT_PAYLOAD:
+        jsr     BOOT3_DEC_COUNT
+        dec     BOOT3_PAYLOAD+1
+        ldaa    BOOT3_PAYLOAD+1
+        cmpa    #$FF
+        bne     BOOT3_DEC_PAYLOAD_DONE
+        dec     BOOT3_PAYLOAD
+BOOT3_DEC_PAYLOAD_DONE:
+        rts
+BOOT3_DEC_COUNT:
+        dec     BOOT3_COUNT+1
+        ldaa    BOOT3_COUNT+1
+        cmpa    #$FF
+        bne     BOOT3_DEC_COUNT_DONE
+        dec     BOOT3_COUNT
+BOOT3_DEC_COUNT_DONE:
+        rts
+
+BOOT3_SET_LBA:
+        clr     SD_LBA0
+        clr     SD_LBA1
+        clr     SD_LBA2
+        ldaa    #SDFS3SYS_FIXED_LBA
+        staa    SD_LBA3
+        rts
+BOOT3_READ_SECTOR:
+        ldx     #SD_SECTOR_BUF
+        jmp     SD_READ_SECTOR
+BOOT3_FAIL_SIG:
+        ldaa    #FAT_ERR_SIG
+        bra     BOOT3_FAIL_A
+BOOT3_FAIL_SIZE:
+        ldaa    #FAT_ERR_SIZE
+        bra     BOOT3_FAIL_A
+BOOT3_FAIL_SUM:
+        ldaa    #FAT_ERR_CHECKSUM
+        bra     BOOT3_FAIL_A
+BOOT3_FAIL_SD:
+        ldaa    SD_ERROR
+BOOT3_FAIL_A:
+        staa    FAT_ERROR
+        sec
+        rts
+
 SDFS3_API_MAJOR    equ 1
 SDFS3_API_MIN_COUNT equ 9
 
@@ -2620,17 +2947,17 @@ TXT_WELCOME:    fcc     "MC6800 MONITOR"
 TXT_HELP:
  if MONITOR_FEATURE_FAT
  if MONITOR_FEATURE_VDG
-                fcc     "D DS DIR M MAP RAMTEST G L LF BOOT CMD B C R U UW H F"
+                fcc     "D DS DIR M MAP RAMTEST G L LF BOOT BOOT3 CMD B C R U UW H F"
  else
-                fcc     "D DIR M MAP RAMTEST G L LF BOOT CMD B C R U H F"
+                fcc     "D DIR M MAP RAMTEST G L LF BOOT BOOT3 CMD B C R U H F"
  endif
  else
  if MONITOR_FEATURE_SD
  if S1_SUPPORTED
  if MONITOR_FEATURE_VDG
-                fcc     "D DS M MAP RAMTEST G L BOOT CMD B C R U UW H F"
+                fcc     "D DS M MAP RAMTEST G L BOOT BOOT3 CMD B C R U UW H F"
  else
-                fcc     "D M MAP RAMTEST G L BOOT CMD B C R U H F"
+                fcc     "D M MAP RAMTEST G L BOOT BOOT3 CMD B C R U H F"
  endif
  else
  if MONITOR_FEATURE_VDG

--- a/tests/test_sd_fixture.py
+++ b/tests/test_sd_fixture.py
@@ -954,14 +954,14 @@ def test_rom_fat_feature_help_policy() -> None:
     stdout, stderr, rc = _run_emu_with_sd("H\r\r", build_fat32_image(with_mbr=True))
     assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
     if _is_fat_build():
-        expected = "D DIR M MAP RAMTEST G L LF BOOT CMD B C R U H F"
-        assert expected in stdout, f"FEATURE_FAT=1 help should include DIR/LF/BOOT: {stdout!r}"
+        expected = "D DIR M MAP RAMTEST G L LF BOOT BOOT3 CMD B C R U H F"
+        assert expected in stdout, f"FEATURE_FAT=1 help should include DIR/LF/BOOT/BOOT3: {stdout!r}"
     elif _is_vdg_build():
-        expected = "D M MAP RAMTEST G L BOOT CMD B C R U H F"
-        assert expected in stdout, f"FEATURE_FAT=0 VDG help should keep BOOT only: {stdout!r}"
+        expected = "D DS M MAP RAMTEST G L BOOT BOOT3 CMD B C R U UW H F"
+        assert expected in stdout, f"FEATURE_FAT=0 VDG help should keep BOOT/BOOT3 only: {stdout!r}"
     else:
-        expected = "D M MAP RAMTEST G L BOOT CMD B C R U H F"
-        assert expected in stdout, f"FEATURE_FAT=0 help should keep BOOT only: {stdout!r}"
+        expected = "D M MAP RAMTEST G L BOOT BOOT3 CMD B C R U H F"
+        assert expected in stdout, f"FEATURE_FAT=0 help should keep BOOT/BOOT3 only: {stdout!r}"
     print("[PASS] test_rom_fat_feature_help_policy")
 
 

--- a/tests/test_sdfs68_v3_build.py
+++ b/tests/test_sdfs68_v3_build.py
@@ -612,6 +612,77 @@ def test_fixed_lba_loader_harness_loads_sdfs3sys() -> None:
     print("[PASS] test_fixed_lba_loader_harness_loads_sdfs3sys")
 
 
+def test_rom_boot3_loads_sdfs3sys_and_enables_cmd() -> None:
+    profile = "k6802_vdg"
+    suffix = "-k6802-vdg-sdfs3-5000"
+    extra_args = [
+        "SDFS3_LOAD_BASE=0x5000",
+        "SDFS3_LOAD_LIMIT=0x7EFF",
+        "BUILD_CONFIG_NAME=k6802-vdg-sdfs3-5000",
+    ]
+    _run_make(profile, "bin", extra_args=extra_args)
+    _run_make(profile, "sdfs3sys", extra_args=extra_args)
+    symbols = _load_symbols(
+        PROJECT_ROOT / "build" / f"mc6800-monitor{suffix}.lst",
+        "SDFS3_LOAD_BASE",
+    )
+    sdfs3sys = (PROJECT_ROOT / "build" / f"SDFS3SYS{suffix}.BIN").read_bytes()
+    payload = sdfs3sys[HEADER_SIZE:]
+    sd_image = _build_sdfs3sys_fat_sd_image(
+        sdfs3sys,
+        [
+            Fat32File(b"HELLO   S  ", b"S9030000FC\r\n"),
+            Fat32File(b"README  TXT", b"HELLO FROM BOOT3\r\n"),
+        ],
+    )
+    stdout, stderr, rc = _run_emu(
+        rom_path=PROJECT_ROOT / "build" / f"mc6800-monitor{suffix}.bin",
+        input_text=(
+            "BOOT3\r"
+            "CMD DIR\r"
+            "\r"
+        ),
+        max_cycles=260_000_000,
+        sd_image=sd_image,
+        dump_range=f"{symbols['SDFS3_LOAD_BASE']:04X}-{symbols['SDFS3_LOAD_BASE'] + 0x3F:04X}",
+        timeout=40,
+    )
+    assert rc == 0 and "[TIMEOUT]" not in stderr, (
+        f"emulator failed for ROM BOOT3: rc={rc} stderr={stderr!r}"
+    )
+    assert "OK" in stdout, f"BOOT3 should report OK after loading resident: {stdout!r}"
+    assert "HELLO.S A " in stdout, f"CMD DIR did not use resident after BOOT3: {stdout!r}"
+    loaded = _dump_range_bytes(stdout, symbols["SDFS3_LOAD_BASE"], 0x40)
+    assert bytes(loaded) == payload[:0x40], f"BOOT3 did not load SDFS3SYS header/code: {stdout!r}"
+    print("[PASS] test_rom_boot3_loads_sdfs3sys_and_enables_cmd")
+
+
+def test_rom_boot3_rejects_bad_sdfs3sys() -> None:
+    profile = "k6802_vdg"
+    suffix = "-k6802-vdg-sdfs3-5000"
+    extra_args = [
+        "SDFS3_LOAD_BASE=0x5000",
+        "SDFS3_LOAD_LIMIT=0x7EFF",
+        "BUILD_CONFIG_NAME=k6802-vdg-sdfs3-5000",
+    ]
+    _run_make(profile, "bin", extra_args=extra_args)
+    _run_make(profile, "sdfs3sys", extra_args=extra_args)
+    sdfs3sys = bytearray((PROJECT_ROOT / "build" / f"SDFS3SYS{suffix}.BIN").read_bytes())
+    sdfs3sys[0] = ord("X")
+    stdout, stderr, rc = _run_emu(
+        rom_path=PROJECT_ROOT / "build" / f"mc6800-monitor{suffix}.bin",
+        input_text="BOOT3\rCMD DIR\r\r",
+        max_cycles=160_000_000,
+        sd_image=_build_sdfs3sys_sd_image(bytes(sdfs3sys)),
+        timeout=30,
+    )
+    assert rc == 0 and "[TIMEOUT]" not in stderr, (
+        f"emulator failed for bad ROM BOOT3 image: rc={rc} stderr={stderr!r}"
+    )
+    assert stdout.count("\n?\n") >= 2, f"BOOT3 and unloaded CMD should both fail: {stdout!r}"
+    print("[PASS] test_rom_boot3_rejects_bad_sdfs3sys")
+
+
 def test_sdfs3_cmd_dir_and_type_read_fat_files() -> None:
     profile = "sbcio_4000"
     expected = EXPECTED[profile]
@@ -1499,8 +1570,9 @@ def _run_emu(
 
 def _dump_bytes(stdout: str, address: int) -> list[int]:
     for line in stdout.splitlines():
-        if line.startswith(f"{address:04X} "):
-            parts = re.findall(r"\b[0-9A-Fa-f]{2}\b", line.split("  ", 1)[0])
+        stripped = line.lstrip("] ")
+        if stripped.startswith(f"{address:04X} "):
+            parts = re.findall(r"\b[0-9A-Fa-f]{2}\b", stripped.split("  ", 1)[0])
             return [int(part, 16) for part in parts]
     raise AssertionError(f"missing dump line for {address:04X}: {stdout!r}")
 
@@ -1582,9 +1654,11 @@ def main() -> None:
         test_rom_detects_sdfs3_api_header,
         test_rom_cmd_gateway_calls_resident_dispatch,
         test_fixed_lba_loader_harness_loads_sdfs3sys,
+        test_rom_boot3_loads_sdfs3sys_and_enables_cmd,
         test_sdfs3_cmd_dir_and_type_read_fat_files,
         test_sdfs3_cmd_load_run_and_com_read_fat_files,
         test_fixed_lba_loader_harness_rejects_bad_sdfs3sys,
+        test_rom_boot3_rejects_bad_sdfs3sys,
     ]
     passed = 0
     failed = 0

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -209,14 +209,14 @@ def test_help_command():
     stdout, stderr, rc = run_emu("H\r\r")
     if is_fat_build():
         if is_vdg_build():
-            expected = "D DS DIR M MAP RAMTEST G L LF BOOT CMD B C R U UW H F"
+            expected = "D DS DIR M MAP RAMTEST G L LF BOOT BOOT3 CMD B C R U UW H F"
         else:
-            expected = "D DIR M MAP RAMTEST G L LF BOOT CMD B C R U H F"
+            expected = "D DIR M MAP RAMTEST G L LF BOOT BOOT3 CMD B C R U H F"
     elif is_sd_build():
         if is_vdg_build():
-            expected = "D DS M MAP RAMTEST G L BOOT CMD B C R U UW H F"
+            expected = "D DS M MAP RAMTEST G L BOOT BOOT3 CMD B C R U UW H F"
         else:
-            expected = "D M MAP RAMTEST G L BOOT CMD B C R U H F"
+            expected = "D M MAP RAMTEST G L BOOT BOOT3 CMD B C R U H F"
     else:
         if is_vdg_build():
             expected = "D DS M MAP RAMTEST G L B C R U UW H F"
@@ -658,7 +658,7 @@ def test_ramtest_command():
         "R\r"
         "\r"
     )
-    stdout, stderr, rc = run_emu(input_text, max_cycles=80_000_000)
+    stdout, stderr, rc = run_emu(input_text, max_cycles=500_000_000, timeout=60)
     assert rc == 0 and "[TIMEOUT]" not in stderr, f"emulator failed: rc={rc} stderr={stderr!r}"
     if is_ram64_4000_work_build():
         assert "RAMTEST 0100-1BFF" in stdout, f"missing low RAMTEST range echo: {stdout!r}"


### PR DESCRIPTION
## 対応Issue

Closes #295
Refs #296

## 変更内容

- ROM monitorに `BOOT3` コマンドを追加し、fixed LBA `64` の `SDFS3SYS` を検証して `SDFS3_LOAD_BASE` へresident payloadをロードするようにしました。
- `BOOT3` 成功後に `CMD <tail>` gatewayから v3 resident を呼び出せることをエミュレータで確認しました。
- `SDFS3SYS` の magic / version / ABI / flags / load address / header size / image size / checksum をROM側で検証します。
- PH2 epic #296 を作成し、#295 をsub-issueとして紐づけました。
- `BOOT3` の実機手順、system SD方針、コマンド説明、Issue計画メモを更新しました。

## テスト結果

- `python tests\test_sdfs68_v3_build.py`
- `make bin MONITOR_PROFILE=k6802_vdg PYTHON=python ASL_INCLUDE_ARG="build;include;src"`
- `PYTHONIOENCODING=utf-8 REQUIRE_BUILD_ROM=1 MONITOR_PROFILE=k6802_vdg MONITOR_ROM_PATH=build/mc6800-monitor-k6802-vdg.bin MONITOR_LST_PATH=build/mc6800-monitor-k6802-vdg.lst python tests\test_smoke.py`
- `PYTHONIOENCODING=utf-8 REQUIRE_BUILD_ROM=1 MONITOR_PROFILE=k6802_vdg MONITOR_ROM_PATH=build/mc6800-monitor-k6802-vdg-sdfs3-5000.bin MONITOR_LST_PATH=build/mc6800-monitor-k6802-vdg-sdfs3-5000.lst python -c "import tests.test_sd_fixture as t; t.test_rom_fat_feature_help_policy()"`
- `make bin MONITOR_PROFILE=sbcio_4000 PYTHON=python ASL_INCLUDE_ARG="build;include;src"`
- `make rombin MONITOR_PROFILE=k6802_vdg ROM_KIND=W27C512 SDFS3_LOAD_BASE=0x5000 SDFS3_LOAD_LIMIT=0x7EFF BUILD_CONFIG_NAME=k6802-vdg-sdfs3-5000 PYTHON=python ASL_INCLUDE_ARG="build;include;src"`

## 影響範囲

- `FEATURE_SD=1` かつ `S1_SUPPORTED=1` のROMで `BOOT3` がヘルプ表示に追加されます。
- v3 system SDでは `SDFS3SYS` をLBA `64`、FAT partitionをLBA `128` 以降に置く前提になります。
- `BOOT` の既存v2 stage1起動経路は維持しています。

## 未対応

- system SD作成ツールで `SDFS3SYS` をLBA `64` に配置する正式対応。
- slot A/B、active marker、fallback slot選択。
- 実機側system install、SD raw write、FAT write、SAVE系。